### PR TITLE
WIXBUG:4416 - MBA on Win7 RTM with .NET 4.5.2

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* SeanHall: WIXBUG:4416 - Fail fast when loading an MBA on Win7 RTM with .NET 4.5.2 or greater installed.
+
 * HeathS: WIXFEAT:4278 - Support redirectable package cache via policy.
 
 * RobMen: WIXBUG:4243 - use hashes to verify bundled packages by default.

--- a/src/ext/BalExtension/mba/host/host.vcxproj
+++ b/src/ext/BalExtension/mba/host/host.vcxproj
@@ -31,7 +31,7 @@
 
   <PropertyGroup>
     <ProjectAdditionalIncludeDirectories>$(WixRoot)src\libs\dutil\inc;$(WixRoot)src\burn\inc;$(WixRoot)src\libs\balutil\inc;$(BaseIntermediateOutputPath)\core</ProjectAdditionalIncludeDirectories>
-    <ProjectAdditionalLinkLibraries>dutil.lib;balutil.lib</ProjectAdditionalLinkLibraries>
+    <ProjectAdditionalLinkLibraries>dutil.lib;balutil.lib;shlwapi.lib</ProjectAdditionalLinkLibraries>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ext/BalExtension/mba/host/host.vcxproj.filters
+++ b/src/ext/BalExtension/mba/host/host.vcxproj.filters
@@ -23,7 +23,6 @@
     <None Include="host.def">
       <Filter>Source Files</Filter>
     </None>
-    <None Include="host.build" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="precomp.h">

--- a/src/ext/BalExtension/mba/host/precomp.h
+++ b/src/ext/BalExtension/mba/host/precomp.h
@@ -15,11 +15,13 @@
 
 #include <windows.h>
 #include <msiquery.h>
-#include <mscoree.h>
+#include <metahost.h>
+#include <shlwapi.h>
 
 #import <mscorlib.tlb> raw_interfaces_only rename("ReportEvent", "mscorlib_ReportEvent")
 
 #include <dutil.h>
+#include <osutil.h>
 #include <pathutil.h>
 #include <regutil.h>
 #include <strutil.h>

--- a/src/ext/BalExtension/wixstdba/Resources/mbapreq.wxl
+++ b/src/ext/BalExtension/wixstdba/Resources/mbapreq.wxl
@@ -21,4 +21,5 @@
   <String Id="FailureRestartText">You must restart your computer to complete the rollback of the software.</String>
   <String Id="FailureRestartButton">&amp;Restart</String>
   <String Id="FailureCloseButton">&amp;Close</String>
+  <String Id="NET452WIN7RTMErrorMessage">[WixBundleName] cannot run on Windows 7 RTM with .NET 4.5.2 (or greater) installed.</String>
 </WixLocalization>

--- a/src/ext/BalExtension/wixstdba/precomp.h
+++ b/src/ext/BalExtension/wixstdba/precomp.h
@@ -48,6 +48,7 @@
 HRESULT CreateBootstrapperApplication(
     __in HMODULE hModule,
     __in BOOL fPrereq,
+    __in HRESULT hrHostInitialization,
     __in IBootstrapperEngine* pEngine,
     __in const BOOTSTRAPPER_COMMAND* pCommand,
     __out IBootstrapperApplication** ppApplication

--- a/src/ext/BalExtension/wixstdba/wixstdba.cpp
+++ b/src/ext/BalExtension/wixstdba/wixstdba.cpp
@@ -47,7 +47,7 @@ extern "C" HRESULT WINAPI BootstrapperApplicationCreate(
 
     BalInitialize(pEngine);
 
-    hr = CreateBootstrapperApplication(vhInstance, FALSE, pEngine, pCommand, ppApplication);
+    hr = CreateBootstrapperApplication(vhInstance, FALSE, S_OK, pEngine, pCommand, ppApplication);
     BalExitOnFailure(hr, "Failed to create bootstrapper application interface.");
 
 LExit:
@@ -62,6 +62,7 @@ extern "C" void WINAPI BootstrapperApplicationDestroy()
 
 
 extern "C" HRESULT WINAPI MbaPrereqBootstrapperApplicationCreate(
+    __in HRESULT hrHostInitialization,
     __in IBootstrapperEngine* pEngine,
     __in const BOOTSTRAPPER_COMMAND* pCommand,
     __out IBootstrapperApplication** ppApplication
@@ -71,7 +72,7 @@ extern "C" HRESULT WINAPI MbaPrereqBootstrapperApplicationCreate(
 
     BalInitialize(pEngine);
 
-    hr = CreateBootstrapperApplication(vhInstance, TRUE, pEngine, pCommand, ppApplication);
+    hr = CreateBootstrapperApplication(vhInstance, TRUE, hrHostInitialization, pEngine, pCommand, ppApplication);
     BalExitOnFailure(hr, "Failed to create managed prerequisite bootstrapper application interface.");
 
 LExit:

--- a/src/libs/balutil/inc/balutil.h
+++ b/src/libs/balutil/inc/balutil.h
@@ -32,6 +32,12 @@ extern "C" {
 #define BalExitOnNullWithLastError(p, x, f) if (NULL == p) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (!FAILED(x)) { x = E_FAIL; } BalLogError(x, f); ExitTrace(x, f); goto LExit; }
 #define BalExitOnNullWithLastError1(p, x, f, s) if (NULL == p) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (!FAILED(x)) { x = E_FAIL; } BalLogError(x, f, s); ExitTrace1(x, f, s); goto LExit; }
 
+#define FACILITY_WIX 500
+
+static const HRESULT E_WIXSTDBA_CONDITION_FAILED = MAKE_HRESULT(SEVERITY_ERROR, FACILITY_WIX, 1);
+
+static const HRESULT E_MBAHOST_NET452_ON_WIN7RTM = MAKE_HRESULT(SEVERITY_ERROR, FACILITY_WIX, 1000);
+
 
 /*******************************************************************
  BalInitialize - remembers the engine interface to enable logging and


### PR DESCRIPTION
(Rebased) Fail fast when loading an MBA on Win7 RTM with .NET 4.5.2 or greater installed.

Testing notes: this only occurs on x64 Win7 and only if the bundle wasn't started elevated.  Server 2008 R2 (which is only x64) works fine.  When run in compatibility mode the bundle works fine (if set to XP it gives a UAC prompt when it launches, if set to Vista it elevates normally).
