### PR TITLE
WIXBUG:4458 - WiX DTF Custom Action Current Directory Different When Interop is in GAC

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* SeanHall: WIXBUG:4458 - Make DTF set the current directory for a managed custom action to the AppDomain's BaseDirectory.
+
 * jchoover: WIXFEAT:4190 - Added support for self updating bundles.
 
 * SeanHall: WIXFEAT:3249 - Allow BA to run elevated async process through the engine.

--- a/src/DTF/Libraries/WindowsInstaller/CustomActionProxy.cs
+++ b/src/DTF/Libraries/WindowsInstaller/CustomActionProxy.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Deployment.WindowsInstaller
             {
                 // Set the current directory to the location of the extracted files.
                 Environment.CurrentDirectory =
-                    Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                    AppDomain.CurrentDomain.BaseDirectory;
 
                 object[] args = new object[] { session };
                 if (DebugBreakEnabled(new string[] { entryPoint, methodName }))


### PR DESCRIPTION
Make DTF set the current directory for a managed custom action to the AppDomain's BaseDirectory, which is always set (in CLRHost.cpp line 165) to the location of the extracted files.
