### PR TITLE
Allow user custom actions to be independently non-vital

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* HeathS: WIXBUG:4424 - Allow user custom actions to be independently non-vital.
+
 * BobArnson: WIXBUG:4443 - Ensure that MsiPackages in a Bundle have ProductVersions that fit in a QWORD, how Burn represents a four-field version number with each field a WORD.
 
 * BobArnson: WIXBUG:3838 - Since the compiler coerces null values to empty strings, check for those in ColumnDefinition.

--- a/src/ext/UtilExtension/wixext/UtilCompiler.cs
+++ b/src/ext/UtilExtension/wixext/UtilCompiler.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Tools.WindowsInstallerXml.Extensions
 
         internal const int UserDontRemoveOnUninstall = 0x00000100;
         internal const int UserDontCreateUser = 0x00000200;
+        internal const int UserNonVital = 0x00000400;
 
         [Flags]
         internal enum WixFileSearchAttributes
@@ -3526,6 +3527,17 @@ namespace Microsoft.Tools.WindowsInstallerXml.Extensions
                             if (YesNoType.Yes == this.Core.GetAttributeYesNoValue(sourceLineNumbers, attrib))
                             {
                                 attributes |= UserUpdateIfExists;
+                            }
+                            break;
+                        case "Vital":
+                            if (null == componentId)
+                            {
+                                this.Core.OnMessage(UtilErrors.IllegalAttributeWithoutComponent(sourceLineNumbers, node.Name, attrib.Name));
+                            }
+
+                            if (YesNoType.No == this.Core.GetAttributeYesNoValue(sourceLineNumbers, attrib))
+                            {
+                                attributes |= UserNonVital;
                             }
                             break;
                         default:

--- a/src/ext/UtilExtension/wixext/UtilDecompiler.cs
+++ b/src/ext/UtilExtension/wixext/UtilDecompiler.cs
@@ -957,6 +957,11 @@ namespace Microsoft.Tools.WindowsInstallerXml.Extensions
                     {
                         user.CreateUser = Util.YesNoType.no;
                     }
+
+                    if (UtilCompiler.UserNonVital == (attributes & UtilCompiler.UserNonVital))
+                    {
+                        user.Vital = Util.YesNoType.no;
+                    }
                 }
 
                 if (null != row[1])

--- a/src/ext/UtilExtension/wixext/Xsd/util.xsd
+++ b/src/ext/UtilExtension/wixext/Xsd/util.xsd
@@ -1269,6 +1269,11 @@
           <xs:documentation>Indicates whether or not to create the user.  User creation can be skipped if all that is desired is to join a user to groups.</xs:documentation>
         </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="Vital" type="YesNoType" default="yes">
+        <xs:annotation>
+          <xs:documentation>Indicates whether failure to create the user or add the user to a group fails the installation. The default value is "yes".</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
     </xs:complexType>
   </xs:element>
   <xs:element name="XmlFile">

--- a/src/ext/ca/serverca/inc/sca.h
+++ b/src/ext/ca/serverca/inc/sca.h
@@ -130,6 +130,7 @@ enum SCAU_ATTRIBUTES
 
     SCAU_DONT_REMOVE_ON_UNINSTALL = 0x00000100,
     SCAU_DONT_CREATE_USER = 0x00000200,
+    SCAU_NON_VITAL = 0x00000400,
 };
 
 // sql database attributes definitions

--- a/src/ext/ca/serverca/scaexec/scaexec.cpp
+++ b/src/ext/ca/serverca/scaexec/scaexec.cpp
@@ -1895,7 +1895,11 @@ LExit:
         ::CoUninitialize();
     }
 
-    if (FAILED(hr))
+    if (SCAU_NON_VITAL & iAttributes)
+    {
+        er = ERROR_SUCCESS;
+    }
+    else if (FAILED(hr))
     {
         er = ERROR_INSTALL_FAILURE;
     }

--- a/test/data/Extensions/UtilExtension/UserTests/NonVitalUserGroup.wxs
+++ b/test/data/Extensions/UtilExtension/UserTests/NonVitalUserGroup.wxs
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  <copyright file="NonVitalUserGroup.wxs" company="Outercurve Foundation">
+    Copyright (c) 2004, Outercurve Foundation.
+    This software is released under Microsoft Reciprocal License (MS-RL).
+    The license and further copyright text can be found in the file
+    LICENSE.TXT at the root directory of the distribution.
+  </copyright>
+-->
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+  <Product Id="ECE4ABA2-1253-480C-A4A3-B0433A296756" Name="UserGroup" Language="1033" Version="1.0.0.0" UpgradeCode="0419D0E1-2467-4DCB-B45D-08F903F34A80" Manufacturer="Microsoft Corporation">
+    <Package Description="Test from: User" Comments="Test from: User" InstallerVersion="200" Compressed="yes" />
+
+    <Media Id="1" Cabinet="product.cab" EmbedCab="yes" />
+
+    <?include $(env.WIX_ROOT)\test\data\SharedData\Authoring\directories.wxi ?>
+
+    <util:Group Id="ShouldNotExist" Name="Should Not Exist" />
+    
+    <DirectoryRef Id="WixTestFolder">
+      <Component Id="Component1" Guid="00030829-0000-0000-C000-000000000046" DiskId="1">
+        <File Source="$(env.WIX_ROOT)\test\data\SharedData\Files\TextFile1.txt" KeyPath="yes"/>
+        
+        <util:User Id="CurrentUser" Name="[LogonUser]" Domain="[%USERDOMAIN]" Vital="no">
+          <util:GroupRef Id="ShouldNotExist" />
+        </util:User>
+      
+      </Component>
+    </DirectoryRef>
+
+    <Feature Id="Feature1" Level="1">
+      <ComponentRef Id="Component1" />
+    </Feature>
+
+  </Product>
+</Wix>

--- a/test/src/WixTestTools/WixTestBase.cs
+++ b/test/src/WixTestTools/WixTestBase.cs
@@ -159,6 +159,7 @@ namespace WixTest
             }
 
             this.TestUninitialize();
+            this.CleanUp();
         }
 
         void IDisposable.Dispose()

--- a/test/src/WixTests/Extensions/UtilExtension/UtilExtension.UserTests.cs
+++ b/test/src/WixTests/Extensions/UtilExtension/UtilExtension.UserTests.cs
@@ -243,5 +243,17 @@ namespace WixTest.Tests.Extensions.UtilExtension
             Assert.True(LogVerifier.MessageInLogFile(logFile, string.Format("ConfigureUsers:  Error 0x80070035: Failed to check existence of domain: {0}, user: testName1",Environment.GetEnvironmentVariable("tempdomain"))) ||
                 LogVerifier.MessageInLogFile(logFile, "CreateUser:  Error 0x80070005: failed to create user: testName1"), String.Format("Could not find CreateUser error message in log file: '{0}'.", logFile));
         }
+
+        [NamedFact]
+        [Description("Verify that adding a user to a non-existent group does not fail the install when non-vital.")]
+        [Priority(2)]
+        [RuntimeTest]
+        public void User_NonVitalUserGroup()
+        {
+            string sourceFile = Path.Combine(UserTests.TestDataDirectory, @"NonVitalUserGroup.wxs");
+            string msiFile = Builder.BuildPackage(sourceFile, "test.msi", "WixUtilExtension");
+
+            string logFile = MSIExec.InstallProduct(msiFile, MSIExec.MSIExecReturnCode.SUCCESS);
+        }
     }
 }


### PR DESCRIPTION
Resolves issue 4424 by allowing User elements to be attributed as non-vital so the whole install isn't failed just to add a user to a group (which can be done after install).
