### PR TITLE
WIXBUG:4510

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* BobArnson: WIXBUG:4510 - Empty the post-reboot resume command line when recreating it.
+
 ## WixBuild: Version 3.9.818.0
 
 * RobMen: WIXBUG:4501 - Add file size to upload metadata for use in releases feed.

--- a/src/burn/engine/core.cpp
+++ b/src/burn/engine/core.cpp
@@ -845,6 +845,9 @@ extern "C" HRESULT CoreRecreateCommandLine(
     LPWSTR scz = NULL;
     LPCWSTR wzRelationTypeCommandLine = CoreRelationTypeToCommandLineString(relationType);
 
+    hr = StrAllocString(psczCommandLine, L"", 0);
+    ExitOnFailure(hr, "Failed to empty command line.");
+
     switch (display)
     {
     case BOOTSTRAPPER_DISPLAY_NONE:


### PR DESCRIPTION
Empty the post-reboot resume command line when recreating it.
