### PR TITLE
WIXBUG:4608 - Fix bug in mbapreq

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* SeanHall: WIXBUG:4608 - Fix bug in mbapreq where it wouldn't reload the bootstrapper if there was a mix of installed and uninstalled prerequisites.
+
 * SeanHall: WIXBUG:4598 - Fix thmutil documentation.  Also backport some thmutil features/fixes from wix4.
 
 * BobArnson: WIXBUG:4580 - Check bit mask appropriately for Burn system variables.

--- a/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
+++ b/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
@@ -864,7 +864,7 @@ public: // IBootstrapperApplication
 
             for (DWORD i = 0; i < m_cPrereqPackages; ++i)
             {
-                if (m_rgPrereqPackages[i].sczPackageId && m_rgPrereqPackages[i].fPlannedToBeInstalled)
+                if (m_rgPrereqPackages[i].sczPackageId && m_rgPrereqPackages[i].fPlannedToBeInstalled && !m_rgPrereqPackages[i].fWasAlreadyInstalled)
                 {
                     if (m_rgPrereqPackages[i].fSuccessfullyInstalled)
                     {


### PR DESCRIPTION
Fix bug in mbapreq where it wouldn't reload the bootstrapper if there was a mix of installed and uninstalled prerequisites.
