### PR TITLE
WIXBUG:4497 - Undeprecate '-spdb' command-line switch.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* RobMen: WIXBUG:4497 - Undeprecate "-spdb" command-line switch.
+
 * SeanHall: WIXBUG:4491 - Make sure the BA DLL is the first payload in the UX container.
 
 ## WixBuild: Version 3.9.805.0

--- a/src/tools/wix/Binder.cs
+++ b/src/tools/wix/Binder.cs
@@ -482,7 +482,6 @@ namespace Microsoft.Tools.WindowsInstallerXml
                     }
                     else if (parameter.Equals("spdb", StringComparison.Ordinal))
                     {
-                        consoleMessageHandler.Display(this, WixWarnings.DeprecatedCommandLineSwitch(parameter));
                         this.suppressWixPdb = true;
                     }
                     else if (parameter.Equals("spsd", StringComparison.Ordinal))


### PR DESCRIPTION
Title pretty much says it all. I went a little too far in the deprecation.
