### PR TITLE
WIXBUG:4470 - LaunchArguments not optional when LaunchTarget is specified

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* SeanHall: WIXBUG:4470 - Check whether the LaunchArguments are null before trying to format them.
+
 * flcdrg: WIXBUG:4437 - Adds CopyLocal COM reference assemblies to the list of assemblies to be included in managed CA.
 
 * champloo: WIXBUG:4097 - Fixes uncaught UnauthorizedAccessException in RecursiveFileAttributes.

--- a/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
+++ b/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
@@ -2578,8 +2578,11 @@ private: // privates
         }
         else
         {
-            hr = BalFormatString(sczUnformattedArguments, &sczArguments);
-            BalExitOnFailure1(hr, "Failed to format launch arguments variable: %ls", sczUnformattedArguments);
+            if (sczUnformattedArguments)
+            {
+                hr = BalFormatString(sczUnformattedArguments, &sczArguments);
+                BalExitOnFailure1(hr, "Failed to format launch arguments variable: %ls", sczUnformattedArguments);
+            }
 
             hr = ShelExec(sczLaunchTarget, sczArguments, L"open", NULL, nCmdShow, m_hWnd, NULL);
             BalExitOnFailure1(hr, "Failed to launch target: %ls", sczLaunchTarget);


### PR DESCRIPTION
Check whether the LaunchArguments are null before trying to format them.
