### PR TITLE
Fix .zipprojs to not layout intermediate files outside of intermediate folder

### DIFF
--- a/src/Setup/Zip/binaries.zipproj
+++ b/src/Setup/Zip/binaries.zipproj
@@ -56,7 +56,9 @@
     <Stage Include="$(OutputPath)WixCop.exe" />
     <Stage Include="$(OutputPath)WixTasks.dll" />
     <!--<Stage Include="$(OutputPath)wui.dll" />-->
-    <Stage Include="$(OutputPath)x86\burn.exe" />
+    <Stage Include="$(OutputPath)x86\burn.exe">
+      <StageSubDirectory>x86</StageSubDirectory>
+    </Stage>
     <Stage Include="$(OutputPath_arm)arm\burn.exe" Condition=" Exists('$(OutputPath_arm)arm\burn.exe') ">
       <StageSubDirectory>arm</StageSubDirectory>
     </Stage>

--- a/tools/WixBuild.zipproj.targets
+++ b/tools/WixBuild.zipproj.targets
@@ -65,7 +65,7 @@
         <Hardlink>%(Stage.Hardlink)</Hardlink>
       </_Stage>
       <_Stage Include="@(Stage)" Condition=" '%(Stage.StageSubDirectory)'=='' ">
-        <TargetPath>$(IntermediateOutputPath)$([MSBuild]::MakeRelative($(OutputPath), %(Identity)))</TargetPath>
+        <TargetPath>$(IntermediateOutputPath)%(Stage.Filename)%(Stage.Extension)</TargetPath>
         <Hardlink>%(Stage.Hardlink)</Hardlink>
       </_Stage>
     </ItemGroup>


### PR DESCRIPTION
Automatic relative path handling could cause staged files to be ".."
pathed outside of the intermediate folder where they are supposed to be
rooted. Since there is only one case where the automatic relative path
handling was used, this commit removes the buggy functionality and
specifically define the relative path.
