### PR TITLE
WIXBUG:4243 - use hashes to verify bundled packages by default.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* RobMen: WIXBUG:4243 - use hashes to verify bundled packages by default.
+
 ## WixBuild: Version 3.9.526.0
 
 * BobArnson: WIXBUG:3701 - Add a check for file size when verifying cab cache.

--- a/src/tools/wix/Compiler.cs
+++ b/src/tools/wix/Compiler.cs
@@ -20614,7 +20614,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
 
             SourceLineNumberCollection sourceLineNumbers = Preprocessor.GetSourceLineNumbers(node);
             YesNoDefaultType compressed = YesNoDefaultType.Default;
-            YesNoType suppressSignatureVerification = YesNoType.NotSet;
+            YesNoType suppressSignatureVerification = YesNoType.Yes;
             string id = null;
             string name = null;
             string sourceFile = null;

--- a/src/tools/wix/Xsd/wix.xsd
+++ b/src/tools/wix/Xsd/wix.xsd
@@ -946,10 +946,12 @@
     <xs:attribute name="SuppressSignatureVerification" type="YesNoTypeUnion">
       <xs:annotation>
         <xs:documentation>
-          By default, a Bundle will use a package's Authenticode signature to verify the contents. If the package does not
-          have an Authenticode signature then the Bundle will use a hash of the package instead. Set this attribute to "yes"
-          to suppress the default behavior and force the Bundle to always use the hash of the package even when the package
-          is signed.
+          By default, a Bundle will use the hash of a package to verify its contents. If this attribute is explicitly set to "no"
+          and the package is signed with an Authenticode signature the Bundle will verify the contents of the package using the
+          signature instead. Therefore, the default for this attribute could be considered to be "yes". It is unusual for "yes" to
+          be the default of an attribute. In this case, the default was changed in WiX v3.9 after experiencing real world issues
+          with Windows verifying Authenticode signatures. Since the Authenticode signatures are no more secure than hashing the
+          packages directly, the default was changed.
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>


### PR DESCRIPTION
Told the story in the wix.xsd.
