### PR TITLE
WIXBUG:4486 - Burn: Installation does not resume after restart

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* SeanHall: WIXBUG:4486 - Put the bundle's executable path back into the resume command line.
+
 ## WixBuild: Version 3.9.721.0
 
 ## WixBuild: Version 3.9.720.0

--- a/src/burn/engine/core.cpp
+++ b/src/burn/engine/core.cpp
@@ -837,7 +837,7 @@ extern "C" HRESULT CoreRecreateCommandLine(
     __in BOOL fPassthrough,
     __in_z_opt LPCWSTR wzActiveParent,
     __in_z_opt LPCWSTR wzAncestors,
-    __in_z_opt LPCWSTR wzApppendLogPath,
+    __in_z_opt LPCWSTR wzAppendLogPath,
     __in_z_opt LPCWSTR wzAdditionalCommandLineArguments
     )
 {
@@ -925,9 +925,9 @@ extern "C" HRESULT CoreRecreateCommandLine(
         ExitOnFailure(hr, "Failed to append passthrough to command-line.");
     }
 
-    if (wzApppendLogPath && *wzApppendLogPath)
+    if (wzAppendLogPath && *wzAppendLogPath)
     {
-        hr = StrAllocFormatted(&scz, L" /%ls \"%ls\"", BURN_COMMANDLINE_SWITCH_LOG_APPEND, wzApppendLogPath);
+        hr = StrAllocFormatted(&scz, L" /%ls \"%ls\"", BURN_COMMANDLINE_SWITCH_LOG_APPEND, wzAppendLogPath);
         ExitOnFailure(hr, "Failed to format append log command-line for command-line.");
 
         hr = StrAllocConcat(psczCommandLine, scz, 0);

--- a/src/burn/engine/core.h
+++ b/src/burn/engine/core.h
@@ -205,7 +205,7 @@ HRESULT CoreRecreateCommandLine(
     __in BOOL fPassthrough,
     __in_z_opt LPCWSTR wzActiveParent,
     __in_z_opt LPCWSTR wzAncestors,
-    __in_z_opt LPCWSTR wzApppendLogPath,
+    __in_z_opt LPCWSTR wzAppendLogPath,
     __in_z_opt LPCWSTR wzAdditionalCommandLineArguments
     );
 

--- a/src/burn/engine/plan.cpp
+++ b/src/burn/engine/plan.cpp
@@ -1814,7 +1814,10 @@ extern "C" HRESULT PlanSetResumeCommand(
 {
     HRESULT hr = S_OK;
 
-    // build the resume command-line.
+    // Build the resume command-line.
+    hr = StrAllocFormatted(&pRegistration->sczResumeCommandLine, L"\"%ls\"", pRegistration->sczCacheExecutablePath);
+    ExitOnFailure(hr, "Failed to copy executable path to resume command-line.");    
+
     hr = CoreRecreateCommandLine(&pRegistration->sczResumeCommandLine, action, pCommand->display, pCommand->restart, pCommand->relationType, pCommand->fPassthrough, pRegistration->sczActiveParent, pRegistration->sczAncestors, pLog->sczPath, pCommand->wzCommandLine);
     ExitOnFailure(hr, "Failed to recreate resume command-line.");
 

--- a/src/burn/engine/pseudobundle.h
+++ b/src/burn/engine/pseudobundle.h
@@ -40,7 +40,7 @@ HRESULT PseudoBundleInitialize(
 HRESULT PseudoBundleInitializePassthrough(
     __in BURN_PACKAGE* pPassthroughPackage,
     __in BOOTSTRAPPER_COMMAND* pCommand,
-    __in_z_opt LPCWSTR wzApppendLogPath,
+    __in_z_opt LPCWSTR wzAppendLogPath,
     __in_z_opt LPWSTR wzActiveParent,
     __in_z_opt LPWSTR wzAncestors,
     __in BURN_PACKAGE* pPackage


### PR DESCRIPTION
Put the bundle's executable path back into the resume command line by putting back code deleted in d089e0cd4db66245caecd4a455a0e921d272290c.
