### PR TITLE
WIXBUG:4468 - fix missed suppression of suppress signature verification ...

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* RobMen: WIXBUG:4468 - fix missed suppression of suppress signature verification of MSI packages.
+
 * SeanHall: WIXBUG:4472 - Try to clean the downloaded update bundle from the cache.
 
 * SeanHall: WIXBUG:4467 - Create path2utl for path functions that require shlwapi.lib.

--- a/src/tools/wix/Compiler.cs
+++ b/src/tools/wix/Compiler.cs
@@ -21451,7 +21451,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
             int installSize = CompilerCore.IntegerNotSet;
             string msuKB = null;
             YesNoType suppressLooseFilePayloadGeneration = YesNoType.NotSet;
-            YesNoType suppressSignatureVerification = YesNoType.NotSet;
+            YesNoType suppressSignatureVerification = YesNoType.Yes;
             YesNoDefaultType compressed = YesNoDefaultType.Default;
             YesNoType displayInternalUI = YesNoType.NotSet;
             YesNoType enableFeatureSelection = YesNoType.NotSet;


### PR DESCRIPTION
Deprecate missed switches in the Binder missed by previous pass.
