### PR TITLE
WIXBUG:4502 - MakeSfxCA may produce dlls not following PE / COFF spec

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* SeanHall: WIXBUG:4502 - Get MakeSfxCA to sort the Export table according to the PE/COFF spec.
+
 ## WixBuild: Version 3.9.818.0
 
 * RobMen: WIXBUG:4501 - Add file size to upload metadata for use in releases feed.

--- a/src/DTF/Tools/MakeSfxCA/MakeSfxCA.cs
+++ b/src/DTF/Tools/MakeSfxCA/MakeSfxCA.cs
@@ -516,7 +516,7 @@ namespace Microsoft.Deployment.Tools.MakeSfxCA
             }
 
             entryPoints.Keys.CopyTo(slotSort, slotCount - entryPoints.Count);
-            Array.Sort<string>(slotSort, slotCount - entryPoints.Count, entryPoints.Count);
+            Array.Sort<string>(slotSort, slotCount - entryPoints.Count, entryPoints.Count, StringComparer.Ordinal);
 
             for (int i = 0; ; i++)
             {


### PR DESCRIPTION
Get MakeSfxCA to sort the Export table according to the PE/COFF spec.
