### PR TITLE
WIXBUG:4394

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* BobArnson: WIXBUG:4394 - Enforce a maximum include nesting depth of 1024 to avoid stack overflows when files include themselves.
+
 * johnbuuck: WIXBUG:4279 - Add support for MSBuild version 12.0.
 
 * mavxg: WIXFEAT:4373 - Add LogonAsBatchJob to WixUtilExtension.User

--- a/src/tools/wix/Data/messages.xml
+++ b/src/tools/wix/Data/messages.xml
@@ -2938,6 +2938,12 @@
               <Parameter Type="System.String" Name="value" />
           </Instance>
       </Message>
+      <Message Id="TooDeeplyIncluded" Number="385">
+        <Instance>
+          Include files cannot be nested more deeply than {0} times. Make sure included files don't accidentally include themselves.
+          <Parameter Type="System.Int32" Name="depth" />
+        </Instance>
+      </Message>
     </Class>
 
     <Class Name="WixWarnings" ContainerName="WixWarningEventArgs" BaseContainerName="MessageEventArgs" Level="Warning">

--- a/src/tools/wix/Preprocessor.cs
+++ b/src/tools/wix/Preprocessor.cs
@@ -1516,6 +1516,11 @@ namespace Microsoft.Tools.WindowsInstallerXml
         /// <param name="fileName">Name to push on to the stack of included files.</param>
         private void PushInclude(string fileName)
         {
+            if (1023 < this.currentFileStack.Count)
+            {
+                throw new WixException(WixErrors.TooDeeplyIncluded(this.GetCurrentSourceLineNumbers(), this.currentFileStack.Count));
+            }
+
             this.currentFileStack.Push(fileName);
             this.sourceStack.Push(this.currentLineNumber);
             this.currentLineNumber = new SourceLineNumber(fileName);


### PR DESCRIPTION
Enforce a maximum include nesting depth of 1024 to avoid stack overflows
when files include themselves.
