### PR TITLE
Setup cleanup

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* BobArnson: Use MediaTemplate in WiX setup. Include native SDK packages when the corresponding compiler is present, not just when the corresponding SDK is present. (The SDK is needed only to create the C++ custom action templates.)
+
 * SeanHall: WIXBUG:4467 - Create path2utl for path functions that require shlwapi.lib.
 
 * SeanHall: WIXBUG:4470 - Check whether the LaunchArguments are null before trying to format them.

--- a/src/Setup/Bundle/Bundle.wxs
+++ b/src/Setup/Bundle/Bundle.wxs
@@ -71,7 +71,7 @@
 
     <Fragment>
         <PackageGroup Id='NativeSdkPackages'>
-            <?ifdef VS2010SdkAvailable ?>
+            <?ifdef VS2010Available ?>
             <MsiPackage Vital='yes' Name='data\nsdk2010.msi' SourceFile='data\nsdk2010.msi'
                         InstallCondition='VS2010InstallFolder'
                         >
@@ -79,7 +79,7 @@
             </MsiPackage>
             <?endif?>
 
-            <?ifdef VS2012SdkAvailable ?>
+            <?ifdef VS2012Available ?>
             <MsiPackage Vital='yes' Name='data\nsdk2012.msi' SourceFile='data\nsdk2012.msi'
                         InstallCondition='VS2012InstallFolder'
                         >
@@ -87,7 +87,7 @@
             </MsiPackage>
             <?endif?>
 
-            <?ifdef VS2013SdkAvailable ?>
+            <?ifdef VS2013Available ?>
             <MsiPackage Vital='yes' Name='data\nsdk2013.msi' SourceFile='data\nsdk2013.msi'
                         InstallCondition='VS2013InstallFolder'
                         >

--- a/src/Setup/CoreMsi/CoreMsi.wxs
+++ b/src/Setup/CoreMsi/CoreMsi.wxs
@@ -18,11 +18,7 @@
 
         <MajorUpgrade DowngradeErrorMessage="A later version of [ProductName] is already installed." />
 
-        <Media Id="1" Cabinet="core.cab" CompressionLevel="high" />
-
-        <Property Id="ARPSYSTEMCOMPONENT" Value="1" />
-
-        <Icon Id="WixSetupIcons.ico" SourceFile="wixsetupicons.dll" />
+        <MediaTemplate CabinetTemplate="core{0}.cab" />
 
         <Feature Id="Feature_WiX" Title="WiX Toolset" Level="1">
             <Component Id="Licensing" Directory="INSTALLFOLDER">

--- a/src/Setup/CoreMsi/Doc.wxs
+++ b/src/Setup/CoreMsi/Doc.wxs
@@ -9,6 +9,8 @@
 -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Fragment>
+        <Icon Id="WixSetupIcons.ico" SourceFile="wixsetupicons.dll" />
+
         <ComponentGroup Id="DocComponents" Directory="DocFolder">
             <Component>
                 <File Source="WiX.chm" />

--- a/src/Setup/ManagedSdkMsi/ManagedSdkMsi.wxs
+++ b/src/Setup/ManagedSdkMsi/ManagedSdkMsi.wxs
@@ -18,9 +18,7 @@
 
         <MajorUpgrade DowngradeErrorMessage="A later version of [ProductName] is already installed." />
 
-        <Media Id="1" Cabinet="msdk.cab" CompressionLevel="high" />
-
-        <Property Id="ARPSYSTEMCOMPONENT" Value="1" />
+        <MediaTemplate CabinetTemplate="msdk{0}.cab" />
 
         <Feature Id="ManagedSdkFeature" Title="Managed SDK" Level="1">
             <Component Directory="SdkFolder">

--- a/src/Setup/NativeSdkMsi/NativeSdkMsi.wxs
+++ b/src/Setup/NativeSdkMsi/NativeSdkMsi.wxs
@@ -18,9 +18,7 @@
 
         <MajorUpgrade DowngradeErrorMessage="A later version of [ProductName] is already installed." />
 
-        <Media Id="1" Cabinet="nsdk$(var.VisualStudioTargetVersion).cab" CompressionLevel="high" />
-
-        <Property Id="ARPSYSTEMCOMPONENT" Value="1" />
+        <MediaTemplate CabinetTemplate="n$(var.VisualStudioTargetVersion){0}.cab" />
 
         <Feature Id="NativeSdkFeature" Title="Native $(var.VisualStudioTargetVersion) SDK" Level="1">
             <ComponentGroupRef Id="HeaderComponents" />

--- a/src/Setup/VotiveMsi/VotiveMsi.wxs
+++ b/src/Setup/VotiveMsi/VotiveMsi.wxs
@@ -18,9 +18,7 @@
 
         <MajorUpgrade DowngradeErrorMessage="A later version of [ProductName] is already installed." />
 
-        <Media Id="1" Cabinet="votive.cab" CompressionLevel="high" />
-
-        <Property Id="ARPSYSTEMCOMPONENT" Value="1" />
+        <MediaTemplate CabinetTemplate="votiv{0}.cab" />
 
         <Feature Id="VotiveFeature" Title="Votive 200x" Level="1">
             <?if $(var.BuildVotive2010)=true ?>

--- a/src/Setup/X64Msi/X64Msi.wxs
+++ b/src/Setup/X64Msi/X64Msi.wxs
@@ -18,7 +18,7 @@
 
         <MajorUpgrade DowngradeErrorMessage="A later version of [ProductName] is already installed." />
 
-        <Media Id="1" Cabinet="wix64.cab" CompressionLevel="high" />
+        <MediaTemplate CabinetTemplate="wix64{0}.cab" />
 
         <DirectoryRef Id="SdkFolder" />
         

--- a/tools/WixBuild.wixproj.props
+++ b/tools/WixBuild.wixproj.props
@@ -16,6 +16,10 @@
     <Cultures>neutral</Cultures>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(OFFICIAL_WIX_BUILD)'!='' ">
+    <DefaultCompressionLevel>high</DefaultCompressionLevel>
+  </PropertyGroup>
+
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);WixBundleCompressed=$(WixBundleCompressed)</DefineConstants>
     <DefineConstants Condition="$(VS2010Available)">$(DefineConstants);VS2010Available=true</DefineConstants>


### PR DESCRIPTION
Use MediaTemplate in WiX setup. Include native SDK packages when the
corresponding compiler is present, not just when the corresponding SDK
is present. (The SDK is needed only to create the C++ custom action
templates.)
