### PR TITLE
Pad log file sequence numbers for proper sorting

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* HeathS: WIXBUG:4542 - Pad package sequence number log file names for proper sorting
+
 ## WixBuild: Version 3.9.901.0
 
 * BobArnson: WIXBUG:4510 - Empty the post-reboot resume command line when recreating it.

--- a/src/burn/engine/logging.cpp
+++ b/src/burn/engine/logging.cpp
@@ -191,7 +191,7 @@ extern "C" HRESULT LoggingSetPackageVariable(
     if ((!fRollback && pPackage->sczLogPathVariable && *pPackage->sczLogPathVariable) ||
         (fRollback && pPackage->sczRollbackLogPathVariable && *pPackage->sczRollbackLogPathVariable))
     {
-        hr = StrAllocFormatted(&sczLogPath, L"%ls%hs%ls_%u_%ls%ls.%ls", pLog->sczPrefix, wzSuffix && *wzSuffix ? "_" : "", wzSuffix && *wzSuffix ? wzSuffix : L"", vdwPackageSequence, pPackage->sczId, fRollback ? L"_rollback" : L"", pLog->sczExtension);
+        hr = StrAllocFormatted(&sczLogPath, L"%ls%hs%ls_%03u_%ls%ls.%ls", pLog->sczPrefix, wzSuffix && *wzSuffix ? "_" : "", wzSuffix && *wzSuffix ? wzSuffix : L"", vdwPackageSequence, pPackage->sczId, fRollback ? L"_rollback" : L"", pLog->sczExtension);
         ExitOnFailure(hr, "Failed to allocate path for package log.");
 
         hr = VariableSetString(pVariables, fRollback ? pPackage->sczRollbackLogPathVariable : pPackage->sczLogPathVariable, sczLogPath, FALSE);


### PR DESCRIPTION
Without proper padding of sequence numbers for log file names if you had more than 10 packages they would be sorted incorrectly.
