### PR TITLE
StrCoreAlloc* and StrAlloc*Secure

### DIFF
--- a/src/burn/engine/approvedexe.cpp
+++ b/src/burn/engine/approvedexe.cpp
@@ -168,7 +168,7 @@ extern "C" HRESULT ApprovedExesLaunch(
         hr = VariableFormatString(pVariables, pLaunchApprovedExe->sczArguments, &sczArgumentsFormatted, NULL);
         ExitOnFailure(hr, "Failed to format argument string.");
 
-        hr = StrAllocateFormatted(&sczCommand, TRUE, L"\"%ls\" %s", pLaunchApprovedExe->sczExecutablePath, sczArgumentsFormatted);
+        hr = StrAllocFormattedSecure(&sczCommand, L"\"%ls\" %s", pLaunchApprovedExe->sczExecutablePath, sczArgumentsFormatted);
         ExitOnFailure(hr, "Failed to create executable command.");
 
         hr = VariableFormatStringObfuscated(pVariables, pLaunchApprovedExe->sczArguments, &sczArgumentsObfuscated, NULL);

--- a/src/burn/engine/embedded.cpp
+++ b/src/burn/engine/embedded.cpp
@@ -81,7 +81,7 @@ extern "C" HRESULT EmbeddedRunBundle(
     hr = PipeCreatePipes(&connection, FALSE, &hCreatedPipesEvent);
     ExitOnFailure(hr, "Failed to create embedded pipe.");
 
-    hr = StrAllocateFormatted(&sczCommand, TRUE, L"%ls -%ls %ls %ls %u", wzArguments, BURN_COMMANDLINE_SWITCH_EMBEDDED, connection.sczName, connection.sczSecret, dwCurrentProcessId);
+    hr = StrAllocFormattedSecure(&sczCommand, L"%ls -%ls %ls %ls %u", wzArguments, BURN_COMMANDLINE_SWITCH_EMBEDDED, connection.sczName, connection.sczSecret, dwCurrentProcessId);
     ExitOnFailure(hr, "Failed to allocate embedded command.");
 
     if (!::CreateProcessW(wzExecutablePath, sczCommand, NULL, NULL, FALSE, CREATE_NO_WINDOW, NULL, NULL, &si, &pi))

--- a/src/burn/engine/exeengine.cpp
+++ b/src/burn/engine/exeengine.cpp
@@ -473,7 +473,7 @@ extern "C" HRESULT ExeEngineExecutePackage(
         hr = VariableFormatString(pVariables, wzArguments, &sczArgumentsFormatted, NULL);
         ExitOnFailure(hr, "Failed to format argument string.");
 
-        hr = StrAllocateFormatted(&sczCommand, TRUE, L"\"%ls\" %s", sczExecutablePath, sczArgumentsFormatted);
+        hr = StrAllocFormattedSecure(&sczCommand, L"\"%ls\" %s", sczExecutablePath, sczArgumentsFormatted);
         ExitOnFailure(hr, "Failed to create executable command.");
 
         hr = VariableFormatStringObfuscated(pVariables, wzArguments, &sczArgumentsObfuscated, NULL);
@@ -495,7 +495,7 @@ extern "C" HRESULT ExeEngineExecutePackage(
         // Add the list of dependencies to ignore, if any, to the burn command line.
         if (pExecuteAction->exePackage.sczIgnoreDependencies && BURN_EXE_PROTOCOL_TYPE_BURN == pExecuteAction->exePackage.pPackage->Exe.protocol)
         {
-            hr = StrAllocateFormatted(&sczCommand, TRUE, L"%ls -%ls=%ls", sczCommand, BURN_COMMANDLINE_SWITCH_IGNOREDEPENDENCIES, pExecuteAction->exePackage.sczIgnoreDependencies);
+            hr = StrAllocFormattedSecure(&sczCommand, L"%ls -%ls=%ls", sczCommand, BURN_COMMANDLINE_SWITCH_IGNOREDEPENDENCIES, pExecuteAction->exePackage.sczIgnoreDependencies);
             ExitOnFailure(hr, "Failed to append the list of dependencies to ignore to the command line.");
 
             hr = StrAllocFormatted(&sczCommandObfuscated, L"%ls -%ls=%ls", sczCommandObfuscated, BURN_COMMANDLINE_SWITCH_IGNOREDEPENDENCIES, pExecuteAction->exePackage.sczIgnoreDependencies);
@@ -505,7 +505,7 @@ extern "C" HRESULT ExeEngineExecutePackage(
         // Add the list of ancestors, if any, to the burn command line.
         if (pExecuteAction->exePackage.sczAncestors)
         {
-            hr = StrAllocateFormatted(&sczCommand, TRUE, L"%ls -%ls=%ls", sczCommand, BURN_COMMANDLINE_SWITCH_ANCESTORS, pExecuteAction->exePackage.sczAncestors);
+            hr = StrAllocFormattedSecure(&sczCommand, L"%ls -%ls=%ls", sczCommand, BURN_COMMANDLINE_SWITCH_ANCESTORS, pExecuteAction->exePackage.sczAncestors);
             ExitOnFailure(hr, "Failed to append the list of ancestors to the command line.");
 
             hr = StrAllocFormatted(&sczCommandObfuscated, L"%ls -%ls=%ls", sczCommandObfuscated, BURN_COMMANDLINE_SWITCH_ANCESTORS, pExecuteAction->exePackage.sczAncestors);

--- a/src/burn/engine/msiengine.cpp
+++ b/src/burn/engine/msiengine.cpp
@@ -1168,13 +1168,13 @@ extern "C" HRESULT MsiEngineExecutePackage(
     switch (pExecuteAction->msiPackage.action)
     {
     case BOOTSTRAPPER_ACTION_STATE_ADMIN_INSTALL:
-        hr = StrAllocateConcat(&sczProperties, L" ACTION=ADMIN", 0, TRUE);
+        hr = StrAllocConcatSecure(&sczProperties, L" ACTION=ADMIN", 0);
         ExitOnFailure(hr, "Failed to add ADMIN property on admin install.");
          __fallthrough;
 
     case BOOTSTRAPPER_ACTION_STATE_MAJOR_UPGRADE: __fallthrough;
     case BOOTSTRAPPER_ACTION_STATE_INSTALL:
-        hr = StrAllocateConcat(&sczProperties, L" REBOOT=ReallySuppress", 0, TRUE);
+        hr = StrAllocConcatSecure(&sczProperties, L" REBOOT=ReallySuppress", 0);
         ExitOnFailure(hr, "Failed to add reboot suppression property on install.");
 
         hr = WiuInstallProduct(sczMsiPath, sczProperties, &restart);
@@ -1188,11 +1188,11 @@ extern "C" HRESULT MsiEngineExecutePackage(
         // updated.
         if (0 == pExecuteAction->msiPackage.pPackage->Msi.cFeatures)
         {
-            hr = StrAllocateConcat(&sczProperties, L" REINSTALL=ALL", 0, TRUE);
+            hr = StrAllocConcatSecure(&sczProperties, L" REINSTALL=ALL", 0);
             ExitOnFailure(hr, "Failed to add reinstall all property on minor upgrade.");
         }
 
-        hr = StrAllocateConcat(&sczProperties, L" REINSTALLMODE=\"vomus\" REBOOT=ReallySuppress", 0, TRUE);
+        hr = StrAllocConcatSecure(&sczProperties, L" REINSTALLMODE=\"vomus\" REBOOT=ReallySuppress", 0);
         ExitOnFailure(hr, "Failed to add reinstall mode and reboot suppression properties on minor upgrade.");
 
         hr = WiuInstallProduct(sczMsiPath, sczProperties, &restart);
@@ -1208,12 +1208,12 @@ extern "C" HRESULT MsiEngineExecutePackage(
                                   pExecuteAction->msiPackage.pPackage->Msi.cFeatures) ? L"" : L" REINSTALL=ALL";
         LPCWSTR wzReinstallMode = (BOOTSTRAPPER_ACTION_STATE_MODIFY == pExecuteAction->msiPackage.action) ? L"o" : L"e";
 
-        hr = StrAllocateFormatted(&sczProperties, TRUE, L"%ls%ls REINSTALLMODE=\"cmus%ls\" REBOOT=ReallySuppress", sczProperties ? sczProperties : L"", wzReinstallAll, wzReinstallMode);
+        hr = StrAllocFormattedSecure(&sczProperties, L"%ls%ls REINSTALLMODE=\"cmus%ls\" REBOOT=ReallySuppress", sczProperties ? sczProperties : L"", wzReinstallAll, wzReinstallMode);
         ExitOnFailure(hr, "Failed to add reinstall mode and reboot suppression properties on repair.");
         }
 
         // Ignore all dependencies, since the Burn engine already performed the check.
-        hr = StrAllocateFormatted(&sczProperties, TRUE, L"%ls %ls=ALL", sczProperties, DEPENDENCY_IGNOREDEPENDENCIES);
+        hr = StrAllocFormattedSecure(&sczProperties, L"%ls %ls=ALL", sczProperties, DEPENDENCY_IGNOREDEPENDENCIES);
         ExitOnFailure(hr, "Failed to add the list of dependencies to ignore to the properties.");
 
         hr = WiuInstallProduct(sczMsiPath, sczProperties, &restart);
@@ -1221,11 +1221,11 @@ extern "C" HRESULT MsiEngineExecutePackage(
         break;
 
     case BOOTSTRAPPER_ACTION_STATE_UNINSTALL:
-        hr = StrAllocateConcat(&sczProperties, L" REBOOT=ReallySuppress", 0, TRUE);
+        hr = StrAllocConcatSecure(&sczProperties, L" REBOOT=ReallySuppress", 0);
         ExitOnFailure(hr, "Failed to add reboot suppression property on uninstall.");
 
         // Ignore all dependencies, since the Burn engine already performed the check.
-        hr = StrAllocateFormatted(&sczProperties, TRUE, L"%ls %ls=ALL", sczProperties, DEPENDENCY_IGNOREDEPENDENCIES);
+        hr = StrAllocFormattedSecure(&sczProperties, L"%ls %ls=ALL", sczProperties, DEPENDENCY_IGNOREDEPENDENCIES);
         ExitOnFailure(hr, "Failed to add the list of dependencies to ignore to the properties.");
 
         hr = WiuConfigureProductEx(pExecuteAction->msiPackage.pPackage->Msi.sczProductCode, INSTALLLEVEL_DEFAULT, INSTALLSTATE_ABSENT, sczProperties, &restart);
@@ -1304,11 +1304,11 @@ extern "C" HRESULT MsiEngineConcatProperties(
         ExitOnFailure(hr, "Failed to escape string.");
 
         // build part
-        hr = StrAllocateFormatted(&sczProperty, !fObfuscateHiddenVariables, L" %s%=\"%s\"", pProperty->sczId, sczEscapedValue);
+        hr = StrCoreAllocFormatted(&sczProperty, !fObfuscateHiddenVariables, L" %s%=\"%s\"", pProperty->sczId, sczEscapedValue);
         ExitOnFailure(hr, "Failed to format property string part.");
 
         // append to property string
-        hr = StrAllocateConcat(psczProperties, sczProperty, 0, !fObfuscateHiddenVariables);
+        hr = StrCoreAllocConcat(psczProperties, sczProperty, 0, !fObfuscateHiddenVariables);
         ExitOnFailure(hr, "Failed to append property string part.");
     }
 
@@ -1604,7 +1604,7 @@ static HRESULT EscapePropertyArgumentString(
     }
 
     // allocate target buffer
-    hr = StrAllocate(psczEscapedValue, cch + cchEscape + 1, fZeroOnRealloc); // character count, plus escape character count, plus null terminator
+    hr = StrCoreAlloc(psczEscapedValue, cch + cchEscape + 1, fZeroOnRealloc); // character count, plus escape character count, plus null terminator
     ExitOnFailure(hr, "Failed to allocate string buffer.");
 
     // write to target buffer
@@ -1718,7 +1718,7 @@ static HRESULT ConcatFeatureActionProperties(
         hr = StrAllocFormatted(&scz, L" ADDLOCAL=\"%s\"", sczAddLocal, 0);
         ExitOnFailure(hr, "Failed to format ADDLOCAL string.");
 
-        hr = StrAllocateConcat(psczArguments, scz, 0, TRUE);
+        hr = StrAllocConcatSecure(psczArguments, scz, 0);
         ExitOnFailure(hr, "Failed to concat argument string.");
     }
 
@@ -1727,7 +1727,7 @@ static HRESULT ConcatFeatureActionProperties(
         hr = StrAllocFormatted(&scz, L" ADDSOURCE=\"%s\"", sczAddSource, 0);
         ExitOnFailure(hr, "Failed to format ADDSOURCE string.");
 
-        hr = StrAllocateConcat(psczArguments, scz, 0, TRUE);
+        hr = StrAllocConcatSecure(psczArguments, scz, 0);
         ExitOnFailure(hr, "Failed to concat argument string.");
     }
 
@@ -1736,7 +1736,7 @@ static HRESULT ConcatFeatureActionProperties(
         hr = StrAllocFormatted(&scz, L" ADDDEFAULT=\"%s\"", sczAddDefault, 0);
         ExitOnFailure(hr, "Failed to format ADDDEFAULT string.");
 
-        hr = StrAllocateConcat(psczArguments, scz, 0, TRUE);
+        hr = StrAllocConcatSecure(psczArguments, scz, 0);
         ExitOnFailure(hr, "Failed to concat argument string.");
     }
 
@@ -1745,7 +1745,7 @@ static HRESULT ConcatFeatureActionProperties(
         hr = StrAllocFormatted(&scz, L" REINSTALL=\"%s\"", sczReinstall, 0);
         ExitOnFailure(hr, "Failed to format REINSTALL string.");
 
-        hr = StrAllocateConcat(psczArguments, scz, 0, TRUE);
+        hr = StrAllocConcatSecure(psczArguments, scz, 0);
         ExitOnFailure(hr, "Failed to concat argument string.");
     }
 
@@ -1754,7 +1754,7 @@ static HRESULT ConcatFeatureActionProperties(
         hr = StrAllocFormatted(&scz, L" ADVERTISE=\"%s\"", sczAdvertise, 0);
         ExitOnFailure(hr, "Failed to format ADVERTISE string.");
 
-        hr = StrAllocateConcat(psczArguments, scz, 0, TRUE);
+        hr = StrAllocConcatSecure(psczArguments, scz, 0);
         ExitOnFailure(hr, "Failed to concat argument string.");
     }
 
@@ -1763,7 +1763,7 @@ static HRESULT ConcatFeatureActionProperties(
         hr = StrAllocFormatted(&scz, L" REMOVE=\"%s\"", sczRemove, 0);
         ExitOnFailure(hr, "Failed to format REMOVE string.");
 
-        hr = StrAllocateConcat(psczArguments, scz, 0, TRUE);
+        hr = StrAllocConcatSecure(psczArguments, scz, 0);
         ExitOnFailure(hr, "Failed to concat argument string.");
     }
 
@@ -1828,7 +1828,7 @@ static HRESULT ConcatPatchProperty(
             hr = StrAllocConcat(&sczPatches, L"\"", 0);
             ExitOnFailure(hr, "Failed to close the quoted PATCH property.");
 
-            hr = StrAllocateConcat(psczArguments, sczPatches, 0, TRUE);
+            hr = StrAllocConcatSecure(psczArguments, sczPatches, 0);
             ExitOnFailure(hr, "Failed to append PATCH property.");
         }
     }

--- a/src/burn/engine/mspengine.cpp
+++ b/src/burn/engine/mspengine.cpp
@@ -545,13 +545,13 @@ extern "C" HRESULT MspEngineExecutePackage(
     {
     case BOOTSTRAPPER_ACTION_STATE_INSTALL: __fallthrough;
     case BOOTSTRAPPER_ACTION_STATE_REPAIR:
-        hr = StrAllocateConcat(&sczProperties, L" PATCH=\"", 0, TRUE);
+        hr = StrAllocConcatSecure(&sczProperties, L" PATCH=\"", 0);
         ExitOnFailure(hr, "Failed to add PATCH property on install.");
 
-        hr = StrAllocateConcat(&sczProperties, sczPatches, 0, TRUE);
+        hr = StrAllocConcatSecure(&sczProperties, sczPatches, 0);
         ExitOnFailure(hr, "Failed to add patches to PATCH property on install.");
 
-        hr = StrAllocateConcat(&sczProperties, L"\" REBOOT=ReallySuppress", 0, TRUE);
+        hr = StrAllocConcatSecure(&sczProperties, L"\" REBOOT=ReallySuppress", 0);
         ExitOnFailure(hr, "Failed to add reboot suppression property on install.");
 
         hr = WiuConfigureProductEx(pExecuteAction->mspTarget.sczTargetProductCode, INSTALLLEVEL_DEFAULT, INSTALLSTATE_DEFAULT, sczProperties, &restart);
@@ -559,11 +559,11 @@ extern "C" HRESULT MspEngineExecutePackage(
         break;
 
     case BOOTSTRAPPER_ACTION_STATE_UNINSTALL:
-        hr = StrAllocateConcat(&sczProperties, L" REBOOT=ReallySuppress", 0, TRUE);
+        hr = StrAllocConcatSecure(&sczProperties, L" REBOOT=ReallySuppress", 0);
         ExitOnFailure(hr, "Failed to add reboot suppression property on uninstall.");
 
         // Ignore all dependencies, since the Burn engine already performed the check.
-        hr = StrAllocateFormatted(&sczProperties, TRUE, L"%ls %ls=ALL", sczProperties, DEPENDENCY_IGNOREDEPENDENCIES);
+        hr = StrAllocFormattedSecure(&sczProperties, L"%ls %ls=ALL", sczProperties, DEPENDENCY_IGNOREDEPENDENCIES);
         ExitOnFailure(hr, "Failed to add the list of dependencies to ignore to the properties.");
 
         hr = WiuRemovePatches(sczPatches, pExecuteAction->mspTarget.sczTargetProductCode, sczProperties, &restart);

--- a/src/burn/engine/netfxchainer.cpp
+++ b/src/burn/engine/netfxchainer.cpp
@@ -382,7 +382,7 @@ extern "C" HRESULT NetFxRunChainer(
     hr = CreateNetFxChainer(sczSectionName, sczEventName, &pNetfxChainer);
     ExitOnFailure(hr, "Failed to create netfx chainer.");
 
-    hr = StrAllocateFormatted(&sczCommand, TRUE, L"%ls /pipe %ls", wzArguments, sczSectionName);
+    hr = StrAllocFormattedSecure(&sczCommand, L"%ls /pipe %ls", wzArguments, sczSectionName);
     ExitOnFailure(hr, "Failed to allocate netfx chainer arguments.");
 
     si.cb = sizeof(si);

--- a/src/burn/engine/search.cpp
+++ b/src/burn/engine/search.cpp
@@ -1098,7 +1098,7 @@ static HRESULT MsiProductSearch(
         // if we actually found a related product then use its upgrade code for the rest of the search
         if (1 == dwRelatedProducts)
         {
-            hr = StrAllocateString(&sczGuid, rgsczRelatedProductCodes[0], 0, TRUE);
+            hr = StrAllocStringSecure(&sczGuid, rgsczRelatedProductCodes[0], 0);
             ExitOnFailure(hr, "Failed to copy upgrade code.");
         }
         else

--- a/src/burn/engine/variable.cpp
+++ b/src/burn/engine/variable.cpp
@@ -1014,7 +1014,7 @@ static HRESULT FormatString(
         if (!wzOpen)
         {
             // end reached, append the remainder of the string and end loop
-            hr = StrAllocateConcat(&sczFormat, wzRead, 0, !fObfuscateHiddenVariables);
+            hr = StrCoreAllocConcat(&sczFormat, wzRead, 0, !fObfuscateHiddenVariables);
             ExitOnFailure(hr, "Failed to append string.");
             break;
         }
@@ -1024,7 +1024,7 @@ static HRESULT FormatString(
         if (!wzClose)
         {
             // end reached, treat unterminated expander as literal
-            hr = StrAllocateConcat(&sczFormat, wzRead, 0, !fObfuscateHiddenVariables);
+            hr = StrCoreAllocConcat(&sczFormat, wzRead, 0, !fObfuscateHiddenVariables);
             ExitOnFailure(hr, "Failed to append string.");
             break;
         }
@@ -1033,7 +1033,7 @@ static HRESULT FormatString(
         if (0 == cch)
         {
             // blank, copy all text including the terminator
-            hr = StrAllocateConcat(&sczFormat, wzRead, (DWORD_PTR)(wzClose - wzRead) + 1, !fObfuscateHiddenVariables);
+            hr = StrCoreAllocConcat(&sczFormat, wzRead, (DWORD_PTR)(wzClose - wzRead) + 1, !fObfuscateHiddenVariables);
             ExitOnFailure(hr, "Failed to append string.");
         }
         else
@@ -1041,12 +1041,12 @@ static HRESULT FormatString(
             // append text preceding expander
             if (wzOpen > wzRead)
             {
-                hr = StrAllocateConcat(&sczFormat, wzRead, (DWORD_PTR)(wzOpen - wzRead), !fObfuscateHiddenVariables);
+                hr = StrCoreAllocConcat(&sczFormat, wzRead, (DWORD_PTR)(wzOpen - wzRead), !fObfuscateHiddenVariables);
                 ExitOnFailure(hr, "Failed to append string.");
             }
 
             // get variable name
-            hr = StrAllocateString(&scz, wzOpen + 1, cch, !fObfuscateHiddenVariables);
+            hr = StrCoreAllocString(&scz, wzOpen + 1, cch, !fObfuscateHiddenVariables);
             ExitOnFailure(hr, "Failed to get variable name.");
 
             // allocate space in variable array
@@ -1066,7 +1066,7 @@ static HRESULT FormatString(
             if (2 <= cch && L'\\' == wzOpen[1])
             {
                 // escape sequence, copy character
-                hr = StrAllocateString(&rgVariables[cVariables], &wzOpen[2], 1, !fObfuscateHiddenVariables);
+                hr = StrCoreAllocString(&rgVariables[cVariables], &wzOpen[2], 1, !fObfuscateHiddenVariables);
             }
             else
             {
@@ -1086,7 +1086,7 @@ static HRESULT FormatString(
                     hr = VariableGetFormatted(pVariables, scz, &rgVariables[cVariables]);
                     if (E_NOTFOUND == hr) // variable not found
                     {
-                        hr = StrAllocateString(&rgVariables[cVariables], L"", 0, TRUE);
+                        hr = StrAllocStringSecure(&rgVariables[cVariables], L"", 0);
                     }
                 }
             }
@@ -1094,10 +1094,10 @@ static HRESULT FormatString(
             ++cVariables;
 
             // append placeholder to format string
-            hr = StrAllocateFormatted(&scz, !fObfuscateHiddenVariables, L"[%d]", cVariables);
+            hr = StrCoreAllocFormatted(&scz, !fObfuscateHiddenVariables, L"[%d]", cVariables);
             ExitOnFailure(hr, "Failed to format placeholder string.");
 
-            hr = StrAllocateConcat(&sczFormat, scz, 0, !fObfuscateHiddenVariables);
+            hr = StrCoreAllocConcat(&sczFormat, scz, 0, !fObfuscateHiddenVariables);
             ExitOnFailure(hr, "Failed to append placeholder.");
         }
 
@@ -1137,13 +1137,13 @@ static HRESULT FormatString(
     // return formatted string
     if (psczOut)
     {
-        hr = StrAllocate(&scz, ++cch, !fObfuscateHiddenVariables);
+        hr = StrCoreAlloc(&scz, ++cch, !fObfuscateHiddenVariables);
         ExitOnFailure(hr, "Failed to allocate string.");
 
         er = ::MsiFormatRecordW(NULL, hRecord, scz, &cch);
         ExitOnWin32Error(er, hr, "Failed to format record.");
 
-        hr = StrAllocateString(psczOut, scz, 0, !fObfuscateHiddenVariables);
+        hr = StrCoreAllocString(psczOut, scz, 0, !fObfuscateHiddenVariables);
         ExitOnFailure(hr, "Failed to copy string.");
     }
 

--- a/src/burn/engine/variant.cpp
+++ b/src/burn/engine/variant.cpp
@@ -113,7 +113,7 @@ extern "C" HRESULT BVariantGetString(
         hr = BVariantRetrieveDecryptedNumeric(pVariant, &llValue);
         if (SUCCEEDED(hr))
         {
-            hr = StrAllocateFormatted(psczValue, TRUE, L"%I64d", llValue);
+            hr = StrAllocFormattedSecure(psczValue, L"%I64d", llValue);
             ExitOnFailure(hr, "Failed to convert int64 to string.");
         }
         SecureZeroMemory(&llValue, sizeof(llValue));
@@ -125,7 +125,7 @@ extern "C" HRESULT BVariantGetString(
         hr = BVariantRetrieveDecryptedVersion(pVariant, &qwValue);
         if (SUCCEEDED(hr))
         {
-            hr = StrAllocateFormatted(psczValue, TRUE, L"%hu.%hu.%hu.%hu",
+            hr = StrAllocFormattedSecure(psczValue, L"%hu.%hu.%hu.%hu",
                 (WORD)(qwValue >> 48),
                 (WORD)(qwValue >> 32),
                 (WORD)(qwValue >> 16),
@@ -226,7 +226,7 @@ extern "C" HRESULT BVariantSetString(
         }
         else
         {
-            hr = StrAllocateString(&pVariant->sczValue, wzValue, cchValue, TRUE);
+            hr = StrAllocStringSecure(&pVariant->sczValue, wzValue, cchValue);
         }
         ExitOnFailure(hr, "Failed to copy string.");
         pVariant->Type = BURN_VARIANT_TYPE_STRING;
@@ -521,7 +521,7 @@ static HRESULT BVariantRetrieveDecryptedString(
         ExitOnFailure(hr, "Failed to decrypt string");
     }
 
-    hr = StrAllocateString(psczValue, pVariant->sczValue, 0, TRUE);
+    hr = StrAllocStringSecure(psczValue, pVariant->sczValue, 0);
     ExitOnFailure(hr, "Failed to copy value.");
 
     if (pVariant->fEncryptValue)

--- a/src/libs/balutil/balcondition.cpp
+++ b/src/libs/balutil/balcondition.cpp
@@ -107,7 +107,7 @@ DAPI_(HRESULT) BalConditionEvaluate(
         {
             ++cchMessage;
 
-            hr = StrAllocate(psczMessage, cchMessage, TRUE);
+            hr = StrAllocSecure(psczMessage, cchMessage);
             ExitOnFailure(hr, "Failed to allocate string for condition's formatted message.");
 
             hr = pEngine->FormatString(pCondition->sczMessage, *psczMessage, reinterpret_cast<DWORD*>(&cchMessage));

--- a/src/libs/balutil/balutil.cpp
+++ b/src/libs/balutil/balutil.cpp
@@ -82,7 +82,7 @@ DAPI_(HRESULT) BalFormatString(
     {
         ++cch;
 
-        hr = StrAllocate(psczOut, cch, TRUE);
+        hr = StrAllocSecure(psczOut, cch);
         ExitOnFailure(hr, "Failed to allocate value.");
 
         hr = vpEngine->FormatString(wzFormat, *psczOut, &cch);
@@ -160,7 +160,7 @@ DAPI_(HRESULT) BalGetStringVariable(
     {
         ++cch;
 
-        hr = StrAllocate(psczValue, cch, TRUE);
+        hr = StrAllocSecure(psczValue, cch);
         ExitOnFailure(hr, "Failed to allocate value.");
 
         hr = vpEngine->GetVariableString(wzVariable, *psczValue, &cch);

--- a/src/libs/dutil/inc/strutil.h
+++ b/src/libs/dutil/inc/strutil.h
@@ -31,7 +31,11 @@ HRESULT DAPI StrAlloc(
     __deref_out_ecount_part(cch, 0) LPWSTR* ppwz,
     __in DWORD_PTR cch
     );
-HRESULT DAPI StrAllocate(
+HRESULT DAPI StrAllocSecure(
+    __deref_out_ecount_part(cch, 0) LPWSTR* ppwz,
+    __in DWORD_PTR cch
+    );
+HRESULT DAPI StrCoreAlloc(
     __deref_out_ecount_part(cch, 0) LPWSTR* ppwz,
     __in DWORD_PTR cch,
     __in BOOL fZeroOnRealloc
@@ -59,7 +63,12 @@ HRESULT DAPI StrAllocString(
     __in_z LPCWSTR wzSource,
     __in DWORD_PTR cchSource
     );
-HRESULT DAPI StrAllocateString(
+HRESULT DAPI StrAllocStringSecure(
+    __deref_out_ecount_z(cchSource + 1) LPWSTR* ppwz,
+    __in_z LPCWSTR wzSource,
+    __in DWORD_PTR cchSource
+    );
+HRESULT DAPI StrCoreAllocString(
     __deref_out_ecount_z(cchSource + 1) LPWSTR* ppwz,
     __in_z LPCWSTR wzSource,
     __in DWORD_PTR cchSource,
@@ -92,7 +101,12 @@ HRESULT DAPI StrAllocConcat(
     __in_z LPCWSTR wzSource,
     __in DWORD_PTR cchSource
     );
-HRESULT DAPI StrAllocateConcat(
+HRESULT DAPI StrAllocConcatSecure(
+    __deref_out_z LPWSTR* ppwz,
+    __in_z LPCWSTR wzSource,
+    __in DWORD_PTR cchSource
+    );
+HRESULT DAPI StrCoreAllocConcat(
     __deref_out_z LPWSTR* ppwz,
     __in_z LPCWSTR wzSource,
     __in DWORD_PTR cchSource,
@@ -108,7 +122,12 @@ HRESULT __cdecl StrAllocFormatted(
     __in __format_string LPCWSTR wzFormat,
     ...
     );
-HRESULT __cdecl StrAllocateFormatted(
+HRESULT __cdecl StrAllocFormattedSecure(
+    __deref_out_z LPWSTR* ppwz,
+    __in __format_string LPCWSTR wzFormat,
+    ...
+    );
+HRESULT __cdecl StrCoreAllocFormatted(
     __deref_out_z LPWSTR* ppwz,
     __in BOOL fZeroOnRealloc,
     __in __format_string LPCWSTR wzFormat,
@@ -124,7 +143,12 @@ HRESULT DAPI StrAllocFormattedArgs(
     __in __format_string LPCWSTR wzFormat,
     __in va_list args
     );
-HRESULT DAPI StrAllocateFormattedArgs(
+HRESULT DAPI StrAllocFormattedArgsSecure(
+    __deref_out_z LPWSTR* ppwz,
+    __in __format_string LPCWSTR wzFormat,
+    __in va_list args
+    );
+HRESULT DAPI StrCoreAllocFormattedArgs(
     __deref_out_z LPWSTR* ppwz,
     __in BOOL fZeroOnRealloc,
     __in __format_string LPCWSTR wzFormat,


### PR DESCRIPTION
Rename the StrAllocate\* functions to StrCoreAlloc\* to make it easier to tell them apart from the original StrAlloc\* methods.

Add the StrAlloc_Secure methods back as wrappers around the StrCoreAlloc_ functions.
