### PR TITLE
Make many core many more good

### DIFF
--- a/src/Setup/CoreMsi/CoreMsi.wixproj
+++ b/src/Setup/CoreMsi/CoreMsi.wixproj
@@ -37,6 +37,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\chm\chm.helpproj">
+      <BuildInParallel>false</BuildInParallel>
+    </ProjectReference>
     <ProjectReference Include="..\Icons\setupicons.vcxproj" />
     <ProjectReference Include="..\CommonLib\CommonLib.wixproj" />
   </ItemGroup>

--- a/tools/WixBuild.Tools.targets
+++ b/tools/WixBuild.Tools.targets
@@ -323,10 +323,6 @@
     <GenerateWixIncludeDependsOn>
       PrepareGenerateWixInclude
     </GenerateWixIncludeDependsOn>
-    <PrepareForBuildDependsOn>
-      $(PrepareForBuildDependsOn);
-      GenerateWixInclude
-    </PrepareForBuildDependsOn>
   </PropertyGroup>
   <Target
     Name="GenerateWixInclude"

--- a/tools/WixBuild.vcxproj.props
+++ b/tools/WixBuild.vcxproj.props
@@ -72,6 +72,7 @@
       <TreatWarningAsError>true</TreatWarningAsError>
       <ExceptionHandling>false</ExceptionHandling>
       <AdditionalOptions>-YlprecompDefine</AdditionalOptions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>$(ArmPreprocessorDefinitions);%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/tools/WixBuild.vcxproj.targets
+++ b/tools/WixBuild.vcxproj.targets
@@ -13,7 +13,8 @@
   <PropertyGroup>
     <PrepareForBuildDependsOn>
       $(PrepareForBuildDependsOn);
-      WriteCppVersionFile
+      WriteCppVersionFile;
+      GenerateWixInclude
     </PrepareForBuildDependsOn>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Explicitly reference the CHM build from the MSI project that consumes
  it. (On 8+ cores, sometimes the setup build started while the chm build
  was still running.)
- Move GenerateWixInclude invocation to .vcxproj targets since it only
  works off .h files.
- Turn on multiproc compilation for C++ (~3 seconds).
