### PR TITLE
Cleanup from 3249

### DIFF
--- a/src/burn/engine/approvedexe.cpp
+++ b/src/burn/engine/approvedexe.cpp
@@ -90,7 +90,7 @@ LExit:
     return hr;
 }
 
-extern "C" HRESULT ApprovedExesUninitialize(
+extern "C" void ApprovedExesUninitialize(
     __in BURN_APPROVED_EXES* pApprovedExes
     )
 {
@@ -106,10 +106,9 @@ extern "C" HRESULT ApprovedExesUninitialize(
         }
         MemFree(pApprovedExes->rgApprovedExes);
     }
-    return S_OK;
 }
 
-extern "C" HRESULT ApprovedExesUninitializeLaunch(
+extern "C" void ApprovedExesUninitializeLaunch(
     __in BURN_LAUNCH_APPROVED_EXE* pLaunchApprovedExe
     )
 {
@@ -120,7 +119,6 @@ extern "C" HRESULT ApprovedExesUninitializeLaunch(
         ReleaseStr(pLaunchApprovedExe->sczId);
         MemFree(pLaunchApprovedExe);
     }
-    return S_OK;
 }
 
 extern "C" HRESULT ApprovedExesFindById(
@@ -211,9 +209,9 @@ extern "C" HRESULT ApprovedExesLaunch(
     }
 
 LExit:
-    ReleaseStr(sczArgumentsFormatted);
+    StrSecureZeroFreeString(sczArgumentsFormatted);
     ReleaseStr(sczArgumentsObfuscated);
-    ReleaseStr(sczCommand);
+    StrSecureZeroFreeString(sczCommand);
     ReleaseStr(sczCommandObfuscated);
     ReleaseStr(sczExecutableDirectory);
 

--- a/src/burn/engine/approvedexe.h
+++ b/src/burn/engine/approvedexe.h
@@ -52,10 +52,10 @@ HRESULT ApprovedExesParseFromXml(
     __in IXMLDOMNode* pixnBundle
     );
 
-HRESULT ApprovedExesUninitialize(
+void ApprovedExesUninitialize(
     __in BURN_APPROVED_EXES* pApprovedExes
     );
-HRESULT ApprovedExesUninitializeLaunch(
+void ApprovedExesUninitializeLaunch(
     __in BURN_LAUNCH_APPROVED_EXE* pLaunchApprovedExe
     );
 HRESULT ApprovedExesFindById(

--- a/src/burn/engine/engine.mc
+++ b/src/burn/engine/engine.mc
@@ -797,7 +797,7 @@ MessageId=600
 Severity=Success
 SymbolicName=MSG_LAUNCH_APPROVED_EXE_BEGIN
 Language=English
-Launch approved exe begin, id: %1!ls!
+LaunchApprovedExe begin, id: %1!ls!
 .
 
 MessageId=601
@@ -818,5 +818,5 @@ MessageId=699
 Severity=Success
 SymbolicName=MSG_LAUNCH_APPROVED_EXE_COMPLETE
 Language=English
-Launch approved exe complete, result: 0x%1!x!, processId: %2!lu!
+LaunchApprovedExe complete, result: 0x%1!x!, processId: %2!lu!
 .

--- a/src/tools/wix/Data/tables.xml
+++ b/src/tools/wix/Data/tables.xml
@@ -1682,7 +1682,7 @@
       <columnDefinition name="Id" type="string" length="0" category="identifier" primaryKey="yes" />
       <columnDefinition name="Key" type="string" length="0" />
       <columnDefinition name="Value" type="string" length="0" nullable="yes" />
-      <columnDefinition name="Attributes" type="number" length="4" minValue="0" maxValue="2147483647" />
+      <columnDefinition name="Attributes" type="number" length="4" minValue="0" maxValue="1" />
     </tableDefinition>
     <tableDefinition name="WixBundleUpdate" unreal="yes">
         <columnDefinition name="Location" type="string" length="0" />


### PR DESCRIPTION
Securely free the strings when launching an approved exe, and address feedback from 3249.
