### PR TITLE
WIXBUG:3838

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* BobArnson: WIXBUG:3838 - Since the compiler coerces null values to empty strings, check for those in ColumnDefinition.
+
 * FireGiant: WIXBUG:4319 - Support full range of ExePackage exit code values.
 
 * BobArnson: WIXBUG:4442 - Add missing tables.

--- a/src/tools/wix/ColumnDefinition.cs
+++ b/src/tools/wix/ColumnDefinition.cs
@@ -375,7 +375,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
         /// <summary>
         /// Gets the validation category for this column.
         /// </summary>
-        /// <value>Validaiton category.</value>
+        /// <value>Validation category.</value>
         public ColumnCategory Category
         {
             get { return this.category; }
@@ -903,12 +903,12 @@ namespace Microsoft.Tools.WindowsInstallerXml
                     break;
             }
 
-            if (null != this.possibilities)
+            if (!String.IsNullOrEmpty(this.possibilities))
             {
                 writer.WriteAttributeString("set", this.possibilities);
             }
 
-            if (null != this.description)
+            if (!String.IsNullOrEmpty(this.description))
             {
                 writer.WriteAttributeString("description", this.description);
             }


### PR DESCRIPTION
Since the compiler coerces null values to empty strings, check for those
in ColumnDefinition.
