### PR TITLE
Prevent clash with direct reference to wix.csproj

### DIFF
--- a/test/test.proj
+++ b/test/test.proj
@@ -15,6 +15,9 @@
     <ProjectReference Include="$(WixSrcFolder)\burn\burn.proj">
       <BuildInParallel>false</BuildInParallel>
     </ProjectReference>
+    <ProjectReference Include="$(WixSrcFolder)\tools\tools.proj">
+      <BuildInParallel>false</BuildInParallel>
+    </ProjectReference>
 
     <ProjectReference Include="src\Utilities\TestBA\TestBA.csproj" />
     <ProjectReference Include="src\UnitTests\Burn\BurnUnitTest.vcxproj" />


### PR DESCRIPTION
WixTestTools.csproj has a direct reference to wix.csproj which MSBuild
might, given enough cores, try to build at the same time it's getting
built from tools.proj.
