### PR TITLE
WIXBUG:3890 - Burn: cmd property value with escaped quotes breaks engine

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* SeanHall: WIXBUG:3890 - put Burn command line arguments first when launching unelevated parent process since malformed user arguments created an infinite loop.
+
 * RobMen: WIXBUG:4288 - do not mask error code when testing file size of payload in cache.
 
 * RobMen: Point to new page for linker error 217 to fix WIXBUG:4208.

--- a/src/burn/engine/pipe.cpp
+++ b/src/burn/engine/pipe.cpp
@@ -365,8 +365,8 @@ HRESULT PipeLaunchParentProcess(
     hr = PathForCurrentProcess(&sczBurnPath, NULL);
     ExitOnFailure(hr, "Failed to get current process path.");
 
-    hr = StrAllocFormatted(&sczParameters, L"%ls -%ls %ls %ls %u", wzCommandLine, BURN_COMMANDLINE_SWITCH_UNELEVATED, sczConnectionName, sczSecret, dwProcessId);
-    ExitOnFailure(hr, "Failed to allocate parameters for elevated process.");
+    hr = StrAllocFormatted(&sczParameters, L"-%ls %ls %ls %u %ls", BURN_COMMANDLINE_SWITCH_UNELEVATED, sczConnectionName, sczSecret, dwProcessId, wzCommandLine);
+    ExitOnFailure(hr, "Failed to allocate parameters for unelevated process.");
 
 #ifdef ENABLE_UNELEVATE
     if (fDisableUnelevate)


### PR DESCRIPTION
Put Burn command line arguments first when launching unelevated parent process since malformed user arguments created an infinite loop.
