### PR TITLE
Ref-count superseded products when provider already exists

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* HeathS: WIXBUG:4422 - Ref-count superseded products when provider already exists.
+
 * BobArnson: WIXBUG:4443 - Ensure that MsiPackages in a Bundle have ProductVersions that fit in a QWORD, how Burn represents a four-field version number with each field a WORD.
 
 * BobArnson: WIXBUG:3838 - Since the compiler coerces null values to empty strings, check for those in ColumnDefinition.

--- a/src/burn/engine/dependency.cpp
+++ b/src/burn/engine/dependency.cpp
@@ -900,10 +900,13 @@ static void CalculateDependencyActionStates(
                 switch (pPackage->currentState)
                 {
                 case BOOTSTRAPPER_PACKAGE_STATE_OBSOLETE:
-                    if (PackageProviderExists(pPackage))
+                    if (!PackageProviderExists(pPackage))
                     {
-                        *pDependencyExecuteAction = BURN_DEPENDENCY_ACTION_REGISTER;
+                        break;
                     }
+                    __fallthrough;
+                case BOOTSTRAPPER_PACKAGE_STATE_SUPERSEDED:
+                    *pDependencyExecuteAction = BURN_DEPENDENCY_ACTION_REGISTER;
                     break;
                 }
                 break;


### PR DESCRIPTION
Resolves issue #4422 by treating obsolesced and superseded package the same for dependency actions.
