### PR TITLE
Support redirectable package cache via policy

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* HeathS: WIXFEAT:4278 - Support redirectable package cache via policy.
+
 * SeanHall: WIXFEAT:3736 - Add WixBundleExecutePackageCacheFolder variable.
 
 * SeanHall: WIXBUG:3890 - put Burn command line arguments first when launching unelevated parent process since malformed user arguments created an infinite loop.

--- a/src/burn/engine/cache.h
+++ b/src/burn/engine/cache.h
@@ -144,6 +144,7 @@ void CacheCleanup(
     __in BOOL fPerMachine,
     __in_z LPCWSTR wzBundleId
     );
+void CacheUninitialize();
 
 #ifdef __cplusplus
 }

--- a/src/burn/engine/engine.cpp
+++ b/src/burn/engine/engine.cpp
@@ -184,6 +184,7 @@ LExit:
     UserExperienceRemove(&engineState.userExperience);
 
     CacheRemoveWorkingFolder(engineState.registration.sczId);
+    CacheUninitialize();
 
     // If this is a related bundle (but not an update) suppress restart and return the standard restart error code.
     if (fRestart && BOOTSTRAPPER_RELATION_NONE != engineState.command.relationType && BOOTSTRAPPER_RELATION_UPDATE != engineState.command.relationType)

--- a/src/libs/dutil/dlutil.cpp
+++ b/src/libs/dutil/dlutil.cpp
@@ -18,7 +18,6 @@
 
 static const DWORD64 DOWNLOAD_ENGINE_TWO_GIGABYTES = DWORD64(2) * 1024 * 1024 * 1024;
 static LPCWSTR DOWNLOAD_ENGINE_ACCEPT_TYPES[] = { L"*/*", NULL };
-const LPCWSTR DOWNLOAD_POLICY_REGISTRY_PATH = L"WiX\\Burn";
 
 // internal function declarations
 
@@ -144,7 +143,7 @@ extern "C" HRESULT DAPI DownloadUrl(
     ExitOnNullWithLastError(hSession, hr, "Failed to open internet session");
 
     // Make a best effort to set the download timeouts to 2 minutes or whatever policy says.
-    PolcReadNumber(DOWNLOAD_POLICY_REGISTRY_PATH, L"DownloadTimeout", 2 * 60, &dwTimeout);
+    PolcReadNumber(POLICY_BURN_REGISTRY_PATH, L"DownloadTimeout", 2 * 60, &dwTimeout);
     if (0 < dwTimeout)
     {
         dwTimeout *= 1000; // convert to milliseconds.

--- a/src/libs/dutil/inc/polcutil.h
+++ b/src/libs/dutil/inc/polcutil.h
@@ -16,6 +16,8 @@
 extern "C" {
 #endif
 
+const LPCWSTR POLICY_BURN_REGISTRY_PATH = L"WiX\\Burn";
+
 /********************************************************************
 PolcReadNumber - reads a number from policy.
 

--- a/test/data/Burn/PolicyTests/A.wxs
+++ b/test/data/Burn/PolicyTests/A.wxs
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  <copyright file="A.wxs" company="Outercurve Foundation">
+    Copyright (c) 2004, Outercurve Foundation.
+    This software is released under Microsoft Reciprocal License (MS-RL).
+    The license and further copyright text can be found in the file
+    LICENSE.TXT at the root directory of the distribution.
+  </copyright>
+-->
+
+<?ifndef ProductCode?>
+<?define ProductCode = *?>
+<?endif?>
+
+<?ifndef Version?>
+<?define Version = 1.0.0.0?>
+<?endif?>
+
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Product Id="$(var.ProductCode)" Name="~$(var.TestName) - A" Language="1033" Version="$(var.Version)" Manufacturer="Microsoft Corporation"
+           UpgradeCode="354573B1-9720-4288-82AD-53C7B26FB71E">
+    <Package Compressed="yes" InstallerVersion="300" InstallScope="perMachine"/>
+
+    <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+    <MediaTemplate />
+
+    <Property Id="MsiLogging" Value="voicewarmup"/>
+    <PropertyRef Id="TestVersion"/>
+
+    <Feature Id="Complete" Level="1">
+      <ComponentRef Id="FileComponent"/>
+      <ComponentRef Id="RegistryComponent"/>
+    </Feature>
+  </Product>
+
+  <Fragment>
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="ProgramFilesFolder">
+        <Directory Id="WixDir" Name="~Test WiX">
+          <Directory Id="TestDir" Name="$(var.TestName)">
+            <Directory Id="INSTALLFOLDER" Name="A"/>
+          </Directory>
+        </Directory>
+      </Directory>
+    </Directory>
+  </Fragment>
+
+  <Fragment>
+    <Component Id="FileComponent" Directory="INSTALLFOLDER">
+      <File Source="$(sys.SOURCEFILEPATH)"/>
+    </Component>
+  </Fragment>
+
+  <Fragment>
+    <Component Id="RegistryComponent" Directory="INSTALLFOLDER">
+      <RegistryValue Root="HKLM" Key="Software\WiX\Tests\$(var.TestName)" Name="A" Value="!(bind.Property.TestVersion)" Type="string" />
+    </Component>
+  </Fragment>
+
+  <Fragment>
+    <Property Id="TestVersion" Value="$(var.Version)"/>
+  </Fragment>
+</Wix>

--- a/test/data/Burn/PolicyTests/B.wxs
+++ b/test/data/Burn/PolicyTests/B.wxs
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  <copyright file="B.wxs" company="Outercurve Foundation">
+    Copyright (c) 2004, Outercurve Foundation.
+    This software is released under Microsoft Reciprocal License (MS-RL).
+    The license and further copyright text can be found in the file
+    LICENSE.TXT at the root directory of the distribution.
+  </copyright>
+-->
+
+<?ifndef ProductCode?>
+<?define ProductCode = *?>
+<?endif?>
+
+<?ifndef Version?>
+<?define Version = 1.0.0.0?>
+<?endif?>
+
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Product Id="$(var.ProductCode)" Name="~$(var.TestName) - B" Language="1033" Version="$(var.Version)" Manufacturer="Microsoft Corporation"
+           UpgradeCode="1380CEF2-6B97-4AA4-A761-59B753BEC324">
+    <Package Compressed="yes" InstallerVersion="300" InstallScope="perMachine"/>
+
+    <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+    <MediaTemplate />
+
+    <Property Id="MsiLogging" Value="voicewarmup"/>
+    <PropertyRef Id="TestVersion"/>
+
+    <Feature Id="Complete" Level="1">
+      <ComponentRef Id="FileComponent"/>
+      <ComponentRef Id="RegistryComponent"/>
+    </Feature>
+  </Product>
+
+  <Fragment>
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="ProgramFilesFolder">
+        <Directory Id="WixDir" Name="~Test WiX">
+          <Directory Id="TestDir" Name="$(var.TestName)">
+            <Directory Id="INSTALLFOLDER" Name="B"/>
+          </Directory>
+        </Directory>
+      </Directory>
+    </Directory>
+  </Fragment>
+
+  <Fragment>
+    <Component Id="FileComponent" Directory="INSTALLFOLDER">
+      <File Source="$(sys.SOURCEFILEPATH)"/>
+    </Component>
+  </Fragment>
+
+  <Fragment>
+    <Component Id="RegistryComponent" Directory="INSTALLFOLDER">
+      <RegistryValue Root="HKLM" Key="Software\WiX\Tests\$(var.TestName)" Name='B' Value="!(bind.Property.TestVersion)" Type="string" />
+    </Component>
+  </Fragment>
+
+  <Fragment>
+    <Property Id="TestVersion" Value="$(var.Version)"/>
+  </Fragment>
+</Wix>

--- a/test/data/Burn/PolicyTests/BundleA.wxs
+++ b/test/data/Burn/PolicyTests/BundleA.wxs
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  <copyright file="BundleA.wxs" company="Outercurve Foundation">
+    Copyright (c) 2004, Outercurve Foundation.
+    This software is released under Microsoft Reciprocal License (MS-RL).
+    The license and further copyright text can be found in the file
+    LICENSE.TXT at the root directory of the distribution.
+  </copyright>
+-->
+
+<?ifndef Version?>
+<?define Version = 1.0.0.0?>
+<?endif?>
+
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Bundle Name="~$(var.TestName) - Bundle A" Manufacturer="!(bind.packageManufacturer.PackageA)" Version="$(var.Version)" UpgradeCode="5802E2D0-AC39-4486-86FF-D4B7AD012EB5">
+    <Log Prefix="~$(var.TestName)_BundleA"/>
+
+    <Variable Name="TestName" Value="$(var.TestName)" />
+
+    <BootstrapperApplicationRef Id='ManagedBootstrapperApplicationHost'>
+      <Payload Name='BootstrapperCore.config' SourceFile='!(bindpath.build)\TestBA.BootstrapperCore.config' />
+
+      <Payload SourceFile='!(bindpath.build)\TestBA.dll' />
+    </BootstrapperApplicationRef>
+    <WixVariable Id='WixMbaPrereqPackageId' Value='ignored' />
+    <WixVariable Id='WixMbaPrereqLicenseUrl' Value='ignored' />
+
+    <Chain>
+      <MsiPackage Id="PackageA" Name="~$(var.TestName)_PackageA.msi" Compressed="yes" SourceFile="!(bindpath.packageA)" Vital="yes"/>
+    </Chain>
+  </Bundle>
+</Wix>

--- a/test/data/Burn/PolicyTests/BundleB.wxs
+++ b/test/data/Burn/PolicyTests/BundleB.wxs
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  <copyright file="BundleB.wxs" company="Outercurve Foundation">
+    Copyright (c) 2004, Outercurve Foundation.
+    This software is released under Microsoft Reciprocal License (MS-RL).
+    The license and further copyright text can be found in the file
+    LICENSE.TXT at the root directory of the distribution.
+  </copyright>
+-->
+
+<?ifndef Version?>
+<?define Version = 1.0.0.0?>
+<?endif?>
+
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Bundle Name="~$(var.TestName) - Bundle B" Manufacturer="!(bind.packageManufacturer.PackageB)" Version="$(var.Version)" UpgradeCode="68AA492B-A014-495F-880D-3629D3354D6B">
+    <Log Prefix="~$(var.TestName)_BundleB"/>
+
+    <Variable Name="TestName" Value="$(var.TestName)" />
+
+    <BootstrapperApplicationRef Id='ManagedBootstrapperApplicationHost'>
+      <Payload Name='BootstrapperCore.config' SourceFile='!(bindpath.build)\TestBA.BootstrapperCore.config' />
+
+      <Payload SourceFile='!(bindpath.build)\TestBA.dll' />
+    </BootstrapperApplicationRef>
+    <WixVariable Id='WixMbaPrereqPackageId' Value='ignored' />
+    <WixVariable Id='WixMbaPrereqLicenseUrl' Value='ignored' />
+
+    <Chain>
+      <MsiPackage Id="PackageA" Name="~$(var.TestName)_PackageA.msi" Compressed="yes" SourceFile="!(bindpath.packageA)" Vital="yes"/>
+
+      <MsiPackage Id="PackageB" Name="~$(var.TestName)_PackageB.msi" Compressed="yes" SourceFile="!(bindpath.PackageB)" Vital="yes"/>
+    </Chain>
+  </Bundle>
+</Wix>

--- a/test/src/WixTests/Burn/Burn.PolicyTests.cs
+++ b/test/src/WixTests/Burn/Burn.PolicyTests.cs
@@ -1,0 +1,92 @@
+//-----------------------------------------------------------------------
+// <copyright file="Burn.PolicyTests.cs" company="Outercurve Foundation">
+//   Copyright (c) 2004, Outercurve Foundation.
+//   This software is released under Microsoft Reciprocal License (MS-RL).
+//   The license and further copyright text can be found in the file
+//   LICENSE.TXT at the root directory of the distribution.
+// </copyright>
+// <summary>
+//     Contains methods test Burn.
+// </summary>
+//-----------------------------------------------------------------------
+
+namespace WixTest.Tests.Burn
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using WixTest.Utilities;
+    using WixTest.Verifiers;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Microsoft.Tools.WindowsInstallerXml;
+    using Microsoft.Tools.WindowsInstallerXml.Bootstrapper;
+    using Microsoft.Win32;
+
+    [TestClass]
+    public class PolicyTests : BurnTests
+    {
+        [TestMethod]
+        [Priority(2)]
+        [Description("Installs bundle A using default settings, changes the package cache, and installs bundle B.")]
+        [TestProperty("IsRuntimeTest", "true")]
+        public void Burn_RedirectPackageCache()
+        {
+            const string PolicyName = "PackageCache";
+
+            // Build the packages.
+            string packageA = new PackageBuilder(this, "A") { Extensions = Extensions }.Build().Output;
+            string packageB = new PackageBuilder(this, "B") { Extensions = Extensions }.Build().Output;
+
+            // Create the named bind paths to the packages.
+            Dictionary<string, string> bindPaths = new Dictionary<string, string>();
+            bindPaths.Add("packageA", packageA);
+            bindPaths.Add("packageB", packageB);
+
+            // Build the bundles.
+            string bundleA = new BundleBuilder(this, "BundleA") { BindPaths = bindPaths, Extensions = Extensions }.Build().Output;
+            string bundleB = new BundleBuilder(this, "BundleB") { BindPaths = bindPaths, Extensions = Extensions }.Build().Output;
+
+            RegistryKey policy = Registry.LocalMachine.CreateSubKey(@"Software\Policies\WiX\Burn");
+            string currentPackageCache = null;
+
+            try
+            {
+                currentPackageCache = policy.GetValue(PolicyName) as string;
+
+                // Install the first bundle using the default package cache.
+                policy.DeleteValue(PolicyName);
+
+                BundleInstaller installerA = new BundleInstaller(this, bundleA).Install();
+                Assert.IsTrue(MsiVerifier.IsPackageInstalled(packageA));
+
+                // Install the second bundle which has a shared package using the redirected package cache.
+                string path = Path.Combine(Path.GetTempPath(), "Package Cache");
+                policy.SetValue(PolicyName, path);
+
+                BundleInstaller installerB = new BundleInstaller(this, bundleB).Install();
+                Assert.IsTrue(MsiVerifier.IsPackageInstalled(packageA));
+                Assert.IsTrue(MsiVerifier.IsPackageInstalled(packageB));
+
+                // The first bundle should leave package A behind.
+                installerA.Uninstall();
+
+                // Now make sure that the second bundle removes packages from either cache directory.
+                installerB.Uninstall();
+
+                this.CleanTestArtifacts = true;
+            }
+            finally
+            {
+                if (!string.IsNullOrEmpty(currentPackageCache))
+                {
+                    policy.SetValue(PolicyName, currentPackageCache);
+                }
+                else
+                {
+                    policy.DeleteValue(PolicyName);
+                }
+
+                policy.Dispose();
+            }
+        }
+    }
+}

--- a/test/src/WixTests/WixTests.csproj
+++ b/test/src/WixTests/WixTests.csproj
@@ -33,6 +33,7 @@
     <Compile Include="Burn\Burn.ParentTests.cs" />
     <Compile Include="Burn\Burn.PatchTests.cs" />
     <Compile Include="Burn\Burn.PermanentTests.cs" />
+    <Compile Include="Burn\Burn.PolicyTests.cs" />
     <Compile Include="Burn\Burn.RegistrationTests.cs" />
     <Compile Include="Burn\Burn.RelatedBundleTests.cs" />
     <Compile Include="Burn\Burn.SearchTests.cs" />
@@ -351,6 +352,18 @@
     </None>
     <None Include="..\..\data\Burn\PermanentTests\BundleA.wxs">
       <Link>Burn\PermanentTests\BundleA.wxs</Link>
+    </None>
+    <None Include="..\..\data\Burn\PolicyTests\A.wxs">
+      <Link>Burn\PolicyTests\A.wxs</Link>
+    </None>
+    <None Include="..\..\data\Burn\PolicyTests\B.wxs">
+      <Link>Burn\PolicyTests\B.wxs</Link>
+    </None>
+    <None Include="..\..\data\Burn\PolicyTests\BundleA.wxs">
+      <Link>Burn\PolicyTests\BundleA.wxs</Link>
+    </None>
+    <None Include="..\..\data\Burn\PolicyTests\BundleB.wxs">
+      <Link>Burn\PolicyTests\BundleA.wxs</Link>
     </None>
     <None Include="..\..\data\Burn\SearchTests\A.wxs">
       <Link>Burn\SearchTests\A.wxs</Link>


### PR DESCRIPTION
Implements feature 4278 by defining a new machine policy for the per-machine package cache location.
