### PR TITLE
StrAlloc*Secure

### DIFF
--- a/src/burn/engine/approvedexe.cpp
+++ b/src/burn/engine/approvedexe.cpp
@@ -168,7 +168,7 @@ extern "C" HRESULT ApprovedExesLaunch(
         hr = VariableFormatString(pVariables, pLaunchApprovedExe->sczArguments, &sczArgumentsFormatted, NULL);
         ExitOnFailure(hr, "Failed to format argument string.");
 
-        hr = StrAllocateFormatted(&sczCommand, TRUE, L"\"%ls\" %s", pLaunchApprovedExe->sczExecutablePath, sczArgumentsFormatted);
+        hr = StrAllocFormattedSecure(&sczCommand, L"\"%ls\" %s", pLaunchApprovedExe->sczExecutablePath, sczArgumentsFormatted);
         ExitOnFailure(hr, "Failed to create executable command.");
 
         hr = VariableFormatStringObfuscated(pVariables, pLaunchApprovedExe->sczArguments, &sczArgumentsObfuscated, NULL);

--- a/src/burn/engine/embedded.cpp
+++ b/src/burn/engine/embedded.cpp
@@ -81,7 +81,7 @@ extern "C" HRESULT EmbeddedRunBundle(
     hr = PipeCreatePipes(&connection, FALSE, &hCreatedPipesEvent);
     ExitOnFailure(hr, "Failed to create embedded pipe.");
 
-    hr = StrAllocateFormatted(&sczCommand, TRUE, L"%ls -%ls %ls %ls %u", wzArguments, BURN_COMMANDLINE_SWITCH_EMBEDDED, connection.sczName, connection.sczSecret, dwCurrentProcessId);
+    hr = StrAllocFormattedSecure(&sczCommand, L"%ls -%ls %ls %ls %u", wzArguments, BURN_COMMANDLINE_SWITCH_EMBEDDED, connection.sczName, connection.sczSecret, dwCurrentProcessId);
     ExitOnFailure(hr, "Failed to allocate embedded command.");
 
     if (!::CreateProcessW(wzExecutablePath, sczCommand, NULL, NULL, FALSE, CREATE_NO_WINDOW, NULL, NULL, &si, &pi))

--- a/src/burn/engine/exeengine.cpp
+++ b/src/burn/engine/exeengine.cpp
@@ -473,7 +473,7 @@ extern "C" HRESULT ExeEngineExecutePackage(
         hr = VariableFormatString(pVariables, wzArguments, &sczArgumentsFormatted, NULL);
         ExitOnFailure(hr, "Failed to format argument string.");
 
-        hr = StrAllocateFormatted(&sczCommand, TRUE, L"\"%ls\" %s", sczExecutablePath, sczArgumentsFormatted);
+        hr = StrAllocFormattedSecure(&sczCommand, L"\"%ls\" %s", sczExecutablePath, sczArgumentsFormatted);
         ExitOnFailure(hr, "Failed to create executable command.");
 
         hr = VariableFormatStringObfuscated(pVariables, wzArguments, &sczArgumentsObfuscated, NULL);
@@ -495,7 +495,7 @@ extern "C" HRESULT ExeEngineExecutePackage(
         // Add the list of dependencies to ignore, if any, to the burn command line.
         if (pExecuteAction->exePackage.sczIgnoreDependencies && BURN_EXE_PROTOCOL_TYPE_BURN == pExecuteAction->exePackage.pPackage->Exe.protocol)
         {
-            hr = StrAllocateFormatted(&sczCommand, TRUE, L"%ls -%ls=%ls", sczCommand, BURN_COMMANDLINE_SWITCH_IGNOREDEPENDENCIES, pExecuteAction->exePackage.sczIgnoreDependencies);
+            hr = StrAllocFormattedSecure(&sczCommand, L"%ls -%ls=%ls", sczCommand, BURN_COMMANDLINE_SWITCH_IGNOREDEPENDENCIES, pExecuteAction->exePackage.sczIgnoreDependencies);
             ExitOnFailure(hr, "Failed to append the list of dependencies to ignore to the command line.");
 
             hr = StrAllocFormatted(&sczCommandObfuscated, L"%ls -%ls=%ls", sczCommandObfuscated, BURN_COMMANDLINE_SWITCH_IGNOREDEPENDENCIES, pExecuteAction->exePackage.sczIgnoreDependencies);
@@ -505,7 +505,7 @@ extern "C" HRESULT ExeEngineExecutePackage(
         // Add the list of ancestors, if any, to the burn command line.
         if (pExecuteAction->exePackage.sczAncestors)
         {
-            hr = StrAllocateFormatted(&sczCommand, TRUE, L"%ls -%ls=%ls", sczCommand, BURN_COMMANDLINE_SWITCH_ANCESTORS, pExecuteAction->exePackage.sczAncestors);
+            hr = StrAllocFormattedSecure(&sczCommand, L"%ls -%ls=%ls", sczCommand, BURN_COMMANDLINE_SWITCH_ANCESTORS, pExecuteAction->exePackage.sczAncestors);
             ExitOnFailure(hr, "Failed to append the list of ancestors to the command line.");
 
             hr = StrAllocFormatted(&sczCommandObfuscated, L"%ls -%ls=%ls", sczCommandObfuscated, BURN_COMMANDLINE_SWITCH_ANCESTORS, pExecuteAction->exePackage.sczAncestors);

--- a/src/burn/engine/msiengine.cpp
+++ b/src/burn/engine/msiengine.cpp
@@ -1168,13 +1168,13 @@ extern "C" HRESULT MsiEngineExecutePackage(
     switch (pExecuteAction->msiPackage.action)
     {
     case BOOTSTRAPPER_ACTION_STATE_ADMIN_INSTALL:
-        hr = StrAllocateConcat(&sczProperties, L" ACTION=ADMIN", 0, TRUE);
+        hr = StrAllocConcatSecure(&sczProperties, L" ACTION=ADMIN", 0);
         ExitOnFailure(hr, "Failed to add ADMIN property on admin install.");
          __fallthrough;
 
     case BOOTSTRAPPER_ACTION_STATE_MAJOR_UPGRADE: __fallthrough;
     case BOOTSTRAPPER_ACTION_STATE_INSTALL:
-        hr = StrAllocateConcat(&sczProperties, L" REBOOT=ReallySuppress", 0, TRUE);
+        hr = StrAllocConcatSecure(&sczProperties, L" REBOOT=ReallySuppress", 0);
         ExitOnFailure(hr, "Failed to add reboot suppression property on install.");
 
         hr = WiuInstallProduct(sczMsiPath, sczProperties, &restart);
@@ -1188,11 +1188,11 @@ extern "C" HRESULT MsiEngineExecutePackage(
         // updated.
         if (0 == pExecuteAction->msiPackage.pPackage->Msi.cFeatures)
         {
-            hr = StrAllocateConcat(&sczProperties, L" REINSTALL=ALL", 0, TRUE);
+            hr = StrAllocConcatSecure(&sczProperties, L" REINSTALL=ALL", 0);
             ExitOnFailure(hr, "Failed to add reinstall all property on minor upgrade.");
         }
 
-        hr = StrAllocateConcat(&sczProperties, L" REINSTALLMODE=\"vomus\" REBOOT=ReallySuppress", 0, TRUE);
+        hr = StrAllocConcatSecure(&sczProperties, L" REINSTALLMODE=\"vomus\" REBOOT=ReallySuppress", 0);
         ExitOnFailure(hr, "Failed to add reinstall mode and reboot suppression properties on minor upgrade.");
 
         hr = WiuInstallProduct(sczMsiPath, sczProperties, &restart);
@@ -1208,12 +1208,12 @@ extern "C" HRESULT MsiEngineExecutePackage(
                                   pExecuteAction->msiPackage.pPackage->Msi.cFeatures) ? L"" : L" REINSTALL=ALL";
         LPCWSTR wzReinstallMode = (BOOTSTRAPPER_ACTION_STATE_MODIFY == pExecuteAction->msiPackage.action) ? L"o" : L"e";
 
-        hr = StrAllocateFormatted(&sczProperties, TRUE, L"%ls%ls REINSTALLMODE=\"cmus%ls\" REBOOT=ReallySuppress", sczProperties ? sczProperties : L"", wzReinstallAll, wzReinstallMode);
+        hr = StrAllocFormattedSecure(&sczProperties, L"%ls%ls REINSTALLMODE=\"cmus%ls\" REBOOT=ReallySuppress", sczProperties ? sczProperties : L"", wzReinstallAll, wzReinstallMode);
         ExitOnFailure(hr, "Failed to add reinstall mode and reboot suppression properties on repair.");
         }
 
         // Ignore all dependencies, since the Burn engine already performed the check.
-        hr = StrAllocateFormatted(&sczProperties, TRUE, L"%ls %ls=ALL", sczProperties, DEPENDENCY_IGNOREDEPENDENCIES);
+        hr = StrAllocFormattedSecure(&sczProperties, L"%ls %ls=ALL", sczProperties, DEPENDENCY_IGNOREDEPENDENCIES);
         ExitOnFailure(hr, "Failed to add the list of dependencies to ignore to the properties.");
 
         hr = WiuInstallProduct(sczMsiPath, sczProperties, &restart);
@@ -1221,11 +1221,11 @@ extern "C" HRESULT MsiEngineExecutePackage(
         break;
 
     case BOOTSTRAPPER_ACTION_STATE_UNINSTALL:
-        hr = StrAllocateConcat(&sczProperties, L" REBOOT=ReallySuppress", 0, TRUE);
+        hr = StrAllocConcatSecure(&sczProperties, L" REBOOT=ReallySuppress", 0);
         ExitOnFailure(hr, "Failed to add reboot suppression property on uninstall.");
 
         // Ignore all dependencies, since the Burn engine already performed the check.
-        hr = StrAllocateFormatted(&sczProperties, TRUE, L"%ls %ls=ALL", sczProperties, DEPENDENCY_IGNOREDEPENDENCIES);
+        hr = StrAllocFormattedSecure(&sczProperties, L"%ls %ls=ALL", sczProperties, DEPENDENCY_IGNOREDEPENDENCIES);
         ExitOnFailure(hr, "Failed to add the list of dependencies to ignore to the properties.");
 
         hr = WiuConfigureProductEx(pExecuteAction->msiPackage.pPackage->Msi.sczProductCode, INSTALLLEVEL_DEFAULT, INSTALLSTATE_ABSENT, sczProperties, &restart);
@@ -1304,11 +1304,11 @@ extern "C" HRESULT MsiEngineConcatProperties(
         ExitOnFailure(hr, "Failed to escape string.");
 
         // build part
-        hr = StrAllocateFormatted(&sczProperty, !fObfuscateHiddenVariables, L" %s%=\"%s\"", pProperty->sczId, sczEscapedValue);
+        hr = VariableStrAllocFormatted(!fObfuscateHiddenVariables, &sczProperty, L" %s%=\"%s\"", pProperty->sczId, sczEscapedValue);
         ExitOnFailure(hr, "Failed to format property string part.");
 
         // append to property string
-        hr = StrAllocateConcat(psczProperties, sczProperty, 0, !fObfuscateHiddenVariables);
+        hr = VariableStrAllocConcat(!fObfuscateHiddenVariables, psczProperties, sczProperty, 0);
         ExitOnFailure(hr, "Failed to append property string part.");
     }
 
@@ -1604,7 +1604,7 @@ static HRESULT EscapePropertyArgumentString(
     }
 
     // allocate target buffer
-    hr = StrAllocate(psczEscapedValue, cch + cchEscape + 1, fZeroOnRealloc); // character count, plus escape character count, plus null terminator
+    hr = VariableStrAlloc(fZeroOnRealloc, psczEscapedValue, cch + cchEscape + 1); // character count, plus escape character count, plus null terminator
     ExitOnFailure(hr, "Failed to allocate string buffer.");
 
     // write to target buffer
@@ -1718,7 +1718,7 @@ static HRESULT ConcatFeatureActionProperties(
         hr = StrAllocFormatted(&scz, L" ADDLOCAL=\"%s\"", sczAddLocal, 0);
         ExitOnFailure(hr, "Failed to format ADDLOCAL string.");
 
-        hr = StrAllocateConcat(psczArguments, scz, 0, TRUE);
+        hr = StrAllocConcatSecure(psczArguments, scz, 0);
         ExitOnFailure(hr, "Failed to concat argument string.");
     }
 
@@ -1727,7 +1727,7 @@ static HRESULT ConcatFeatureActionProperties(
         hr = StrAllocFormatted(&scz, L" ADDSOURCE=\"%s\"", sczAddSource, 0);
         ExitOnFailure(hr, "Failed to format ADDSOURCE string.");
 
-        hr = StrAllocateConcat(psczArguments, scz, 0, TRUE);
+        hr = StrAllocConcatSecure(psczArguments, scz, 0);
         ExitOnFailure(hr, "Failed to concat argument string.");
     }
 
@@ -1736,7 +1736,7 @@ static HRESULT ConcatFeatureActionProperties(
         hr = StrAllocFormatted(&scz, L" ADDDEFAULT=\"%s\"", sczAddDefault, 0);
         ExitOnFailure(hr, "Failed to format ADDDEFAULT string.");
 
-        hr = StrAllocateConcat(psczArguments, scz, 0, TRUE);
+        hr = StrAllocConcatSecure(psczArguments, scz, 0);
         ExitOnFailure(hr, "Failed to concat argument string.");
     }
 
@@ -1745,7 +1745,7 @@ static HRESULT ConcatFeatureActionProperties(
         hr = StrAllocFormatted(&scz, L" REINSTALL=\"%s\"", sczReinstall, 0);
         ExitOnFailure(hr, "Failed to format REINSTALL string.");
 
-        hr = StrAllocateConcat(psczArguments, scz, 0, TRUE);
+        hr = StrAllocConcatSecure(psczArguments, scz, 0);
         ExitOnFailure(hr, "Failed to concat argument string.");
     }
 
@@ -1754,7 +1754,7 @@ static HRESULT ConcatFeatureActionProperties(
         hr = StrAllocFormatted(&scz, L" ADVERTISE=\"%s\"", sczAdvertise, 0);
         ExitOnFailure(hr, "Failed to format ADVERTISE string.");
 
-        hr = StrAllocateConcat(psczArguments, scz, 0, TRUE);
+        hr = StrAllocConcatSecure(psczArguments, scz, 0);
         ExitOnFailure(hr, "Failed to concat argument string.");
     }
 
@@ -1763,7 +1763,7 @@ static HRESULT ConcatFeatureActionProperties(
         hr = StrAllocFormatted(&scz, L" REMOVE=\"%s\"", sczRemove, 0);
         ExitOnFailure(hr, "Failed to format REMOVE string.");
 
-        hr = StrAllocateConcat(psczArguments, scz, 0, TRUE);
+        hr = StrAllocConcatSecure(psczArguments, scz, 0);
         ExitOnFailure(hr, "Failed to concat argument string.");
     }
 
@@ -1828,7 +1828,7 @@ static HRESULT ConcatPatchProperty(
             hr = StrAllocConcat(&sczPatches, L"\"", 0);
             ExitOnFailure(hr, "Failed to close the quoted PATCH property.");
 
-            hr = StrAllocateConcat(psczArguments, sczPatches, 0, TRUE);
+            hr = StrAllocConcatSecure(psczArguments, sczPatches, 0);
             ExitOnFailure(hr, "Failed to append PATCH property.");
         }
     }

--- a/src/burn/engine/mspengine.cpp
+++ b/src/burn/engine/mspengine.cpp
@@ -545,13 +545,13 @@ extern "C" HRESULT MspEngineExecutePackage(
     {
     case BOOTSTRAPPER_ACTION_STATE_INSTALL: __fallthrough;
     case BOOTSTRAPPER_ACTION_STATE_REPAIR:
-        hr = StrAllocateConcat(&sczProperties, L" PATCH=\"", 0, TRUE);
+        hr = StrAllocConcatSecure(&sczProperties, L" PATCH=\"", 0);
         ExitOnFailure(hr, "Failed to add PATCH property on install.");
 
-        hr = StrAllocateConcat(&sczProperties, sczPatches, 0, TRUE);
+        hr = StrAllocConcatSecure(&sczProperties, sczPatches, 0);
         ExitOnFailure(hr, "Failed to add patches to PATCH property on install.");
 
-        hr = StrAllocateConcat(&sczProperties, L"\" REBOOT=ReallySuppress", 0, TRUE);
+        hr = StrAllocConcatSecure(&sczProperties, L"\" REBOOT=ReallySuppress", 0);
         ExitOnFailure(hr, "Failed to add reboot suppression property on install.");
 
         hr = WiuConfigureProductEx(pExecuteAction->mspTarget.sczTargetProductCode, INSTALLLEVEL_DEFAULT, INSTALLSTATE_DEFAULT, sczProperties, &restart);
@@ -559,11 +559,11 @@ extern "C" HRESULT MspEngineExecutePackage(
         break;
 
     case BOOTSTRAPPER_ACTION_STATE_UNINSTALL:
-        hr = StrAllocateConcat(&sczProperties, L" REBOOT=ReallySuppress", 0, TRUE);
+        hr = StrAllocConcatSecure(&sczProperties, L" REBOOT=ReallySuppress", 0);
         ExitOnFailure(hr, "Failed to add reboot suppression property on uninstall.");
 
         // Ignore all dependencies, since the Burn engine already performed the check.
-        hr = StrAllocateFormatted(&sczProperties, TRUE, L"%ls %ls=ALL", sczProperties, DEPENDENCY_IGNOREDEPENDENCIES);
+        hr = StrAllocFormattedSecure(&sczProperties, L"%ls %ls=ALL", sczProperties, DEPENDENCY_IGNOREDEPENDENCIES);
         ExitOnFailure(hr, "Failed to add the list of dependencies to ignore to the properties.");
 
         hr = WiuRemovePatches(sczPatches, pExecuteAction->mspTarget.sczTargetProductCode, sczProperties, &restart);

--- a/src/burn/engine/netfxchainer.cpp
+++ b/src/burn/engine/netfxchainer.cpp
@@ -382,7 +382,7 @@ extern "C" HRESULT NetFxRunChainer(
     hr = CreateNetFxChainer(sczSectionName, sczEventName, &pNetfxChainer);
     ExitOnFailure(hr, "Failed to create netfx chainer.");
 
-    hr = StrAllocateFormatted(&sczCommand, TRUE, L"%ls /pipe %ls", wzArguments, sczSectionName);
+    hr = StrAllocFormattedSecure(&sczCommand, L"%ls /pipe %ls", wzArguments, sczSectionName);
     ExitOnFailure(hr, "Failed to allocate netfx chainer arguments.");
 
     si.cb = sizeof(si);

--- a/src/burn/engine/search.cpp
+++ b/src/burn/engine/search.cpp
@@ -1098,7 +1098,7 @@ static HRESULT MsiProductSearch(
         // if we actually found a related product then use its upgrade code for the rest of the search
         if (1 == dwRelatedProducts)
         {
-            hr = StrAllocateString(&sczGuid, rgsczRelatedProductCodes[0], 0, TRUE);
+            hr = StrAllocStringSecure(&sczGuid, rgsczRelatedProductCodes[0], 0);
             ExitOnFailure(hr, "Failed to copy upgrade code.");
         }
         else

--- a/src/burn/engine/variable.h
+++ b/src/burn/engine/variable.h
@@ -153,6 +153,29 @@ HRESULT VariableDeserialize(
     __in SIZE_T cbBuffer,
     __inout SIZE_T* piBuffer
     );
+HRESULT VariableStrAlloc(
+    __in BOOL fZeroOnRealloc,
+    __deref_out_ecount_part(cch, 0) LPWSTR* ppwz,
+    __in DWORD_PTR cch
+    );
+HRESULT VariableStrAllocString(
+    __in BOOL fZeroOnRealloc,
+    __deref_out_ecount_z(cchSource + 1) LPWSTR* ppwz,
+    __in_z LPCWSTR wzSource,
+    __in DWORD_PTR cchSource
+    );
+HRESULT VariableStrAllocConcat(
+    __in BOOL fZeroOnRealloc,
+    __deref_out_z LPWSTR* ppwz,
+    __in_z LPCWSTR wzSource,
+    __in DWORD_PTR cchSource
+    );
+HRESULT __cdecl VariableStrAllocFormatted(
+    __in BOOL fZeroOnRealloc,
+    __deref_out_z LPWSTR* ppwz,
+    __in __format_string LPCWSTR wzFormat,
+    ...
+    );
 
 #if defined(__cplusplus)
 }

--- a/src/burn/engine/variant.cpp
+++ b/src/burn/engine/variant.cpp
@@ -113,7 +113,7 @@ extern "C" HRESULT BVariantGetString(
         hr = BVariantRetrieveDecryptedNumeric(pVariant, &llValue);
         if (SUCCEEDED(hr))
         {
-            hr = StrAllocateFormatted(psczValue, TRUE, L"%I64d", llValue);
+            hr = StrAllocFormattedSecure(psczValue, L"%I64d", llValue);
             ExitOnFailure(hr, "Failed to convert int64 to string.");
         }
         SecureZeroMemory(&llValue, sizeof(llValue));
@@ -125,7 +125,7 @@ extern "C" HRESULT BVariantGetString(
         hr = BVariantRetrieveDecryptedVersion(pVariant, &qwValue);
         if (SUCCEEDED(hr))
         {
-            hr = StrAllocateFormatted(psczValue, TRUE, L"%hu.%hu.%hu.%hu",
+            hr = StrAllocFormattedSecure(psczValue, L"%hu.%hu.%hu.%hu",
                 (WORD)(qwValue >> 48),
                 (WORD)(qwValue >> 32),
                 (WORD)(qwValue >> 16),
@@ -226,7 +226,7 @@ extern "C" HRESULT BVariantSetString(
         }
         else
         {
-            hr = StrAllocateString(&pVariant->sczValue, wzValue, cchValue, TRUE);
+            hr = StrAllocStringSecure(&pVariant->sczValue, wzValue, cchValue);
         }
         ExitOnFailure(hr, "Failed to copy string.");
         pVariant->Type = BURN_VARIANT_TYPE_STRING;
@@ -521,7 +521,7 @@ static HRESULT BVariantRetrieveDecryptedString(
         ExitOnFailure(hr, "Failed to decrypt string");
     }
 
-    hr = StrAllocateString(psczValue, pVariant->sczValue, 0, TRUE);
+    hr = StrAllocStringSecure(psczValue, pVariant->sczValue, 0);
     ExitOnFailure(hr, "Failed to copy value.");
 
     if (pVariant->fEncryptValue)

--- a/src/libs/balutil/balcondition.cpp
+++ b/src/libs/balutil/balcondition.cpp
@@ -107,7 +107,7 @@ DAPI_(HRESULT) BalConditionEvaluate(
         {
             ++cchMessage;
 
-            hr = StrAllocate(psczMessage, cchMessage, TRUE);
+            hr = StrAllocSecure(psczMessage, cchMessage);
             ExitOnFailure(hr, "Failed to allocate string for condition's formatted message.");
 
             hr = pEngine->FormatString(pCondition->sczMessage, *psczMessage, reinterpret_cast<DWORD*>(&cchMessage));

--- a/src/libs/balutil/balutil.cpp
+++ b/src/libs/balutil/balutil.cpp
@@ -82,7 +82,7 @@ DAPI_(HRESULT) BalFormatString(
     {
         ++cch;
 
-        hr = StrAllocate(psczOut, cch, TRUE);
+        hr = StrAllocSecure(psczOut, cch);
         ExitOnFailure(hr, "Failed to allocate value.");
 
         hr = vpEngine->FormatString(wzFormat, *psczOut, &cch);
@@ -160,7 +160,7 @@ DAPI_(HRESULT) BalGetStringVariable(
     {
         ++cch;
 
-        hr = StrAllocate(psczValue, cch, TRUE);
+        hr = StrAllocSecure(psczValue, cch);
         ExitOnFailure(hr, "Failed to allocate value.");
 
         hr = vpEngine->GetVariableString(wzVariable, *psczValue, &cch);

--- a/src/libs/dutil/inc/strutil.h
+++ b/src/libs/dutil/inc/strutil.h
@@ -31,10 +31,9 @@ HRESULT DAPI StrAlloc(
     __deref_out_ecount_part(cch, 0) LPWSTR* ppwz,
     __in DWORD_PTR cch
     );
-HRESULT DAPI StrAllocate(
+HRESULT DAPI StrAllocSecure(
     __deref_out_ecount_part(cch, 0) LPWSTR* ppwz,
-    __in DWORD_PTR cch,
-    __in BOOL fZeroOnRealloc
+    __in DWORD_PTR cch
     );
 HRESULT DAPI StrTrimCapacity(
     __deref_out_z LPWSTR* ppwz
@@ -59,11 +58,10 @@ HRESULT DAPI StrAllocString(
     __in_z LPCWSTR wzSource,
     __in DWORD_PTR cchSource
     );
-HRESULT DAPI StrAllocateString(
+HRESULT DAPI StrAllocStringSecure(
     __deref_out_ecount_z(cchSource + 1) LPWSTR* ppwz,
     __in_z LPCWSTR wzSource,
-    __in DWORD_PTR cchSource,
-    __in BOOL fZeroOnRealloc
+    __in DWORD_PTR cchSource
     );
 HRESULT DAPI StrAnsiAllocString(
     __deref_out_ecount_z(cchSource+1) LPSTR* ppsz,
@@ -92,11 +90,10 @@ HRESULT DAPI StrAllocConcat(
     __in_z LPCWSTR wzSource,
     __in DWORD_PTR cchSource
     );
-HRESULT DAPI StrAllocateConcat(
+HRESULT DAPI StrAllocConcatSecure(
     __deref_out_z LPWSTR* ppwz,
     __in_z LPCWSTR wzSource,
-    __in DWORD_PTR cchSource,
-    __in BOOL fZeroOnRealloc
+    __in DWORD_PTR cchSource
     );
 HRESULT DAPI StrAnsiAllocConcat(
     __deref_out_z LPSTR* ppz,
@@ -108,9 +105,8 @@ HRESULT __cdecl StrAllocFormatted(
     __in __format_string LPCWSTR wzFormat,
     ...
     );
-HRESULT __cdecl StrAllocateFormatted(
+HRESULT __cdecl StrAllocFormattedSecure(
     __deref_out_z LPWSTR* ppwz,
-    __in BOOL fZeroOnRealloc,
     __in __format_string LPCWSTR wzFormat,
     ...
     );
@@ -124,9 +120,8 @@ HRESULT DAPI StrAllocFormattedArgs(
     __in __format_string LPCWSTR wzFormat,
     __in va_list args
     );
-HRESULT DAPI StrAllocateFormattedArgs(
+HRESULT DAPI StrAllocFormattedArgsSecure(
     __deref_out_z LPWSTR* ppwz,
-    __in BOOL fZeroOnRealloc,
     __in __format_string LPCWSTR wzFormat,
     __in va_list args
     );


### PR DESCRIPTION
Rename the StrAllocate\* functions to Alloc_Helper to make it easier to tell them apart from the original StrAlloc_ methods, and don't export them.

Add the StrAlloc_Secure methods back as wrappers around the Alloc_Helper functions.

Create wrapper functions in variable.cpp around StrAlloc\* and StrAlloc_Secure.  Putting them in variable worked out, since VariableStrAlloc_ means it's variable which StrAlloc\* gets called :)
