### PR TITLE
Feature4239 - Supress Cabinet Extraction in melt

### DIFF
--- a/src/tools/melt/MeltStrings.resx
+++ b/src/tools/melt/MeltStrings.resx
@@ -126,6 +126,7 @@
    -notidy    do not delete temporary files (useful for debugging)
    -o[ut]     specify output file (default: write to current directory)
    -pdb       specify .wixpdb matching database.msi
+   -se        supress extraction of the cabinet(s) - applicable ONLY for .msi
    -sw[N]     suppress all warnings or a specific message ID
               (example: -sw1059 -sw1067)
    -swall     suppress all warnings (deprecated)

--- a/src/tools/melt/melt.cs
+++ b/src/tools/melt/melt.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Tools.WindowsInstallerXml.Tools
         private bool showHelp;
         private bool showLogo;
         private bool tidy;
+        private bool supressCABExtraction;
 
         /// <summary>
         /// Instantiate a new Melt class.
@@ -263,7 +264,10 @@ namespace Microsoft.Tools.WindowsInstallerXml.Tools
             IDictionary<string, string> paths = null;
             using (InstallPackage package = new InstallPackage(this.inputFile, DatabaseOpenMode.ReadOnly, null, outputDirectory))
             {
-                package.ExtractFiles();
+                if (!this.supressCABExtraction)
+                {
+                    package.ExtractFiles();
+                }
                 paths = package.Files.SourcePaths;
             }
 
@@ -388,6 +392,10 @@ namespace Microsoft.Tools.WindowsInstallerXml.Tools
                         {
                             this.messageHandler.Display(this, WixErrors.IllegalSuppressWarningId(paramArg));
                         }
+                    }
+                    else if ("se" == parameter)
+                    {
+                        this.supressCABExtraction = true;
                     }
                     else if ("wxall" == parameter)
                     {


### PR DESCRIPTION
To speed up pdb re-base for repeated re-melts of RTM installers for
patching.

Re-issuing pull request now that we are on github.com.
