### PR TITLE
WIXFEAT:3249

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* SeanHall: WIXFEAT:3249 - Allow BA to run elevated async process through the engine.
+
 * SeanHall: WIXBUG:3835 - Fix progress bug when extracting multiple packages from a container.
 
 * BobArnson: WIXBUG:4410 - Fix MediaTemplate/@CompressionLevel and ensure that when it's not specified, the default compression level takes effect.

--- a/src/burn/engine/EngineForApplication.cpp
+++ b/src/burn/engine/EngineForApplication.cpp
@@ -718,6 +718,74 @@ public: // IBootstrapperEngine
         return hr;
     }
 
+    virtual STDMETHODIMP LaunchApprovedExe(
+        __in_opt HWND hwndParent,
+        __in_z LPCWSTR wzApprovedExeForElevationId,
+        __in_z LPCWSTR wzExecutablePath,
+        __in_z_opt LPCWSTR wzArguments,
+        __in DWORD dwWaitForInputIdleTimeout
+        )
+    {
+        HRESULT hr = S_OK;
+        BURN_APPROVED_EXE* pApprovedExe = NULL;
+        BOOL fLeaveCriticalSection = FALSE;
+        BURN_LAUNCH_APPROVED_EXE* pLaunchApprovedExe = (BURN_LAUNCH_APPROVED_EXE*)MemAlloc(sizeof(BURN_LAUNCH_APPROVED_EXE), TRUE);
+
+        ::EnterCriticalSection(&m_pEngineState->csActive);
+        fLeaveCriticalSection = TRUE;
+        hr = UserExperienceEnsureEngineInactive(&m_pEngineState->userExperience);
+        ExitOnFailure(hr, "Engine is active, cannot change engine state.");
+
+        if (!wzExecutablePath || !*wzExecutablePath)
+        {
+            ExitFunction1(hr = E_INVALIDARG);
+        }
+        else if (!wzApprovedExeForElevationId || !*wzApprovedExeForElevationId)
+        {
+            ExitFunction1(hr = E_INVALIDARG);
+        }
+
+        hr = ApprovedExesFindById(&m_pEngineState->approvedExes, wzApprovedExeForElevationId, &pApprovedExe);
+        ExitOnFailure1(hr, "UX requested unknown approved exe with id: %ls", wzApprovedExeForElevationId);
+
+        ::LeaveCriticalSection(&m_pEngineState->csActive);
+        fLeaveCriticalSection = FALSE;
+
+        hr = StrAllocString(&pLaunchApprovedExe->sczId, wzApprovedExeForElevationId, NULL);
+        ExitOnFailure(hr, "Failed to copy the id.");
+
+        hr = StrAllocString(&pLaunchApprovedExe->sczExecutablePath, wzExecutablePath, NULL);
+        ExitOnFailure(hr, "Failed to copy the executable path.");
+
+        if (wzArguments)
+        {
+            hr = StrAllocString(&pLaunchApprovedExe->sczArguments, wzArguments, NULL);
+            ExitOnFailure(hr, "Failed to copy the arguments.");
+        }
+
+        pLaunchApprovedExe->dwWaitForInputIdleTimeout = dwWaitForInputIdleTimeout;
+
+        pLaunchApprovedExe->hwndParent = hwndParent;
+
+        if (!::PostThreadMessageW(m_dwThreadId, WM_BURN_LAUNCH_APPROVED_EXE, 0, reinterpret_cast<LPARAM>(pLaunchApprovedExe)))
+        {
+            ExitWithLastError(hr, "Failed to post launch approved exe message.");
+        }
+
+    LExit:
+        if (fLeaveCriticalSection)
+        {
+            ::LeaveCriticalSection(&m_pEngineState->csActive);
+        }
+
+        if (FAILED(hr))
+        {
+            ApprovedExesUninitializeLaunch(pLaunchApprovedExe);
+        }
+
+        return hr;
+    }
+
 public: // IMarshal
     virtual STDMETHODIMP GetUnmarshalClass( 
         __in REFIID /*riid*/,

--- a/src/burn/engine/EngineForApplication.h
+++ b/src/burn/engine/EngineForApplication.h
@@ -30,6 +30,7 @@ enum WM_BURN
     WM_BURN_PLAN,
     WM_BURN_ELEVATE,
     WM_BURN_APPLY,
+    WM_BURN_LAUNCH_APPROVED_EXE,
     WM_BURN_QUIT,
 
     WM_BURN_LAST, // this enum value must always be last.

--- a/src/burn/engine/approvedexe.cpp
+++ b/src/burn/engine/approvedexe.cpp
@@ -1,0 +1,348 @@
+//-------------------------------------------------------------------------------------------------
+// <copyright file="approvedexe.cpp" company="Outercurve Foundation">
+//   Copyright (c) 2004, Outercurve Foundation.
+//   This software is released under Microsoft Reciprocal License (MS-RL).
+//   The license and further copyright text can be found in the file
+//   LICENSE.TXT at the root directory of the distribution.
+// </copyright>
+//
+// <summary>
+//    Module: Core
+// </summary>
+//-------------------------------------------------------------------------------------------------
+
+#include "precomp.h"
+
+
+// function definitions
+
+extern "C" HRESULT ApprovedExesParseFromXml(
+    __in BURN_APPROVED_EXES* pApprovedExes,
+    __in IXMLDOMNode* pixnBundle
+    )
+{
+    HRESULT hr = S_OK;
+    IXMLDOMNodeList* pixnNodes = NULL;
+    IXMLDOMNode* pixnNode = NULL;
+    DWORD cNodes = 0;
+    LPWSTR scz = NULL;
+
+    // select approved exe nodes
+    hr = XmlSelectNodes(pixnBundle, L"ApprovedExeForElevation", &pixnNodes);
+    ExitOnFailure(hr, "Failed to select approved exe nodes.");
+
+    // get approved exe node count
+    hr = pixnNodes->get_length((long*)&cNodes);
+    ExitOnFailure(hr, "Failed to get approved exe node count.");
+
+    if (!cNodes)
+    {
+        ExitFunction();
+    }
+
+    // allocate memory for approved exes
+    pApprovedExes->rgApprovedExes = (BURN_APPROVED_EXE*)MemAlloc(sizeof(BURN_APPROVED_EXE) * cNodes, TRUE);
+    ExitOnNull(pApprovedExes->rgApprovedExes, hr, E_OUTOFMEMORY, "Failed to allocate memory for approved exe structs.");
+
+    pApprovedExes->cApprovedExes = cNodes;
+
+    // parse approved exe elements
+    for (DWORD i = 0; i < cNodes; ++i)
+    {
+        BURN_APPROVED_EXE* pApprovedExe = &pApprovedExes->rgApprovedExes[i];
+
+        hr = XmlNextElement(pixnNodes, &pixnNode, NULL);
+        ExitOnFailure(hr, "Failed to get next node.");
+
+        // @Id
+        hr = XmlGetAttributeEx(pixnNode, L"Id", &pApprovedExe->sczId);
+        ExitOnFailure(hr, "Failed to get @Id.");
+
+        // @FileSize
+        hr = XmlGetAttributeEx(pixnNode, L"FileSize", &scz);
+        if (E_NOTFOUND != hr)
+        {
+            ExitOnFailure(hr, "Failed to get @FileSize.");
+
+            hr = StrStringToUInt64(scz, 0, &pApprovedExe->qwFileSize);
+            ExitOnFailure(hr, "Failed to parse @FileSize.");
+        }
+
+        // @Hash
+        hr = XmlGetAttributeEx(pixnNode, L"Hash", &scz);
+        ExitOnFailure(hr, "Failed to get @Hash.");
+
+        hr = StrAllocHexDecode(scz, &pApprovedExe->pbHash, &pApprovedExe->cbHash);
+        ExitOnFailure(hr, "Failed to hex decode the ApprovedExeForElevation/@Hash.");
+
+        // prepare next iteration
+        ReleaseNullObject(pixnNode);
+        ReleaseNullStr(scz);
+    }
+
+    hr = S_OK;
+
+LExit:
+    ReleaseObject(pixnNodes);
+    ReleaseObject(pixnNode);
+    ReleaseStr(scz);
+    return hr;
+}
+
+extern "C" HRESULT ApprovedExesUninitialize(
+    __in BURN_APPROVED_EXES* pApprovedExes
+    )
+{
+    if (pApprovedExes->rgApprovedExes)
+    {
+        for (DWORD i = 0; i < pApprovedExes->cApprovedExes; ++i)
+        {
+            BURN_APPROVED_EXE* pApprovedExe = &pApprovedExes->rgApprovedExes[i];
+
+            ReleaseStr(pApprovedExe->sczId);
+            ReleaseMem(pApprovedExe->pbHash);
+        }
+        MemFree(pApprovedExes->rgApprovedExes);
+    }
+    return S_OK;
+}
+
+extern "C" HRESULT ApprovedExesUninitializeLaunch(
+    __in BURN_LAUNCH_APPROVED_EXE* pLaunchApprovedExe
+    )
+{
+    if (pLaunchApprovedExe)
+    {
+        ReleaseStr(pLaunchApprovedExe->sczArguments);
+        ReleaseStr(pLaunchApprovedExe->sczExecutablePath);
+        ReleaseStr(pLaunchApprovedExe->sczId);
+        MemFree(pLaunchApprovedExe);
+    }
+    return S_OK;
+}
+
+extern "C" HRESULT ApprovedExesFindById(
+    __in BURN_APPROVED_EXES* pApprovedExes,
+    __in_z LPCWSTR wzId,
+    __out BURN_APPROVED_EXE** ppApprovedExe
+    )
+{
+    HRESULT hr = S_OK;
+    BURN_APPROVED_EXE* pApprovedExe = NULL;
+
+    for (DWORD i = 0; i < pApprovedExes->cApprovedExes; ++i)
+    {
+        pApprovedExe = &pApprovedExes->rgApprovedExes[i];
+
+        if (CSTR_EQUAL == ::CompareStringW(LOCALE_INVARIANT, 0, pApprovedExe->sczId, -1, wzId, -1))
+        {
+            *ppApprovedExe = pApprovedExe;
+            ExitFunction1(hr = S_OK);
+        }
+    }
+
+    hr = E_NOTFOUND;
+
+LExit:
+    return hr;
+}
+
+extern "C" HRESULT ApprovedExesLaunch(
+    __in BURN_LAUNCH_APPROVED_EXE* pLaunchApprovedExe,
+    __out DWORD* pdwProcessId
+    )
+{
+    HRESULT hr = S_OK;
+    LPWSTR sczCommand = NULL;
+    LPWSTR sczExecutableDirectory = NULL;
+    STARTUPINFOW si = {};
+    PROCESS_INFORMATION pi = {};
+
+    // build command
+    if (pLaunchApprovedExe->sczArguments && *pLaunchApprovedExe->sczArguments)
+    {
+        hr = StrAllocFormatted(&sczCommand, L"\"%ls\" %s", pLaunchApprovedExe->sczExecutablePath, pLaunchApprovedExe->sczArguments);
+    }
+    else
+    {
+        hr = StrAllocFormatted(&sczCommand, L"\"%ls\"", pLaunchApprovedExe->sczExecutablePath);
+    }
+    ExitOnFailure(hr, "Failed to create executable command.");
+
+    // Try to get the directory of the executable so we can set the current directory of the process to help those executables
+    // that expect stuff to be relative to them.  Best effort only.
+    hr = PathGetDirectory(pLaunchApprovedExe->sczExecutablePath, &sczExecutableDirectory);
+    if (FAILED(hr))
+    {
+        ReleaseNullStr(sczExecutableDirectory);
+    }
+
+    si.cb = sizeof(si);
+    if (!::CreateProcessW(pLaunchApprovedExe->sczExecutablePath, sczCommand, NULL, NULL, FALSE, CREATE_NEW_PROCESS_GROUP, NULL, sczExecutableDirectory, &si, &pi))
+    {
+        ExitWithLastError1(hr, "Failed to CreateProcess on path: %ls", pLaunchApprovedExe->sczExecutablePath);
+    }
+
+    *pdwProcessId = pi.dwProcessId;
+
+    if (pLaunchApprovedExe->dwWaitForInputIdleTimeout)
+    {
+        ::WaitForInputIdle(pi.hProcess, pLaunchApprovedExe->dwWaitForInputIdleTimeout);
+    }
+
+LExit:
+    ReleaseStr(sczCommand);
+    ReleaseStr(sczExecutableDirectory);
+
+    ReleaseHandle(pi.hThread);
+    ReleaseHandle(pi.hProcess);
+
+    return hr;
+}
+
+extern "C" HRESULT ApprovedExesVerifySecureLocation(
+    __in BURN_VARIABLES* pVariables,
+    __in BURN_LAUNCH_APPROVED_EXE* pLaunchApprovedExe
+    )
+{
+    HRESULT hr = S_OK;
+    LPWSTR sczProgramFilesFolder = NULL;
+    LPWSTR sczProgramFiles64Folder = NULL;
+    LPWSTR sczRootCacheFolder = NULL;
+
+    hr = VariableGetString(pVariables, L"ProgramFiles64Folder", &sczProgramFiles64Folder);
+    if (SUCCEEDED(hr))
+    {
+        hr = PathDirectoryContainsPath(sczProgramFiles64Folder, pLaunchApprovedExe->sczExecutablePath);
+        if (S_OK == hr)
+        {
+            ExitFunction();
+        }
+    }
+    else if (E_NOTFOUND != hr)
+    {
+        ExitOnFailure(hr, "Failed to get the ProgramFiles64 folder.");
+    }
+
+    hr = VariableGetString(pVariables, L"ProgramFilesFolder", &sczProgramFilesFolder);
+    if (SUCCEEDED(hr))
+    {
+        hr = PathDirectoryContainsPath(sczProgramFilesFolder, pLaunchApprovedExe->sczExecutablePath);
+        if (S_OK == hr)
+        {
+            ExitFunction();
+        }
+    }
+    else if (E_NOTFOUND != hr)
+    {
+        ExitOnFailure(hr, "Failed to get the ProgramFiles folder.");
+    }
+
+    hr = CacheGetRootCompletedPath(TRUE, TRUE, &sczRootCacheFolder);
+    if (SUCCEEDED(hr))
+    {
+        hr = PathDirectoryContainsPath(sczRootCacheFolder, pLaunchApprovedExe->sczExecutablePath);
+        if (S_OK == hr)
+        {
+            ExitFunction();
+        }
+    }
+    else if (E_NOTFOUND != hr)
+    {
+        ExitOnFailure(hr, "Failed to get the PackageCache folder.");
+    }
+
+    hr = S_FALSE;
+
+LExit:
+    ReleaseStr(sczProgramFilesFolder);
+    ReleaseStr(sczProgramFiles64Folder);
+    ReleaseStr(sczRootCacheFolder);
+
+    return hr;
+}
+
+extern "C" HRESULT PathCanonicalizePath(
+    __in_z LPCWSTR wzPath,
+    __deref_out_z LPWSTR* psczCanonicalized
+    )
+{
+    HRESULT hr = S_OK;
+    int cch = MAX_PATH + 1;
+
+    hr = StrAlloc(psczCanonicalized, cch);
+    ExitOnFailure(hr, "Failed to allocate string for the canonicalized path.");
+
+    if (::PathCanonicalizeW(*psczCanonicalized, wzPath))
+    {
+        hr = S_OK;
+    }
+    else
+    {
+        hr = HRESULT_FROM_WIN32(::GetLastError());
+    }
+
+LExit:
+    return hr;
+}
+
+extern "C" HRESULT PathDirectoryContainsPath(
+    __in_z LPCWSTR wzDirectory,
+    __in_z LPCWSTR wzPath
+    )
+{
+    HRESULT hr = S_OK;
+    LPWSTR sczPath = NULL;
+    LPWSTR sczDirectory = NULL;
+    LPWSTR sczOriginalPath = NULL;
+    LPWSTR sczOriginalDirectory = NULL;
+
+    hr = PathCanonicalizePath(wzPath, &sczOriginalPath);
+    ExitOnFailure(hr, "Failed to canonicalize the path.");
+
+    hr = PathCanonicalizePath(wzDirectory, &sczOriginalDirectory);
+    ExitOnFailure(hr, "Failed to canonicalize the directory.");
+
+    if (!sczOriginalPath || !*sczOriginalPath)
+    {
+        ExitFunction1(hr = S_FALSE);
+    }
+    if (!sczOriginalDirectory || !*sczOriginalDirectory)
+    {
+        ExitFunction1(hr = S_FALSE);
+    }
+
+    sczPath = sczOriginalPath;
+    sczDirectory = sczOriginalDirectory;
+
+    for (; *sczDirectory;)
+    {
+        if (!*sczPath)
+        {
+            ExitFunction1(hr = S_FALSE);
+        }
+
+        if (CSTR_EQUAL != ::CompareStringW(LOCALE_NEUTRAL, NORM_IGNORECASE, sczDirectory, 1, sczPath, 1))
+        {
+            ExitFunction1(hr = S_FALSE);
+        }
+
+        ++sczDirectory;
+        ++sczPath;
+    }
+
+    --sczDirectory;
+    if (('\\' == *sczDirectory && *sczPath) || '\\' == *sczPath)
+    {
+        hr = S_OK;
+    }
+    else
+    {
+        hr = S_FALSE;
+    }
+
+LExit:
+    ReleaseStr(sczOriginalPath);
+    ReleaseStr(sczOriginalDirectory);
+    return hr;
+}

--- a/src/burn/engine/approvedexe.h
+++ b/src/burn/engine/approvedexe.h
@@ -1,0 +1,86 @@
+//-------------------------------------------------------------------------------------------------
+// <copyright file="approvedexe.h" company="Outercurve Foundation">
+//   Copyright (c) 2004, Outercurve Foundation.
+//   This software is released under Microsoft Reciprocal License (MS-RL).
+//   The license and further copyright text can be found in the file
+//   LICENSE.TXT at the root directory of the distribution.
+// </copyright>
+//
+// <summary>
+//    Module: Core
+// </summary>
+//-------------------------------------------------------------------------------------------------
+
+#pragma once
+
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+
+// structs
+
+typedef struct _BURN_APPROVED_EXE
+{
+    LPWSTR sczId;
+    DWORD64 qwFileSize;
+    BYTE* pbHash;
+    DWORD cbHash;
+} BURN_APPROVED_EXE;
+
+typedef struct _BURN_APPROVED_EXES
+{
+    BURN_APPROVED_EXE* rgApprovedExes;
+    DWORD cApprovedExes;
+} BURN_APPROVED_EXES;
+
+typedef struct _BURN_LAUNCH_APPROVED_EXE
+{
+    HWND hwndParent;
+    LPWSTR sczId;
+    LPWSTR sczExecutablePath;
+    LPWSTR sczArguments;
+    DWORD dwWaitForInputIdleTimeout;
+} BURN_LAUNCH_APPROVED_EXE;
+
+
+// function declarations
+
+HRESULT ApprovedExesParseFromXml(
+    __in BURN_APPROVED_EXES* pApprovedExes,
+    __in IXMLDOMNode* pixnBundle
+    );
+
+HRESULT ApprovedExesUninitialize(
+    __in BURN_APPROVED_EXES* pApprovedExes
+    );
+HRESULT ApprovedExesUninitializeLaunch(
+    __in BURN_LAUNCH_APPROVED_EXE* pLaunchApprovedExe
+    );
+HRESULT ApprovedExesFindById(
+    __in BURN_APPROVED_EXES* pApprovedExes,
+    __in_z LPCWSTR wzId,
+    __out BURN_APPROVED_EXE** ppApprovedExe
+    );
+HRESULT ApprovedExesLaunch(
+    __in BURN_LAUNCH_APPROVED_EXE* pLaunchApprovedExe,
+    __out DWORD* pdwProcessId
+    );
+HRESULT ApprovedExesVerifySecureLocation(
+    __in BURN_VARIABLES* pVariables,
+    __in BURN_LAUNCH_APPROVED_EXE* pLaunchApprovedExe
+    );
+HRESULT PathCanonicalizePath(
+    __in_z LPCWSTR wzPath,
+    __deref_out_z LPWSTR* psczCanonicalized
+    );
+HRESULT PathDirectoryContainsPath(
+    __in_z LPCWSTR wzDirectory,
+    __in_z LPCWSTR wzPath
+    );
+
+
+#if defined(__cplusplus)
+}
+#endif

--- a/src/burn/engine/cache.h
+++ b/src/burn/engine/cache.h
@@ -54,6 +54,11 @@ HRESULT CacheCaclulateContainerWorkingPath(
     __in BURN_CONTAINER* pContainer,
     __deref_out_z LPWSTR* psczWorkingPath
     );
+HRESULT CacheGetRootCompletedPath(
+    __in BOOL fPerMachine,
+    __in BOOL fForceInitialize,
+    __deref_out_z LPWSTR* psczRootCompletedPath
+    );
 HRESULT CacheGetCompletedPath(
     __in BOOL fPerMachine,
     __in_z LPCWSTR wzCacheId,
@@ -144,6 +149,11 @@ HRESULT CacheVerifyPayloadSignature(
     __in BURN_PAYLOAD* pPayload,
     __in_z LPCWSTR wzUnverifiedPayloadPath,
     __in HANDLE hFile
+    );
+HRESULT CacheVerifyFileAgainstHash(
+    __in LPWSTR wzUnverifiedPath,
+    __in BYTE* pbHash,
+    __in DWORD cbHash
     );
 void CacheCleanup(
     __in BOOL fPerMachine,

--- a/src/burn/engine/core.h
+++ b/src/burn/engine/core.h
@@ -115,6 +115,7 @@ typedef struct _BURN_ENGINE_STATE
     BURN_PAYLOADS payloads;
     BURN_PACKAGES packages;
     BURN_UPDATE update;
+    BURN_APPROVED_EXES approvedExes;
 
     HWND hMessageWindow;
     HANDLE hMessageWindowThread;
@@ -177,6 +178,10 @@ HRESULT CoreElevate(
 HRESULT CoreApply(
     __in BURN_ENGINE_STATE* pEngineState,
     __in_opt HWND hwndParent
+    );
+HRESULT CoreLaunchApprovedExe(
+    __in BURN_ENGINE_STATE* pEngineState,
+    __in BURN_LAUNCH_APPROVED_EXE* pLaunchApprovedExe
     );
 HRESULT CoreQuit(
     __in BURN_ENGINE_STATE* pEngineState,

--- a/src/burn/engine/elevation.cpp
+++ b/src/burn/engine/elevation.cpp
@@ -40,11 +40,13 @@ typedef enum _BURN_ELEVATION_MESSAGE_TYPE
     BURN_ELEVATION_MESSAGE_TYPE_LOAD_COMPATIBLE_PACKAGE,
     BURN_ELEVATION_MESSAGE_TYPE_LAUNCH_EMBEDDED_CHILD,
     BURN_ELEVATION_MESSAGE_TYPE_CLEAN_PACKAGE,
+    BURN_ELEVATION_MESSAGE_TYPE_LAUNCH_APPROVED_EXE,
 
     BURN_ELEVATION_MESSAGE_TYPE_EXECUTE_PROGRESS,
     BURN_ELEVATION_MESSAGE_TYPE_EXECUTE_ERROR,
     BURN_ELEVATION_MESSAGE_TYPE_EXECUTE_MSI_MESSAGE,
     BURN_ELEVATION_MESSAGE_TYPE_EXECUTE_FILES_IN_USE,
+    BURN_ELEVATION_MESSAGE_TYPE_LAUNCH_APPROVED_EXE_PROCESSID,
 } BURN_ELEVATION_MESSAGE_TYPE;
 
 
@@ -62,12 +64,18 @@ typedef struct _BURN_ELEVATION_MSI_MESSAGE_CONTEXT
     LPVOID pvContext;
 } BURN_ELEVATION_MSI_MESSAGE_CONTEXT;
 
+typedef struct _BURN_ELEVATION_LAUNCH_APPROVED_EXE_MESSAGE_CONTEXT
+{
+    DWORD dwProcessId;
+} BURN_ELEVATION_LAUNCH_APPROVED_EXE_MESSAGE_CONTEXT;
+
 typedef struct _BURN_ELEVATION_CHILD_MESSAGE_CONTEXT
 {
     DWORD dwLoggingTlsId;
     HANDLE hPipe;
     HANDLE* phLock;
     BOOL* pfDisabledAutomaticUpdates;
+    BURN_APPROVED_EXES* pApprovedExes;
     BURN_CONTAINERS* pContainers;
     BURN_PACKAGES* pPackages;
     BURN_PAYLOADS* pPayloads;
@@ -97,6 +105,11 @@ static HRESULT ProcessGenericExecuteMessages(
     __out DWORD* pdwResult
     );
 static HRESULT ProcessMsiPackageMessages(
+    __in BURN_PIPE_MESSAGE* pMsg,
+    __in_opt LPVOID pvContext,
+    __out DWORD* pdwResult
+    );
+static HRESULT ProcessLaunchApprovedExeMessages(
     __in BURN_PIPE_MESSAGE* pMsg,
     __in_opt LPVOID pvContext,
     __out DWORD* pdwResult
@@ -218,6 +231,13 @@ static int MsiExecuteMessageHandler(
     );
 static HRESULT OnCleanPackage(
     __in BURN_PACKAGES* pPackages,
+    __in BYTE* pbData,
+    __in DWORD cbData
+    );
+static HRESULT OnLaunchApprovedExe(
+    __in HANDLE hPipe,
+    __in BURN_APPROVED_EXES* pApprovedExes,
+    __in BURN_VARIABLES* pVariables,
     __in BYTE* pbData,
     __in DWORD cbData
     );
@@ -1006,6 +1026,44 @@ LExit:
     return hr;
 }
 
+extern "C" HRESULT ElevationLaunchApprovedExe(
+    __in HANDLE hPipe,
+    __in BURN_LAUNCH_APPROVED_EXE* pLaunchApprovedExe,
+    __out DWORD* pdwProcessId
+    )
+{
+    HRESULT hr = S_OK;
+    BYTE* pbData = NULL;
+    SIZE_T cbData = 0;
+    DWORD dwResult = 0;
+    BURN_ELEVATION_LAUNCH_APPROVED_EXE_MESSAGE_CONTEXT context = {};
+
+    // Serialize message data.
+    hr = BuffWriteString(&pbData, &cbData, pLaunchApprovedExe->sczId);
+    ExitOnFailure(hr, "Failed to write approved exe id to message buffer.");
+
+    hr = BuffWriteString(&pbData, &cbData, pLaunchApprovedExe->sczExecutablePath);
+    ExitOnFailure(hr, "Failed to write approved exe path to message buffer.");
+
+    hr = BuffWriteString(&pbData, &cbData, pLaunchApprovedExe->sczArguments);
+    ExitOnFailure(hr, "Failed to write approved exe arguments to message buffer.");
+
+    hr = BuffWriteNumber(&pbData, &cbData, pLaunchApprovedExe->dwWaitForInputIdleTimeout);
+    ExitOnFailure(hr, "Failed to write approved exe WaitForInputIdle timeout to message buffer.");
+
+    // Send the message.
+    hr = PipeSendMessage(hPipe, BURN_ELEVATION_MESSAGE_TYPE_LAUNCH_APPROVED_EXE, pbData, cbData, ProcessLaunchApprovedExeMessages, &context, &dwResult);
+    ExitOnFailure(hr, "Failed to send BURN_ELEVATION_MESSAGE_TYPE_LAUNCH_APPROVED_EXE message to per-machine process.");
+
+    hr = (HRESULT)dwResult;
+    *pdwProcessId = context.dwProcessId;
+
+LExit:
+    ReleaseBuffer(pbData);
+
+    return hr;
+}
+
 /*******************************************************************
  ElevationChildPumpMessages - 
 
@@ -1014,6 +1072,7 @@ extern "C" HRESULT ElevationChildPumpMessages(
     __in DWORD dwLoggingTlsId,
     __in HANDLE hPipe,
     __in HANDLE hCachePipe,
+    __in BURN_APPROVED_EXES* pApprovedExes,
     __in BURN_CONTAINERS* pContainers,
     __in BURN_PACKAGES* pPackages,
     __in BURN_PAYLOADS* pPayloads,
@@ -1045,6 +1104,7 @@ extern "C" HRESULT ElevationChildPumpMessages(
     context.hPipe = hPipe;
     context.phLock = phLock;
     context.pfDisabledAutomaticUpdates = pfDisabledAutomaticUpdates;
+    context.pApprovedExes = pApprovedExes;
     context.pContainers = pContainers;
     context.pPackages = pPackages;
     context.pPayloads = pPayloads;
@@ -1329,6 +1389,39 @@ LExit:
     return hr;
 }
 
+static HRESULT ProcessLaunchApprovedExeMessages(
+    __in BURN_PIPE_MESSAGE* pMsg,
+    __in_opt LPVOID pvContext,
+    __out DWORD* pdwResult
+    )
+{
+    HRESULT hr = S_OK;
+    SIZE_T iData = 0;
+    BURN_ELEVATION_LAUNCH_APPROVED_EXE_MESSAGE_CONTEXT* pContext = static_cast<BURN_ELEVATION_LAUNCH_APPROVED_EXE_MESSAGE_CONTEXT*>(pvContext);
+    DWORD dwProcessId = 0;
+
+    // Process the message.
+    switch (pMsg->dwMessage)
+    {
+    case BURN_ELEVATION_MESSAGE_TYPE_LAUNCH_APPROVED_EXE_PROCESSID:
+        // read message parameters
+        hr = BuffReadNumber((BYTE*)pMsg->pvData, pMsg->cbData, &iData, &dwProcessId);
+        ExitOnFailure(hr, "Failed to read approved exe process id.");
+        pContext->dwProcessId = dwProcessId;
+        break;
+
+    default:
+        hr = E_INVALIDARG;
+        ExitOnRootFailure(hr, "Invalid launch approved exe message.");
+        break;
+    }
+
+    *pdwResult = static_cast<DWORD>(hr);
+
+LExit:
+    return hr;
+}
+
 static HRESULT ProcessElevatedChildMessage(
     __in BURN_PIPE_MESSAGE* pMsg,
     __in_opt LPVOID pvContext,
@@ -1400,6 +1493,10 @@ static HRESULT ProcessElevatedChildMessage(
 
     case BURN_ELEVATION_MESSAGE_TYPE_CLEAN_PACKAGE:
         hrResult = OnCleanPackage(pContext->pPackages, (BYTE*)pMsg->pvData, pMsg->cbData);
+        break;
+
+    case BURN_ELEVATION_MESSAGE_TYPE_LAUNCH_APPROVED_EXE:
+        hrResult = OnLaunchApprovedExe(pContext->hPipe, pContext->pApprovedExes, pContext->pVariables, (BYTE*)pMsg->pvData, pMsg->cbData);
         break;
 
     default:
@@ -2474,5 +2571,66 @@ static HRESULT OnCleanPackage(
 
 LExit:
     ReleaseStr(sczPackage);
+    return hr;
+}
+
+static HRESULT OnLaunchApprovedExe(
+    __in HANDLE hPipe,
+    __in BURN_APPROVED_EXES* pApprovedExes,
+    __in BURN_VARIABLES* pVariables,
+    __in BYTE* pbData,
+    __in DWORD cbData
+    )
+{
+    HRESULT hr = S_OK;
+    SIZE_T iData = 0;
+    BURN_LAUNCH_APPROVED_EXE* pLaunchApprovedExe = NULL;
+    BURN_APPROVED_EXE* pApprovedExe = NULL;
+    DWORD dwProcessId = 0;
+    BYTE* pbSendData = NULL;
+    SIZE_T cbSendData = 0;
+    DWORD dwResult = 0;
+
+    pLaunchApprovedExe = (BURN_LAUNCH_APPROVED_EXE*)MemAlloc(sizeof(BURN_LAUNCH_APPROVED_EXE), TRUE);
+
+    // deserialize message data
+    hr = BuffReadString(pbData, cbData, &iData, &pLaunchApprovedExe->sczId);
+    ExitOnFailure(hr, "Failed to read approved exe id.");
+
+    hr = BuffReadString(pbData, cbData, &iData, &pLaunchApprovedExe->sczExecutablePath);
+    ExitOnFailure(hr, "Failed to read approved exe path.");
+
+    hr = BuffReadString(pbData, cbData, &iData, &pLaunchApprovedExe->sczArguments);
+    ExitOnFailure(hr, "Failed to read approved exe arguments.");
+
+    hr = BuffReadNumber(pbData, cbData, &iData, &pLaunchApprovedExe->dwWaitForInputIdleTimeout);
+    ExitOnFailure(hr, "Failed to read approved exe WaitForInputIdle timeout.");
+
+    hr = ApprovedExesFindById(pApprovedExes, pLaunchApprovedExe->sczId, &pApprovedExe);
+    ExitOnFailure1(hr, "The per-user process requested unknown approved exe with id: %ls", pLaunchApprovedExe->sczId);
+
+    hr = ApprovedExesVerifySecureLocation(pVariables, pLaunchApprovedExe);
+    ExitOnFailure(hr, "Failed to verify the executable path is in a secure location.");
+    if (S_FALSE == hr)
+    {
+        ExitFunction1(hr = HRESULT_FROM_WIN32(ERROR_ACCESS_DENIED));
+    }
+
+    hr = CacheVerifyFileAgainstHash(pLaunchApprovedExe->sczExecutablePath, pApprovedExe->pbHash, pApprovedExe->cbHash);
+    ExitOnFailure1(hr, "Hash verification failed for approved exe with id: %ls", pLaunchApprovedExe->sczId);
+
+    hr = ApprovedExesLaunch(pLaunchApprovedExe, &dwProcessId);
+    ExitOnFailure(hr, "Failed to launch approved exe.");
+
+    //send process id over pipe
+    hr = BuffWriteNumber(&pbSendData, &cbSendData, dwProcessId);
+    ExitOnFailure(hr, "Failed to write the approved exe process id to message buffer.");
+
+    hr = PipeSendMessage(hPipe, BURN_ELEVATION_MESSAGE_TYPE_LAUNCH_APPROVED_EXE_PROCESSID, pbSendData, cbSendData, NULL, NULL, &dwResult);
+    ExitOnFailure(hr, "Failed to send BURN_ELEVATION_MESSAGE_TYPE_LAUNCH_APPROVED_EXE_PROCESSID message to per-user process.");
+
+LExit:
+    ReleaseBuffer(pbSendData);
+    ApprovedExesUninitializeLaunch(pLaunchApprovedExe);
     return hr;
 }

--- a/src/burn/engine/elevation.h
+++ b/src/burn/engine/elevation.h
@@ -142,12 +142,18 @@ HRESULT ElevationCleanPackage(
     __in HANDLE hPipe,
     __in BURN_PACKAGE* pPackage
     );
+HRESULT ElevationLaunchApprovedExe(
+    __in HANDLE hPipe,
+    __in BURN_LAUNCH_APPROVED_EXE* pLaunchApprovedExe,
+    __out DWORD* pdwProcessId
+    );
 
 // Child (per-machine process) side functions.
 HRESULT ElevationChildPumpMessages(
     __in DWORD dwLoggingTlsId,
     __in HANDLE hPipe,
     __in HANDLE hCachePipe,
+    __in BURN_APPROVED_EXES* pApprovedExes,
     __in BURN_CONTAINERS* pContainers,
     __in BURN_PACKAGES* pPackages,
     __in BURN_PAYLOADS* pPayloads,

--- a/src/burn/engine/engine.mc
+++ b/src/burn/engine/engine.mc
@@ -785,3 +785,17 @@ SymbolicName=MSG_STATE_NOT_SAVED
 Language=English
 The state file could not be saved, error: 0x%1!x!. Continuing...
 .
+
+MessageId=600
+Severity=Success
+SymbolicName=MSG_LAUNCH_APPROVED_EXE_BEGIN
+Language=English
+Launch approved exe begin.
+.
+
+MessageId=699
+Severity=Success
+SymbolicName=MSG_LAUNCH_APPROVED_EXE_COMPLETE
+Language=English
+Launch approved exe complete, result: 0x%1!x!, processId: %2!lu!
+.

--- a/src/burn/engine/engine.vcxproj
+++ b/src/burn/engine/engine.vcxproj
@@ -39,6 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="apply.cpp" />
+    <ClCompile Include="approvedexe.cpp" />
     <ClCompile Include="bitsengine.cpp" />
     <ClCompile Include="catalog.cpp" />
     <ClCompile Include="detect.cpp" />
@@ -80,6 +81,7 @@
     <ClInclude Include="..\inc\IBootstrapperEngine.h" />
     <ClInclude Include="..\inc\IBootstrapperApplication.h" />
     <ClInclude Include="apply.h" />
+    <ClInclude Include="approvedexe.h" />
     <ClInclude Include="bitsengine.h" />
     <ClInclude Include="catalog.h" />
     <ClInclude Include="detect.h" />

--- a/src/burn/engine/engine.vcxproj.filters
+++ b/src/burn/engine/engine.vcxproj.filters
@@ -84,9 +84,6 @@
     <ClCompile Include="dependency.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="downloadengine.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="apply.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -127,6 +124,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="relatedbundle.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="approvedexe.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
@@ -203,9 +203,6 @@
     <ClInclude Include="dependency.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="downloadengine.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="apply.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -255,6 +252,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="relatedbundle.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="approvedexe.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/burn/engine/manifest.cpp
+++ b/src/burn/engine/manifest.cpp
@@ -65,21 +65,21 @@ extern "C" HRESULT ManifestLoadXmlFromBuffer(
         hr = XmlGetYesNoAttribute(pixnChain, L"DisableRollback", &pEngineState->fDisableRollback);
         if (E_NOTFOUND != hr)
         {
-            ExitOnFailure(hr, "Failed to to get Chain/@DisableRollback");
+            ExitOnFailure(hr, "Failed to get Chain/@DisableRollback");
         }
 
         // parse disable system restore
         hr = XmlGetYesNoAttribute(pixnChain, L"DisableSystemRestore", &pEngineState->fDisableSystemRestore);
         if (E_NOTFOUND != hr)
         {
-            ExitOnFailure(hr, "Failed to to get Chain/@DisableSystemRestore");
+            ExitOnFailure(hr, "Failed to get Chain/@DisableSystemRestore");
         }
 
         // parse parallel cache
         hr = XmlGetYesNoAttribute(pixnChain, L"ParallelCache", &pEngineState->fParallelCacheAndExecute);
         if (E_NOTFOUND != hr)
         {
-            ExitOnFailure(hr, "Failed to to get Chain/@ParallelCache");
+            ExitOnFailure(hr, "Failed to get Chain/@ParallelCache");
         }
     }
 
@@ -122,6 +122,10 @@ extern "C" HRESULT ManifestLoadXmlFromBuffer(
     // parse packages
     hr = PackagesParseFromXml(&pEngineState->packages, &pEngineState->payloads, pixeBundle);
     ExitOnFailure(hr, "Failed to parse packages.");
+
+    // parse approved exes for elevation
+    hr = ApprovedExesParseFromXml(&pEngineState->approvedExes, pixeBundle);
+    ExitOnFailure(hr, "Failed to parse approved exes.");
 
 LExit:
     ReleaseObject(pixnChain);

--- a/src/burn/engine/precomp.h
+++ b/src/burn/engine/precomp.h
@@ -73,6 +73,7 @@
 #include "condition.h"
 #include "search.h"
 #include "section.h"
+#include "approvedexe.h"
 #include "container.h"
 #include "catalog.h"
 #include "payload.h"

--- a/src/burn/inc/IBootstrapperApplication.h
+++ b/src/burn/inc/IBootstrapperApplication.h
@@ -714,6 +714,16 @@ DECLARE_INTERFACE_IID_(IBootstrapperApplication, IUnknown, "53C31D56-49C0-426B-A
         __in HRESULT hrStatus,
         __in BOOTSTRAPPER_APPLY_RESTART restart
         ) = 0;
+
+    // OnLaunchApprovedExeComplete - called after trying to launch the preapproved executable.
+    //
+    // Parameters:
+    //  dwProcessId is only valid if the operation succeeded.
+    //
+    STDMETHOD_(void, OnLaunchApprovedExeComplete)(
+        __in HRESULT hrStatus,
+        __in DWORD dwProcessId
+        ) = 0;
 };
 
 

--- a/src/burn/inc/IBootstrapperEngine.h
+++ b/src/burn/inc/IBootstrapperEngine.h
@@ -217,4 +217,12 @@ DECLARE_INTERFACE_IID_(IBootstrapperEngine, IUnknown, "6480D616-27A0-44D7-905B-8
     STDMETHOD(Quit)(
         __in DWORD dwExitCode
         ) = 0;
+
+    STDMETHOD(LaunchApprovedExe)(
+        __in_opt HWND hwndParent,
+        __in_z LPCWSTR wzApprovedExeForElevationId,
+        __in_z LPCWSTR wzExecutablePath,
+        __in_z_opt LPCWSTR wzArguments,
+        __in DWORD dwWaitForInputIdleTimeout
+        ) = 0;
 };

--- a/src/ext/BalExtension/mba/core/BootstrapperApplication.cs
+++ b/src/ext/BalExtension/mba/core/BootstrapperApplication.cs
@@ -311,6 +311,11 @@ namespace Microsoft.Tools.WindowsInstallerXml.Bootstrapper
         public event EventHandler<ExecuteProgressEventArgs> ExecuteProgress;
 
         /// <summary>
+        /// Fired when the engine has completed launching the preapproved executable.
+        /// </summary>
+        public event EventHandler<LaunchApprovedExeCompleteArgs> LaunchApprovedExeComplete;
+
+        /// <summary>
         /// Specifies whether this bootstrapper should run asynchronously. The default is true.
         /// </summary>
         public virtual bool AsyncExecution
@@ -1050,7 +1055,20 @@ namespace Microsoft.Tools.WindowsInstallerXml.Bootstrapper
             }
         }
 
-        #region IBurnUserExperience Members
+        /// <summary>
+        /// Called by the engine after trying to launch the preapproved executable.
+        /// </summary>
+        /// <param name="args">Additional arguments for this event.</param>
+        protected virtual void OnLaunchApprovedExeComplete(LaunchApprovedExeCompleteArgs args)
+        {
+            EventHandler<LaunchApprovedExeCompleteArgs> handler = this.LaunchApprovedExeComplete;
+            if (null != handler)
+            {
+                handler(this, args);
+            }
+        }
+
+        #region IBootstrapperApplication Members
 
         void IBootstrapperApplication.OnStartup()
         {
@@ -1427,6 +1445,11 @@ namespace Microsoft.Tools.WindowsInstallerXml.Bootstrapper
             this.OnExecuteProgress(args);
 
             return args.Result;
+        }
+
+        void IBootstrapperApplication.OnLaunchApprovedExeComplete(int hrStatus, int processId)
+        {
+            this.OnLaunchApprovedExeComplete(new LaunchApprovedExeCompleteArgs(hrStatus, processId));
         }
 
         #endregion

--- a/src/ext/BalExtension/mba/core/Engine.cs
+++ b/src/ext/BalExtension/mba/core/Engine.cs
@@ -296,6 +296,31 @@ namespace Microsoft.Tools.WindowsInstallerXml.Bootstrapper
         }
 
         /// <summary>
+        /// Launches a preapproved executable elevated.  As long as the engine already elevated, there will be no UAC prompt.
+        /// </summary>
+        /// <param name="hwndParent">The parent window of the elevation dialog (if the engine hasn't elevated yet).</param>
+        /// <param name="approvedExeForElevationId">Id of the ApprovedExeForElevation element specified when the bundle was authored.</param>
+        /// <param name="executablePath">Absolute path to the executable.  The executable must be in a secure location, currently one of the ProgramFilesFolders or the Package Cache.</param>
+        /// <param name="arguments">Optional arguments.</param>
+        public void LaunchApprovedExe(IntPtr hwndParent, string approvedExeForElevationId, string executablePath, string arguments)
+        {
+            LaunchApprovedExe(hwndParent, approvedExeForElevationId, executablePath, arguments, 0);
+        }
+
+        /// <summary>
+        /// Launches a preapproved executable elevated.  As long as the engine already elevated, there will be no UAC prompt.
+        /// </summary>
+        /// <param name="hwndParent">The parent window of the elevation dialog (if the engine hasn't elevated yet).</param>
+        /// <param name="approvedExeForElevationId">Id of the ApprovedExeForElevation element specified when the bundle was authored.</param>
+        /// <param name="executablePath">Absolute path to the executable. The executable must be in a secure location, currently one of the ProgramFilesFolders or the Package Cache.</param>
+        /// <param name="arguments">Optional arguments.</param>
+		/// <param name="waitForInputIdleTimeout">Timeout in milliseconds. When set to something other than zero, the engine will call WaitForInputIdle for the new process with this timeout before calling OnLaunchApprovedExeComplete.</param>
+        public void LaunchApprovedExe(IntPtr hwndParent, string approvedExeForElevationId, string executablePath, string arguments, int waitForInputIdleTimeout)
+        {
+            engine.LaunchApprovedExe(hwndParent, approvedExeForElevationId, executablePath, arguments, waitForInputIdleTimeout);
+        }
+
+        /// <summary>
         /// Logs the <paramref name="message"/>.
         /// </summary>
         /// <param name="level">The logging level.</param>

--- a/src/ext/BalExtension/mba/core/EventArgs.cs
+++ b/src/ext/BalExtension/mba/core/EventArgs.cs
@@ -2120,4 +2120,28 @@ namespace Microsoft.Tools.WindowsInstallerXml.Bootstrapper
             get { return this.overallPercentage; }
         }
     }
+
+    /// <summary>
+    /// Additional arguments passed by the engine after it finished trying to launch the preapproved executable.
+    /// </summary>
+    [Serializable]
+    public class LaunchApprovedExeCompleteArgs : StatusEventArgs
+    {
+        private int processId;
+
+        public LaunchApprovedExeCompleteArgs(int status, int processId)
+            : base(status)
+        {
+            this.processId = processId;
+        }
+
+        /// <summary>
+        /// Gets the ProcessId of the process that was launched.
+        /// This is only valid if the status reports success.
+        /// </summary>
+        public int ProcessId
+        {
+            get { return this.processId; }
+        }
+    }
 }

--- a/src/ext/BalExtension/mba/core/IBootstrapperApplication.cs
+++ b/src/ext/BalExtension/mba/core/IBootstrapperApplication.cs
@@ -370,6 +370,11 @@ namespace Microsoft.Tools.WindowsInstallerXml.Bootstrapper
             int hrStatus,
             [MarshalAs(UnmanagedType.U4)] ApplyRestart restart
             );
+
+        void OnLaunchApprovedExeComplete(
+            int hrStatus,
+            int processId
+            );
     }
 
     /// <summary>

--- a/src/ext/BalExtension/mba/core/IBootstrapperEngine.cs
+++ b/src/ext/BalExtension/mba/core/IBootstrapperEngine.cs
@@ -145,6 +145,14 @@ namespace Microsoft.Tools.WindowsInstallerXml.Bootstrapper
         void Quit(
             [MarshalAs(UnmanagedType.U4)] int dwExitCode
             );
+
+        void LaunchApprovedExe(
+            IntPtr hwndParent,
+            [MarshalAs(UnmanagedType.LPWStr)] string wzApprovedExeForElevationId,
+            [MarshalAs(UnmanagedType.LPWStr)] string wzExecutablePath,
+            [MarshalAs(UnmanagedType.LPWStr)] string wzArguments,
+            [MarshalAs(UnmanagedType.U4)] int dwWaitForInputIdleTimeout
+            );
     }
 
     /// <summary>

--- a/src/ext/BalExtension/wixext/BalCompiler.cs
+++ b/src/ext/BalExtension/wixext/BalCompiler.cs
@@ -211,6 +211,9 @@ namespace Microsoft.Tools.WindowsInstallerXml.Extensions
         {
             SourceLineNumberCollection sourceLineNumbers = Preprocessor.GetSourceLineNumbers(node);
             string launchTarget = null;
+            string launchTargetElevatedId = null;
+            string launchArguments = null;
+            YesNoType launchHidden = YesNoType.NotSet;
             string licenseFile = null;
             string licenseUrl = null;
             string logoFile = null;
@@ -230,6 +233,15 @@ namespace Microsoft.Tools.WindowsInstallerXml.Extensions
                     {
                         case "LaunchTarget":
                             launchTarget = this.Core.GetAttributeValue(sourceLineNumbers, attrib, false);
+                            break;
+                        case "LaunchTargetElevatedId":
+                            launchTargetElevatedId = this.Core.GetAttributeIdentifierValue(sourceLineNumbers, attrib);
+                            break;
+                        case "LaunchArguments":
+                            launchArguments = this.Core.GetAttributeValue(sourceLineNumbers, attrib, false);
+                            break;
+                        case "LaunchHidden":
+                            launchHidden = this.Core.GetAttributeYesNoValue(sourceLineNumbers, attrib);
                             break;
                         case "LicenseFile":
                             licenseFile = this.Core.GetAttributeValue(sourceLineNumbers, attrib, false);
@@ -297,6 +309,21 @@ namespace Microsoft.Tools.WindowsInstallerXml.Extensions
                 if (!String.IsNullOrEmpty(launchTarget))
                 {
                     this.Core.CreateVariableRow(sourceLineNumbers, "LaunchTarget", launchTarget, "string", false, false);
+                }
+
+                if (!String.IsNullOrEmpty(launchTargetElevatedId))
+                {
+                    this.Core.CreateVariableRow(sourceLineNumbers, "LaunchTargetElevatedId", launchTargetElevatedId, "string", false, false);
+                }
+
+                if (!String.IsNullOrEmpty(launchArguments))
+                {
+                    this.Core.CreateVariableRow(sourceLineNumbers, "LaunchArguments", launchArguments, "string", false, false);
+                }
+
+                if (YesNoType.Yes == launchHidden)
+                {
+                    this.Core.CreateVariableRow(sourceLineNumbers, "LaunchHidden", "yes", "string", false, false);
                 }
 
                 if (!String.IsNullOrEmpty(licenseFile))

--- a/src/ext/BalExtension/wixext/Xsd/bal.xsd
+++ b/src/ext/BalExtension/wixext/Xsd/bal.xsd
@@ -62,7 +62,36 @@
         <xs:complexType>
             <xs:attribute name="LaunchTarget" type="xs:string">
                 <xs:annotation>
-                    <xs:documentation>If set, the success page will show a Launch button the user can use to launch the application being installed. The string value can be formatted using Burn variables enclosed in brackets, to refer to installation directories and so forth.</xs:documentation>
+                    <xs:documentation>
+                        If set, the success page will show a Launch button the user can use to launch the application being installed.
+                        The string value can be formatted using Burn variables enclosed in brackets, 
+                        to refer to installation directories and so forth.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="LaunchTargetElevatedId" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>
+                        Id of the target ApprovedExeForElevation element.
+                        If set with LaunchTarget, WixStdBA will launch the application through the Engine's LaunchApprovedExe method instead of through ShellExecute.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="LaunchArguments" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>
+                        If set, WixStdBA will supply these arguments when launching the application specified by the LaunchTarget attribute.
+                        The string value can be formatted using Burn variables enclosed in brackets,
+                        to refer to installation directories and so forth.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="LaunchHidden" type="YesNoType">
+                <xs:annotation>
+                    <xs:documentation>
+                        If set to "yes", WixStdBA will launch the application specified by the LaunchTarget attribute with the SW_HIDE flag.
+                        This attribute is ignored when the LaunchTargetElevatedId attribute is specified.
+                    </xs:documentation>
                 </xs:annotation>
             </xs:attribute>
             <xs:attribute name="LicenseFile" type="xs:string">

--- a/src/libs/balutil/inc/BalBaseBootstrapperApplication.h
+++ b/src/libs/balutil/inc/BalBaseBootstrapperApplication.h
@@ -65,7 +65,7 @@ public: // IUnknown
         return 0;
     }
 
-public: // IBurnUserExperience
+public: // IBootstrapperApplication
     virtual STDMETHODIMP OnStartup()
     {
         return S_OK;
@@ -568,6 +568,13 @@ public: // IBurnUserExperience
         )
     {
         return CheckCanceled() ? IDCANCEL : IDNOACTION;
+    }
+
+    virtual STDMETHODIMP_(void) OnLaunchApprovedExeComplete(
+        __in HRESULT /*hrStatus*/,
+        __in DWORD /*dwProcessId*/
+        )
+    {
     }
 
 protected:

--- a/src/tools/wix/ApprovedExeForElevation.cs
+++ b/src/tools/wix/ApprovedExeForElevation.cs
@@ -1,0 +1,45 @@
+﻿//-------------------------------------------------------------------------------------------------
+// <copyright file="ApprovedExeForElevation.cs" company="Outercurve Foundation">
+//   Copyright (c) 2004, Outercurve Foundation.
+//   This software is released under Microsoft Reciprocal License (MS-RL).
+//   The license and further copyright text can be found in the file
+//   LICENSE.TXT at the root directory of the distribution.
+// </copyright>
+// 
+// <summary>
+// ApprovedExeForElevation dynamically generated info.
+// </summary>
+//-------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Tools.WindowsInstallerXml
+{
+    using System;
+    using System.IO;
+
+    /// <summary>
+    /// ApprovedExeForElevation dynamically generated info.
+    /// </summary>
+    public class ApprovedExeForElevation
+    {
+        public ApprovedExeForElevation(WixApprovedExeForElevationRow wixApprovedExeForElevationRow)
+        {
+            this.Id = wixApprovedExeForElevationRow.Id;
+            this.SourceFile = wixApprovedExeForElevationRow.SourceFile;
+        }
+
+        public void CalculateHash()
+        {
+            FileInfo fileInfo = new FileInfo(this.SourceFile);
+            this.FileSize = fileInfo.Length;
+            this.Hash = Common.GetFileHash(fileInfo);
+        }
+
+        public string Id { get; set; }
+
+        public string SourceFile { get; set; }
+
+        public long FileSize { get; set; }
+
+        public string Hash { get; set; }
+    }
+}

--- a/src/tools/wix/Compiler.cs
+++ b/src/tools/wix/Compiler.cs
@@ -19779,6 +19779,71 @@ namespace Microsoft.Tools.WindowsInstallerXml
             }
         }
 
+
+        /// <summary>
+        /// Parses a Bundle element.
+        /// </summary>
+        /// <param name="node">Element to parse</param>
+        private void ParseApprovedExeForElevation(XmlNode node)
+        {
+            SourceLineNumberCollection sourceLineNumbers = Preprocessor.GetSourceLineNumbers(node);
+            string id = null;
+            string sourceFile = null;
+
+            foreach (XmlAttribute attrib in node.Attributes)
+            {
+                if (0 == attrib.NamespaceURI.Length || attrib.NamespaceURI == this.schema.TargetNamespace)
+                {
+                    switch (attrib.LocalName)
+                    {
+                        case "Id":
+                            id = this.core.GetAttributeIdentifierValue(sourceLineNumbers, attrib);
+                            break;
+                        case "SourceFile":
+                            sourceFile = this.core.GetAttributeValue(sourceLineNumbers, attrib);
+                            break;
+                        default:
+                            this.core.UnexpectedAttribute(sourceLineNumbers, attrib);
+                            break;
+                    }
+                }
+                else
+                {
+                    this.core.UnsupportedExtensionAttribute(sourceLineNumbers, attrib);
+                }
+            }
+
+            if (null == id)
+            {
+                this.core.OnMessage(WixErrors.ExpectedAttribute(sourceLineNumbers, node.Name, "Id"));
+            }
+
+            if (null == sourceFile)
+            {
+                this.core.OnMessage(WixErrors.ExpectedAttribute(sourceLineNumbers, node.Name, "SourceFile"));
+            }
+
+            foreach (XmlNode child in node.ChildNodes)
+            {
+                if (XmlNodeType.Element == child.NodeType)
+                {
+                    if (child.NamespaceURI == this.schema.TargetNamespace)
+                    {
+                        this.core.UnexpectedElement(node, child);
+                    }
+                    else
+                    {
+                        this.core.UnsupportedExtensionElement(node, child);
+                    }
+                }
+            }
+
+            if (!this.core.EncounteredError)
+            {
+                this.core.CreateWixApprovedExeForElevationRow(sourceLineNumbers, id, sourceFile);
+            }
+        }
+
         /// <summary>
         /// Parses a Bundle element.
         /// </summary>
@@ -19951,6 +20016,9 @@ namespace Microsoft.Tools.WindowsInstallerXml
                     {
                         switch (child.LocalName)
                         {
+                            case "ApprovedExeForElevation":
+                                this.ParseApprovedExeForElevation(child);
+                                break;
                             case "BootstrapperApplication":
                                 if (baSeen)
                                 {

--- a/src/tools/wix/CompilerCore.cs
+++ b/src/tools/wix/CompilerCore.cs
@@ -741,6 +741,17 @@ namespace Microsoft.Tools.WindowsInstallerXml
         }
 
         /// <summary>
+        /// Creates a WixApprovedExeForElevation row in the active session.
+        /// </summary>
+        /// <param name="sourceLineNumbers">Source and line number of current row.</param>
+        public void CreateWixApprovedExeForElevationRow(SourceLineNumberCollection sourceLineNumbers, string id, string sourceFile)
+        {
+            WixApprovedExeForElevationRow wixApprovedExeForElevationRow = (WixApprovedExeForElevationRow)this.CreateRow(sourceLineNumbers, "WixApprovedExeForElevation");
+            wixApprovedExeForElevationRow.Id = id;
+            wixApprovedExeForElevationRow.SourceFile = sourceFile;
+        }
+
+        /// <summary>
         /// Creates a WixCatalog row in the active section.
         /// </summary>
         /// <param name="sourceLineNumbers">Source and line number of current row.</param>

--- a/src/tools/wix/Data/tables.xml
+++ b/src/tools/wix/Data/tables.xml
@@ -1678,6 +1678,10 @@
         <columnDefinition name="ProviderKey" type="string" length="38" category="guid" nullable="yes" description="Only valid after binding." />
         <columnDefinition name="PerMachine" type="number" length="2" nullable="yes" minValue="0" maxValue="1" description="Only valid after binding." />
     </tableDefinition>
+    <tableDefinition name="WixApprovedExeForElevation" createSymbols="yes" unreal="yes">
+      <columnDefinition name="Id" type="string" length="0" category="identifier" primaryKey="yes"/>
+      <columnDefinition name="SourceFile" type="object" length="0"/>
+    </tableDefinition>
     <tableDefinition name="WixBundleUpdate" unreal="yes">
         <columnDefinition name="Location" type="string" length="0" />
         <columnDefinition name="Attributes" type="number" length="4" nullable="yes" />

--- a/src/tools/wix/Table.cs
+++ b/src/tools/wix/Table.cs
@@ -163,6 +163,9 @@ namespace Microsoft.Tools.WindowsInstallerXml
                 case "WixAction":
                     row = new WixActionRow(sourceLineNumbers, this);
                     break;
+                case "WixApprovedExeForElevation":
+                    row = new WixApprovedExeForElevationRow(sourceLineNumbers, this);
+                    break;
                 case "WixBundle":
                     row = new WixBundleRow(sourceLineNumbers, this);
                     break;

--- a/src/tools/wix/Wix.csproj
+++ b/src/tools/wix/Wix.csproj
@@ -18,6 +18,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="ApprovedExeForElevation.cs" />
     <Compile Include="AssemblyDefaultFabricatorExtensionAttribute.cs" />
     <Compile Include="AssemblyDefaultHeatExtensionAttribute.cs" />
     <Compile Include="AssemblyDefaultWixExtensionAttribute.cs" />
@@ -58,6 +59,7 @@
     <Compile Include="InspectorExtension.cs" />
     <Compile Include="Patch.cs" />
     <Compile Include="PatchAPI\PatchInterop.cs" />
+    <Compile Include="WixApprovedExeForElevationRow.cs" />
     <Compile Include="WixBundlePatchTargetCodeRow.cs" />
     <Compile Include="PatchTransform.cs" />
     <Compile Include="PayloadInfoRow.cs" />

--- a/src/tools/wix/WixApprovedExeForElevationRow.cs
+++ b/src/tools/wix/WixApprovedExeForElevationRow.cs
@@ -1,0 +1,63 @@
+﻿//-------------------------------------------------------------------------------------------------
+// <copyright file="WixApprovedExeForElevationRow.cs" company="Outercurve Foundation">
+//   Copyright (c) 2004, Outercurve Foundation.
+//   This software is released under Microsoft Reciprocal License (MS-RL).
+//   The license and further copyright text can be found in the file
+//   LICENSE.TXT at the root directory of the distribution.
+// </copyright>
+// 
+// <summary>
+// Specialization of a row for the WixApprovedExeForElevation table.
+// </summary>
+//-------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Tools.WindowsInstallerXml
+{
+    using System;
+
+    /// <summary>
+    /// Specialization of a row for the WixApprovedExeForElevation table.
+    /// </summary>
+    public class WixApprovedExeForElevationRow : Row
+    {
+        /// <summary>
+        /// Creates an ApprovedExeForElevation row that does not belong to a table.
+        /// </summary>
+        /// <param name="sourceLineNumbers">Original source lines for this row.</param>
+        /// <param name="tableDef">TableDefinition this ApprovedExeForElevation row belongs to and should get its column definitions from.</param>
+        public WixApprovedExeForElevationRow(SourceLineNumberCollection sourceLineNumbers, TableDefinition tableDef) :
+            base(sourceLineNumbers, tableDef)
+        {
+        }
+
+        /// <summary>
+        /// Creates an ApprovedExeForElevation row that belongs to a table.
+        /// </summary>
+        /// <param name="sourceLineNumbers">Original source lines for this row.</param>
+        /// <param name="table">Table this ApprovedExeForElevation row belongs to and should get its column definitions from.</param>
+        public WixApprovedExeForElevationRow(SourceLineNumberCollection sourceLineNumbers, Table table)
+            : base(sourceLineNumbers, table)
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the ApprovedExeForElevation identifier.
+        /// </summary>
+        /// <value>The catalog identifier.</value>
+        public string Id
+        {
+            get { return (string)this.Fields[0].Data; }
+            set { this.Fields[0].Data = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the source file (path).
+        /// </summary>
+        /// <value>The source file (path).</value>
+        public string SourceFile
+        {
+            get { return (string)this.Fields[1].Data; }
+            set { this.Fields[1].Data = value; }
+        }
+    }
+}

--- a/src/tools/wix/Xsd/wix.xsd
+++ b/src/tools/wix/Xsd/wix.xsd
@@ -73,6 +73,7 @@
     </xs:annotation>
     <xs:complexType>
       <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="ApprovedExeForElevation" minOccurs="0" maxOccurs="unbounded" />
         <xs:element ref="Log" minOccurs="0" maxOccurs="1" />
         <xs:element ref="Catalog" minOccurs="0" maxOccurs="unbounded" />
         <xs:element ref="BootstrapperApplication" minOccurs="0" maxOccurs="1" />
@@ -252,6 +253,26 @@
           </xs:documentation>
         </xs:annotation>
       </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ApprovedExeForElevation">
+    <xs:annotation>
+      <xs:documentation>Provides information about an .exe so that the BA can request the engine to run it elevated from any secure location.</xs:documentation>
+      <xs:appinfo>
+        <xse:parent namespace="http://schemas.microsoft.com/wix/2006/wi" ref="Bundle" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The identifier of the ApprovedExeForElevation element.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SourceFile" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The .exe file</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
     </xs:complexType>
   </xs:element>
   <xs:element name="Log">

--- a/test/src/UnitTests/Burn/precomp.h
+++ b/test/src/UnitTests/Burn/precomp.h
@@ -51,6 +51,7 @@
 #include "condition.h"
 #include "search.h"
 #include "section.h"
+#include "approvedexe.h"
 #include "container.h"
 #include "catalog.h"
 #include "payload.h"


### PR DESCRIPTION
Add ApprovedExeForElevation element, IBootstrapperEngine.LaunchApprovedExe, IBootstrapperApplication.OnLaunchApprovedExeCompleted, and enable WixStdBA to use them.

There are a couple of new pathutil functions that I had to keep in Burn, because I couldn't figure out how to get winterop and one other project to build. They couldn't find PathCanonicalizeW.
