### PR TITLE
Get rid of annoying build warnings

### DIFF
--- a/tools/WixBuild.Tools.targets
+++ b/tools/WixBuild.Tools.targets
@@ -286,7 +286,11 @@
       <_RcPreprocessorSwitch>@(_RcPreprocessorDefinition -> '/d &quot;%(Identity)&quot;', ' ')</_RcPreprocessorSwitch>
     </PropertyGroup>
 
-    <Exec Command="&quot;$(PlatformSdkBinPath)rc.exe&quot; /nologo /fo &quot;$(ResFile)&quot; $(_RcIncludeSwitch) $(_RcPreprocessorSwitch) &quot;@(EmbeddedNativeResource)&quot;"
+    <PropertyGroup Condition=" '$(PlatformSdkRegistryVersion)'=='v7.1A' and '12.0'&lt;='$(MSBuildToolsVersion)' ">
+      <_RcUsingSdkSwitch>/D &quot;_USING_V110_SDK71_&quot;</_RcUsingSdkSwitch>
+    </PropertyGroup>
+
+    <Exec Command="&quot;$(PlatformSdkBinPath)rc.exe&quot; /nologo /fo &quot;$(ResFile)&quot; $(_RcIncludeSwitch) $(_RcPreprocessorSwitch) $(_RcUsingSdkSwitch) &quot;@(EmbeddedNativeResource)&quot;"
           Outputs="$(ResFile)" />
 
     <PropertyGroup>

--- a/tools/WixBuild.props
+++ b/tools/WixBuild.props
@@ -83,8 +83,20 @@
 
   <PropertyGroup>
     <PlatformSdkInstallPath>$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.0', 'InstallationFolder', null, RegistryView.Registry64, RegistryView.Registry32))</PlatformSdkInstallPath>
-    <PlatformSdkInstallPath Condition=" '$(PlatformSdkInstallPath)'=='' ">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1A', 'InstallationFolder', null, RegistryView.Registry64, RegistryView.Registry32))</PlatformSdkInstallPath>
-    <PlatformSdkInstallPath Condition=" '$(PlatformSdkInstallPath)'=='' ">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A', 'InstallationFolder', null, RegistryView.Registry64, RegistryView.Registry32))</PlatformSdkInstallPath>
+    <PlatformSdkRegistryVersion Condition=" '$(PlatformSdkInstallPath)'!='' ">v8.0</PlatformSdkRegistryVersion>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition=" '$(PlatformSdkInstallPath)'=='' ">
+    <PlatformSdkInstallPath>$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1A', 'InstallationFolder', null, RegistryView.Registry64, RegistryView.Registry32))</PlatformSdkInstallPath>
+    <PlatformSdkRegistryVersion Condition=" '$(PlatformSdkInstallPath)'!='' ">v7.1A</PlatformSdkRegistryVersion>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition=" '$(PlatformSdkInstallPath)'=='' ">
+    <PlatformSdkInstallPath>$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A', 'InstallationFolder', null, RegistryView.Registry64, RegistryView.Registry32))</PlatformSdkInstallPath>
+    <PlatformSdkRegistryVersion Condition=" '$(PlatformSdkInstallPath)'!='' ">v7.0A</PlatformSdkRegistryVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <PlatformSdkInstallPath Condition="!HasTrailingSlash('$(PlatformSdkInstallPath)')">$(PlatformSdkInstallPath)\</PlatformSdkInstallPath>
 
     <PlatformSdkIncludePath>$(PlatformSdkInstallPath)include</PlatformSdkIncludePath>


### PR DESCRIPTION
When building Wix with only VS2013 installed, the CompileNativeResources task generates the following warnings:

```
C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\include\sal.h(2886): warning RC4005: '__useHeader' : redefinition
C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\include\sal.h(2896): warning RC4005: '__on_failure' : redefinition
```

Get rid of them by passing in "/D _USING_V110_SDK71_" to rc.exe when using the v7.1A Platform SDK and msbuild >= 12.0. 
