### PR TITLE
Do not repair dependent bundles if no packages are executed

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* ErnestT: WIXBUG:4430 - Do not repair dependent bundles if no packages are executed.
+
 * BobArnson: WIXBUG:4443 - Ensure that MsiPackages in a Bundle have ProductVersions that fit in a QWORD, how Burn represents a four-field version number with each field a WORD.
 
 * BobArnson: WIXBUG:3838 - Since the compiler coerces null values to empty strings, check for those in ColumnDefinition.

--- a/src/burn/engine/engine.mc
+++ b/src/burn/engine/engine.mc
@@ -365,6 +365,13 @@ Language=English
 Plan skipped related bundle: %1!ls!, type: %2!hs!, provider key: %3!ls!, because an embedded bundle with the same provider key is being installed.
 .
 
+MessageId=217
+Severity=Success
+SymbolicName=MSG_PLAN_SKIPPED_DEPENDENT_BUNDLE_REPAIR
+Language=English
+Plan skipped dependent bundle repair: %1!ls!, type: %2!hs!, because no packages are being executed during this uninstall operation.
+.
+
 MessageId=299
 Severity=Success
 SymbolicName=MSG_PLAN_COMPLETE


### PR DESCRIPTION
Resolves issue #4430 by skipping packages that will not be executed, but does not skip other burn actions like dependency unregistration.
