### PR TITLE
WIXBUG:4410 

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* BobArnson: WIXBUG:4410 - Fix MediaTemplate/@CompressionLevel and ensure that when it's not specified, the default compression level takes effect.
+
 * BobArnson: WIXBUG:4394 - Enforce a maximum include nesting depth of 1024 to avoid stack overflows when files include themselves.
 
 * johnbuuck: WIXBUG:4279 - Add support for MSBuild version 12.0.

--- a/src/tools/wix/AutoMediaAssigner.cs
+++ b/src/tools/wix/AutoMediaAssigner.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
     using System.Globalization;
     using System.Collections.Generic;
     using System.Runtime.InteropServices;
+    using Microsoft.Tools.WindowsInstallerXml.Cab;
 
     /// <summary>
     /// AutoMediaAssigner assigns files to cabs depending on Media or MediaTemplate.
@@ -357,6 +358,12 @@ namespace Microsoft.Tools.WindowsInstallerXml
             MediaRow currentMediaRow = (MediaRow)mediaTable.CreateRow(null);
             currentMediaRow.DiskId = cabIndex;
             currentMediaRow.Cabinet = String.Format(this.cabinetNameTemplate, cabIndex);
+
+            if (!String.IsNullOrEmpty(compressionLevel))
+            {
+                currentMediaRow.CompressionLevel = WixCreateCab.CompressionLevelFromString(compressionLevel);
+            }
+
             this.mediaRows.Add(currentMediaRow);
             this.cabinets.Add(currentMediaRow, new FileRowCollection());
 

--- a/src/tools/wix/Compiler.cs
+++ b/src/tools/wix/Compiler.cs
@@ -8213,8 +8213,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
             string volumeLabel = null;
             int maximumUncompressedMediaSize = CompilerCore.IntegerNotSet;
             int maximumCabinetSizeForLargeFileSplitting = CompilerCore.IntegerNotSet;
-
-            Wix.CompressionLevelType compressionLevelType = Wix.CompressionLevelType.none;
+            Wix.CompressionLevelType compressionLevelType = Wix.CompressionLevelType.NotSet;
 
             YesNoType embedCab = patch ? YesNoType.Yes : YesNoType.NotSet;
 
@@ -8337,7 +8336,6 @@ namespace Microsoft.Tools.WindowsInstallerXml
                         mediaTemplateRow.CompressionLevel = Cab.CompressionLevel.None.ToString();
                         break;
                     case Wix.CompressionLevelType.mszip:
-                    case Wix.CompressionLevelType.NotSet:
                         mediaTemplateRow.CompressionLevel = Cab.CompressionLevel.Mszip.ToString();
                         break;
                 }


### PR DESCRIPTION
Fix MediaTemplate/@CompressionLevel and ensure that when it's not specified, the default compression level takes effect.
