### PR TITLE
WIXBUG:4114 - PostQuitMessage in wixstdba from WM_NCDESTROY.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* RobMen: WIXBUG:4114 - PostQuitMessage in wixstdba from WM_NCDESTROY to avoid hangs.
+
 ## WixBuild: Version 3.9.901.0
 
 * BobArnson: WIXBUG:4510 - Empty the post-reboot resume command line when recreating it.

--- a/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
+++ b/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
@@ -1669,6 +1669,7 @@ private: // privates
             {
             LRESULT lres = ThemeDefWindowProc(pBA ? pBA->m_pTheme : NULL, hWnd, uMsg, wParam, lParam);
             ::SetWindowLongPtrW(hWnd, GWLP_USERDATA, 0);
+            ::PostQuitMessage(0);
             return lres;
             }
 
@@ -1688,10 +1689,6 @@ private: // privates
             {
                 return 0;
             }
-            break;
-
-        case WM_DESTROY:
-            ::PostQuitMessage(0);
             break;
 
         case WM_WIXSTDBA_SHOW_HELP:


### PR DESCRIPTION
SHAutoComplete documentation says you need to wait for the control to be
destroyed before calling CoUninitialize. Since the window gets the
WM_DESTROY message before its child controls, the control is probably
never being destroyed. If we wait for the WM_NCDESTROY message instead,
the control will be destroyed when we call PostQuitMessage.
