### PR TITLE
WIXBUG:4163

### DIFF
--- a/src/Votive/votive2010/src/Templates/Projects/CustomActionCS/CustomAction.csproj
+++ b/src/Votive/votive2010/src/Templates/Projects/CustomActionCS/CustomAction.csproj
@@ -41,7 +41,9 @@
 		<Reference Include="Microsoft.CSharp" />
  		$endif$
 		<Reference Include="System.Xml"/>
-		<Reference Include="Microsoft.Deployment.WindowsInstaller"/>
+		<Reference Include="Microsoft.Deployment.WindowsInstaller">
+			<Private>True</Private>
+		</Reference>
 	</ItemGroup>
 	<ItemGroup>
 		<Compile Include="CustomAction.cs" />

--- a/src/Votive/votive2010/src/Templates/Projects/CustomActionVB/CustomAction.vbproj
+++ b/src/Votive/votive2010/src/Templates/Projects/CustomActionVB/CustomAction.vbproj
@@ -37,7 +37,9 @@ $if$ ($targetframeworkversion$ >= 3.5)
 		<Reference Include="System.Xml.Linq"/>
 $endif$
 		<Reference Include="System.Xml" />
-		<Reference Include="Microsoft.Deployment.WindowsInstaller"/>
+		<Reference Include="Microsoft.Deployment.WindowsInstaller">
+			<Private>True</Private>
+		</Reference>
 	</ItemGroup>
 	<ItemGroup>
 		<Import Include="Microsoft.VisualBasic" />


### PR DESCRIPTION
Set Private to True for the references to Microsoft.Deployment.WindowsInstaller.dll so that the VB/CS custom action projects can still
build if that DLL is in the GAC.

http://wixtoolset.org/issues/4163/
