### PR TITLE
WIXBUG:4481

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* BobArnson: WIXBUG:4481 - Switch the WiX bundle to have an Uninstall/Change button in ARP, to avoid having Uninstall kick off immediately while the user could click the Update button and kick off an update install. Also, disable Update during apply phase.
+
 ## WixBuild: Version 3.9.721.0
 
 ## WixBuild: Version 3.9.720.0

--- a/src/Setup/Bundle/Bundle.wxs
+++ b/src/Setup/Bundle/Bundle.wxs
@@ -18,7 +18,7 @@
     <Bundle Name='!(loc.ShortProduct) v$(var.WixVersion)' Manufacturer='!(loc.Company)'
             Version='$(var.WixVersion)' UpgradeCode='65E893AD-EDD5-4E7D-80CA-F0F50F383532'
             IconSourceFile='ProjectFile.ico' SplashScreenSourceFile='SplashScreen.bmp'
-            AboutUrl='!(loc.SupportUrl)' UpdateUrl='!(loc.UpdateUrl)'
+            DisableModify='button' AboutUrl='!(loc.SupportUrl)' UpdateUrl='!(loc.UpdateUrl)'
             Compressed='$(var.WixBundleCompressed)'>
 
         <swid:Tag Regid="regid.2008-09.org.wixtoolset" />

--- a/src/Setup/WixBA/UpdateViewModel.cs
+++ b/src/Setup/WixBA/UpdateViewModel.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Tools.WindowsInstallerXml.UX
             {
                 if (this.updateCommand == null)
                 {
-                    this.updateCommand = new RelayCommand(param => WixBA.Plan(LaunchAction.UpdateReplace), param => this.State == UpdateState.Available);
+                    this.updateCommand = new RelayCommand(param => WixBA.Plan(LaunchAction.UpdateReplace), param => this.State == UpdateState.Available && this.root.State != InstallationState.Applying);
                 }
 
                 return this.updateCommand;


### PR DESCRIPTION
Switch the WiX bundle to have an Uninstall/Change button in ARP, to
avoid having Uninstall kick off immediately while the user could click
the Update button and kick off an update install. Also, disable Update
during apply phase.
