### PR TITLE
issue4568 - Evaluate Checkboxes on Modify-Page prior to repair

### DIFF
--- a/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
+++ b/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
@@ -2458,6 +2458,8 @@ private: // privates
     //
     void OnClickRepairButton()
     {
+        SavePageSettings(WIXSTDBA_PAGE_MODIFY);
+
         this->OnPlan(BOOTSTRAPPER_ACTION_REPAIR);
     }
 


### PR DESCRIPTION
Issue 4568 is about evaluating checkboxes prior to uninstall ; this pull request is about having the same behavior when in repair mode.
I've used exactly the same solution as Mr Erichsen in pull request 162
