### PR TITLE
WIXBUG  #4461 UriProtocol function is case sensitive

### DIFF
--- a/src/libs/dutil/uriutil.cpp
+++ b/src/libs/dutil/uriutil.cpp
@@ -303,28 +303,51 @@ extern "C" HRESULT DAPI UriProtocol(
 
     HRESULT hr = S_OK;
 
-    if (L'f' == wzUri[0] && L'i' == wzUri[1] && L'l' == wzUri[2] && L'e' == wzUri[3] && L':' == wzUri[4] && L'/' == wzUri[5] && L'/' == wzUri[6])
+    if ((L'h' == wzUri[0] || L'H' == wzUri[0]) &&
+        (L't' == wzUri[1] || L'T' == wzUri[1]) &&
+        (L't' == wzUri[2] || L'T' == wzUri[2]) &&
+        (L'p' == wzUri[3] || L'P' == wzUri[3]) &&
+        (L's' == wzUri[4] || L'S' == wzUri[4]) &&
+         L':' == wzUri[5] &&
+         L'/' == wzUri[6] &&
+         L'/' == wzUri[7])
     {
-        *pProtocol = URI_PROTOCOL_FILE;
+        *pProtocol = URI_PROTOCOL_HTTPS;
     }
-    else if (L'f' == wzUri[0] && L't' == wzUri[1] && L'p' == wzUri[2] && L':' == wzUri[3] && L'/' == wzUri[4] && L'/' == wzUri[5])
-    {
-        *pProtocol = URI_PROTOCOL_FILE;
-    }
-    else if (L'h' == wzUri[0] && L't' == wzUri[1] && L't' == wzUri[2] && L'p' == wzUri[3] && L':' == wzUri[4] && L'/' == wzUri[5] && L'/' == wzUri[6])
+    else if ((L'h' == wzUri[0] || L'H' == wzUri[0]) &&
+             (L't' == wzUri[1] || L'T' == wzUri[1]) &&
+             (L't' == wzUri[2] || L'T' == wzUri[2]) &&
+             (L'p' == wzUri[3] || L'P' == wzUri[3]) &&
+              L':' == wzUri[4] &&
+              L'/' == wzUri[5] &&
+              L'/' == wzUri[6])
     {
         *pProtocol = URI_PROTOCOL_HTTP;
     }
-    else if (L'h' == wzUri[0] && L't' == wzUri[1] && L't' == wzUri[2] && L'p' == wzUri[3] && L'S' == wzUri[4] && L':' == wzUri[5] && L'/' == wzUri[6] && L'/' == wzUri[7])
+    else if ((L'f' == wzUri[0] || L'F' == wzUri[0]) &&
+             (L't' == wzUri[1] || L'T' == wzUri[1]) &&
+             (L'p' == wzUri[2] || L'P' == wzUri[2]) &&
+              L':' == wzUri[3] &&
+              L'/' == wzUri[4] &&
+              L'/' == wzUri[5])
     {
-        *pProtocol = URI_PROTOCOL_HTTPS;
+        *pProtocol = URI_PROTOCOL_FTP;
+    }
+    else if ((L'f' == wzUri[0] || L'F' == wzUri[0]) &&
+             (L'i' == wzUri[1] || L'I' == wzUri[1]) &&
+             (L'l' == wzUri[2] || L'L' == wzUri[2]) &&
+             (L'e' == wzUri[3] || L'E' == wzUri[3]) &&
+              L':' == wzUri[4] &&
+              L'/' == wzUri[5] &&
+              L'/' == wzUri[6])
+    {
+        *pProtocol = URI_PROTOCOL_FILE;
     }
     else
     {
         *pProtocol = URI_PROTOCOL_UNKNOWN;
     }
 
-//LExit:
     return hr;
 }
 

--- a/test/src/UnitTests/dutil/DUtilUnitTest.vcxproj
+++ b/test/src/UnitTests/dutil/DUtilUnitTest.vcxproj
@@ -30,13 +30,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), wix.proj))\tools\WixBuild.props" />
   <PropertyGroup>
     <ProjectAdditionalIncludeDirectories>$(WixRoot)src\libs\dutil\inc</ProjectAdditionalIncludeDirectories>
-    <ProjectAdditionalLinkLibraries>rpcrt4.lib;dutil.lib</ProjectAdditionalLinkLibraries>
+    <ProjectAdditionalLinkLibraries>rpcrt4.lib;dutil.lib;urlmon.lib;wininet.lib</ProjectAdditionalLinkLibraries>
   </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <Link>
-      <AdditionalDependencies>urlmon.lib;wininet.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="AssemblyInfo.cpp" />
     <ClCompile Include="DictUtilTest.cpp" />

--- a/test/src/UnitTests/dutil/DUtilUnitTest.vcxproj
+++ b/test/src/UnitTests/dutil/DUtilUnitTest.vcxproj
@@ -32,6 +32,11 @@
     <ProjectAdditionalIncludeDirectories>$(WixRoot)src\libs\dutil\inc</ProjectAdditionalIncludeDirectories>
     <ProjectAdditionalLinkLibraries>rpcrt4.lib;dutil.lib</ProjectAdditionalLinkLibraries>
   </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Link>
+      <AdditionalDependencies>urlmon.lib;wininet.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="AssemblyInfo.cpp" />
     <ClCompile Include="DictUtilTest.cpp" />
@@ -40,6 +45,7 @@
     <ClCompile Include="IniUtilTest.cpp" />
     <ClCompile Include="MemUtilTest.cpp" />
     <ClCompile Include="StrUtilTest.cpp" />
+    <ClCompile Include="UriUtilTest.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="precomp.h" />

--- a/test/src/UnitTests/dutil/DUtilUnitTest.vcxproj.filters
+++ b/test/src/UnitTests/dutil/DUtilUnitTest.vcxproj.filters
@@ -39,6 +39,9 @@
     <ClCompile Include="$(WixRoot)src\common\precomp.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="UriUtilTest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="UnitTest.rc">

--- a/test/src/UnitTests/dutil/UriUtilTest.cpp
+++ b/test/src/UnitTests/dutil/UriUtilTest.cpp
@@ -1,0 +1,103 @@
+//-------------------------------------------------------------------------------------------------
+// <copyright file="StrUtilTest.cpp" company="Outercurve Foundation">
+//   Copyright (c) 2004, Outercurve Foundation.
+//   This software is released under Microsoft Reciprocal License (MS-RL).
+//   The license and further copyright text can be found in the file
+//   LICENSE.TXT at the root directory of the distribution.
+// </copyright>
+//-------------------------------------------------------------------------------------------------
+
+#include "precomp.h"
+
+using namespace System;
+using namespace System::Text;
+using namespace System::Collections::Generic;
+using namespace Xunit;
+
+namespace CfgTests
+{
+	public ref class UriUtil
+	{
+	public:
+		[Fact]
+		void UriProtocolTest()
+		{
+			HRESULT hr = S_OK;
+
+			LPCWSTR uri = L"https://localhost/";
+			URI_PROTOCOL uriProtocol = URI_PROTOCOL::URI_PROTOCOL_UNKNOWN;
+			hr = UriProtocol(uri, &uriProtocol);
+			ExitOnFailure(hr, "Failed to determine UriProtocol");
+			Assert::Equal((int)URI_PROTOCOL::URI_PROTOCOL_HTTPS, (int)uriProtocol);
+
+			uri = L"HTTPS://localhost/";
+			uriProtocol = URI_PROTOCOL::URI_PROTOCOL_UNKNOWN;
+			hr = UriProtocol(uri, &uriProtocol);
+			ExitOnFailure(hr, "Failed to determine UriProtocol");
+			Assert::Equal((int)URI_PROTOCOL::URI_PROTOCOL_HTTPS, (int)uriProtocol);
+
+			uri = L"HtTpS://localhost/";
+			uriProtocol = URI_PROTOCOL::URI_PROTOCOL_UNKNOWN;
+			hr = UriProtocol(uri, &uriProtocol);
+			ExitOnFailure(hr, "Failed to determine UriProtocol");
+			Assert::Equal((int)URI_PROTOCOL::URI_PROTOCOL_HTTPS, (int)uriProtocol);
+
+			uri = L"HTTP://localhost/";
+			uriProtocol = URI_PROTOCOL::URI_PROTOCOL_UNKNOWN;
+			hr = UriProtocol(uri, &uriProtocol);
+			ExitOnFailure(hr, "Failed to determine UriProtocol");
+			Assert::Equal((int)URI_PROTOCOL::URI_PROTOCOL_HTTP, (int)uriProtocol);
+
+			uri = L"http://localhost/";
+			uriProtocol = URI_PROTOCOL::URI_PROTOCOL_UNKNOWN;
+			hr = UriProtocol(uri, &uriProtocol);
+			ExitOnFailure(hr, "Failed to determine UriProtocol");
+			Assert::Equal((int)URI_PROTOCOL::URI_PROTOCOL_HTTP, (int)uriProtocol);
+
+			uri = L"HtTp://localhost/";
+			uriProtocol = URI_PROTOCOL::URI_PROTOCOL_UNKNOWN;
+			hr = UriProtocol(uri, &uriProtocol);
+			ExitOnFailure(hr, "Failed to determine UriProtocol");
+			Assert::Equal((int)URI_PROTOCOL::URI_PROTOCOL_HTTP, (int)uriProtocol);
+
+			uri = L"file://localhost/";
+			uriProtocol = URI_PROTOCOL::URI_PROTOCOL_UNKNOWN;
+			hr = UriProtocol(uri, &uriProtocol);
+			ExitOnFailure(hr, "Failed to determine UriProtocol");
+			Assert::Equal((int)URI_PROTOCOL::URI_PROTOCOL_FILE, (int)uriProtocol);
+
+			uri = L"FILE://localhost/";
+			uriProtocol = URI_PROTOCOL::URI_PROTOCOL_UNKNOWN;
+			hr = UriProtocol(uri, &uriProtocol);
+			ExitOnFailure(hr, "Failed to determine UriProtocol");
+			Assert::Equal((int)URI_PROTOCOL::URI_PROTOCOL_FILE, (int)uriProtocol);
+
+			uri = L"FiLe://localhost/";
+			uriProtocol = URI_PROTOCOL::URI_PROTOCOL_UNKNOWN;
+			hr = UriProtocol(uri, &uriProtocol);
+			ExitOnFailure(hr, "Failed to determine UriProtocol");
+			Assert::Equal((int)URI_PROTOCOL::URI_PROTOCOL_FILE, (int)uriProtocol);
+
+			uri = L"FTP://localhost/";
+			uriProtocol = URI_PROTOCOL::URI_PROTOCOL_UNKNOWN;
+			hr = UriProtocol(uri, &uriProtocol);
+			ExitOnFailure(hr, "Failed to determine UriProtocol");
+			Assert::Equal((int)URI_PROTOCOL::URI_PROTOCOL_FTP, (int)uriProtocol);
+
+			uri = L"ftp://localhost/";
+			uriProtocol = URI_PROTOCOL::URI_PROTOCOL_UNKNOWN;
+			hr = UriProtocol(uri, &uriProtocol);
+			ExitOnFailure(hr, "Failed to determine UriProtocol");
+			Assert::Equal((int)URI_PROTOCOL::URI_PROTOCOL_FTP, (int)uriProtocol);
+
+			uri = L"FtP://localhost/";
+			uriProtocol = URI_PROTOCOL::URI_PROTOCOL_UNKNOWN;
+			hr = UriProtocol(uri, &uriProtocol);
+			ExitOnFailure(hr, "Failed to determine UriProtocol");
+			Assert::Equal((int)URI_PROTOCOL::URI_PROTOCOL_FTP, (int)uriProtocol);
+
+		LExit:
+			;
+		}
+	};
+}

--- a/test/src/UnitTests/dutil/precomp.h
+++ b/test/src/UnitTests/dutil/precomp.h
@@ -28,6 +28,7 @@
 #include <memutil.h>
 #include <pathutil.h>
 #include <strutil.h>
+#include <uriutil.h>
 
 #pragma managed
 #include <vcclr.h>


### PR DESCRIPTION
Created tests for and corrected two issues with the UriProtocol function in dutil

protocol strings are now compared case insensitive and the ftp scheme was incorrectly being mapped to URI_PROCOL::URI_PROTOCOL_FILE

WIXBUG:4461 UriProtocol function is case sensitive

incorporated feedback from previous pull request, re-submit as a single commit