### PR TITLE
Remove sn.exe commands with wix.pub

### DIFF
--- a/src/chm/documents/wixdev/building_wix.html.md
+++ b/src/chm/documents/wixdev/building_wix.html.md
@@ -53,8 +53,6 @@ The DTF help build process looks for these tools in an &quot;external&quot; dire
 To create a build that can be installed on different machines, create a new strong name key pair and point OFFICIAL\_WIX\_BUILD to it:
 
     sn -k wix.snk
-    sn -p wix.snk wix.pub
-    sn -tp wix.pub
 
 Then run the build:
 


### PR DESCRIPTION
The only point of creating the wix.pub file was to figure out what to put in InternalsVisibleTo.
