### PR TITLE
WIXBUG:4609 - Fix incorrect use of BVariantCopy

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* SeanHall: WIXBUG:4609 - Fix incorrect use of BVariantCopy by creating the new method BVariantSetValue.
+
 * SeanHall: WIXBUG:4608 - Fix bug in mbapreq where it wouldn't reload the bootstrapper if there was a mix of installed and uninstalled prerequisites.
 
 ## WixBuild: Version 3.10.1124.0

--- a/src/burn/engine/variable.cpp
+++ b/src/burn/engine/variable.cpp
@@ -409,7 +409,7 @@ extern "C" HRESULT VariablesParseFromXml(
         pVariables->rgVariables[iVariable].fPersisted = fPersisted;
 
         // update variable value
-        hr = BVariantCopy(&value, &pVariables->rgVariables[iVariable].Value);
+        hr = BVariantSetValue(&pVariables->rgVariables[iVariable].Value, &value);
         ExitOnFailure1(hr, "Failed to set value of variable: %ls", sczId);
 
         hr = BVariantSetEncryption(&pVariables->rgVariables[iVariable].Value, fHidden);
@@ -1528,7 +1528,7 @@ static HRESULT SetVariableValue(
     }
 
     // update variable value
-    hr = BVariantCopy(pVariant, &pVariables->rgVariables[iVariable].Value);
+    hr = BVariantSetValue(&pVariables->rgVariables[iVariable].Value, pVariant);
     ExitOnFailure1(hr, "Failed to set value of variable: %ls", wzVariable);
 
 LExit:

--- a/src/burn/engine/variant.h
+++ b/src/burn/engine/variant.h
@@ -75,6 +75,21 @@ HRESULT BVariantSetVersion(
     __in BURN_VARIANT* pVariant,
     __in DWORD64 qwValue
     );
+/********************************************************************
+BVariantSetValue - Convenience function that calls BVariantUninitialize,
+                   BVariantSetNumeric, BVariantSetString, or 
+                   BVariantSetVersion based on the type of pValue.
+                   The encryption state of pVariant is preserved.
+********************************************************************/
+HRESULT BVariantSetValue(
+    __in BURN_VARIANT* pVariant,
+    __in BURN_VARIANT* pValue
+    );
+/********************************************************************
+BVariantCopy - creates a copy of pSource.
+               The encryption state of pTarget is set to
+               the encryption state of pSource.
+********************************************************************/
 HRESULT BVariantCopy(
     __in BURN_VARIANT* pSource,
     __out BURN_VARIANT* pTarget
@@ -83,6 +98,11 @@ HRESULT BVariantChangeType(
     __in BURN_VARIANT* pVariant,
     __in BURN_VARIANT_TYPE type
     );
+/********************************************************************
+BVariantSetEncryption - sets the encryption state of pVariant.
+                        If the encryption state matches the requested
+                        state, this function does nothing.
+********************************************************************/
 HRESULT BVariantSetEncryption(
     __in BURN_VARIANT* pVariant,
     __in BOOL fEncrypt


### PR DESCRIPTION
Fix incorrect use of BVariantCopy by creating the new method BVariantSetValue.
