### PR TITLE
**BREAKING CHANGE** Changed bundle versioning.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* BobArnson: **BREAKING CHANGE** Changed bundle version to Major.Minor.0.BuildNumber. This allows us to publish updates as Major.Minor.(GreaterThanZero).BuildNumber. MSI product version numbers remain Major.Minor.BuildNumber so major upgrades continue to work. This bundle will not upgrade from build v3.10.1124.0. If you've installed v3.10.1124.0, you must uninstall before installing a later bundle.
+
 * BMurri: WIXBUG:3750 - Add LaunchWorkingFolder to wixstdba to facilitate processes that require a different working folder.
 
 * SeanHall: WIXBUG:4609 - Fix incorrect use of BVariantCopy by creating the new method BVariantSetValue.

--- a/src/Setup/Bundle/Bundle.wixproj
+++ b/src/Setup/Bundle/Bundle.wixproj
@@ -32,6 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\dtf\dtf.proj" />
     <ProjectReference Include="..\CoreMsi\CoreMsi.wixproj" />
     <ProjectReference Include="..\X64Msi\X64Msi.wixproj" />
     <ProjectReference Include="..\ManagedSdkMsi\ManagedSdkMsi.wixproj" />

--- a/src/Setup/CoreMsi/CoreMsi.wxs
+++ b/src/Setup/CoreMsi/CoreMsi.wxs
@@ -12,7 +12,7 @@
 
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:swid="http://schemas.microsoft.com/wix/TagExtension">
     <Product Id="*" Name="!(loc.ShortProduct) v$(var.WixMajorMinor) Core" Language="1033" Manufacturer="!(loc.Company)"
-             Version="$(var.WixVersion)" UpgradeCode="3618724B-2523-44F9-A908-866AA619504D">
+             Version="$(var.WixMsiProductVersion)" UpgradeCode="3618724B-2523-44F9-A908-866AA619504D">
         <Package Compressed="yes" InstallerVersion="200" SummaryCodepage="1252" InstallScope="perMachine" />
         <swid:Tag Regid="regid.2008-09.org.wixtoolset" Type="component" />
 

--- a/src/Setup/ManagedSdkMsi/ManagedSdkMsi.wxs
+++ b/src/Setup/ManagedSdkMsi/ManagedSdkMsi.wxs
@@ -12,7 +12,7 @@
 
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:swid="http://schemas.microsoft.com/wix/TagExtension">
     <Product Id="*" Name="!(loc.ShortProduct) v$(var.WixMajorMinor) Managed SDK" Language="1033" Manufacturer="!(loc.Company)"
-             Version="$(var.WixVersion)" UpgradeCode="1BF98B34-B863-4AF7-956C-FEEB1938B2C8">
+             Version="$(var.WixMsiProductVersion)" UpgradeCode="1BF98B34-B863-4AF7-956C-FEEB1938B2C8">
         <Package Compressed="yes" InstallerVersion="200" SummaryCodepage="1252" InstallScope="perMachine" />
         <swid:Tag Regid="regid.2008-09.org.wixtoolset" Type="component" />
 

--- a/src/Setup/NativeSdkMsi/NativeSdkMsi.wxs
+++ b/src/Setup/NativeSdkMsi/NativeSdkMsi.wxs
@@ -12,7 +12,7 @@
 
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:swid="http://schemas.microsoft.com/wix/TagExtension">
     <Product Id="*" Name="!(loc.ShortProduct) v$(var.WixMajorMinor) Native $(var.VisualStudioTargetVersion) SDK" Language="1033" Manufacturer="!(loc.Company)"
-             Version="$(var.WixVersion)" UpgradeCode="C1450CC3-3F3F-481E-AC13-E09FAF44FA54">
+             Version="$(var.WixMsiProductVersion)" UpgradeCode="C1450CC3-3F3F-481E-AC13-E09FAF44FA54">
         <Package Compressed="yes" InstallerVersion="200" SummaryCodepage="1252" InstallScope="perMachine" />
         <swid:Tag Regid="regid.2008-09.org.wixtoolset" Type="component" />
 

--- a/src/Setup/VotiveMsi/VotiveMsi.wxs
+++ b/src/Setup/VotiveMsi/VotiveMsi.wxs
@@ -12,7 +12,7 @@
 
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:swid="http://schemas.microsoft.com/wix/TagExtension">
     <Product Id="*" Name="!(loc.ShortProduct) v$(var.WixMajorMinor) Visual Studio Integration" Language="1033" Manufacturer="!(loc.Company)"
-             Version="$(var.WixVersion)" UpgradeCode="B6D64CBC-7075-4A94-AD48-DB084C0E70B1">
+             Version="$(var.WixMsiProductVersion)" UpgradeCode="B6D64CBC-7075-4A94-AD48-DB084C0E70B1">
         <Package Compressed="yes" InstallerVersion="200" SummaryCodepage="1252" InstallScope="perMachine" />
         <swid:Tag Regid="regid.2008-09.org.wixtoolset" Type="component" />
 

--- a/src/Setup/WixBA/Model.cs
+++ b/src/Setup/WixBA/Model.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Tools.WindowsInstallerXml.UX
         private Version version;
         private const string BurnBundleInstallDirectoryVariable = "InstallFolder";
         private const string BurnBundleLayoutDirectoryVariable = "WixBundleLayoutDirectory";
+        private const string BurnBundleVersionVariable = "WixBundleVersion";
 
         /// <summary>
         /// Creates a new model for the UX.
@@ -73,10 +74,7 @@ namespace Microsoft.Tools.WindowsInstallerXml.UX
             {
                 if (null == this.version)
                 {
-                    Assembly assembly = Assembly.GetExecutingAssembly();
-                    FileVersionInfo fileVersion = FileVersionInfo.GetVersionInfo(assembly.Location);
-
-                    this.version = new Version(fileVersion.FileVersion);
+                    this.version = new Version(this.Engine.StringVariables[BurnBundleVersionVariable]);
                 }
 
                 return this.version;

--- a/src/Setup/X64Msi/X64Msi.wxs
+++ b/src/Setup/X64Msi/X64Msi.wxs
@@ -12,7 +12,7 @@
 
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:swid="http://schemas.microsoft.com/wix/TagExtension">
     <Product Id="*" Name="!(loc.ShortProduct) v$(var.WixMajorMinor) X64" Language="1033" Manufacturer="!(loc.Company)"
-             Version="$(var.WixVersion)" UpgradeCode="4BF424CC-D118-4018-B49D-CC1A26968834">
+             Version="$(var.WixMsiProductVersion)" UpgradeCode="4BF424CC-D118-4018-B49D-CC1A26968834">
         <Package Compressed="yes" InstallerVersion="200" SummaryCodepage="1252" InstallScope="perMachine" />
         <swid:Tag Regid="regid.2008-09.org.wixtoolset" Type="component" />
 

--- a/tools/WixBuild.Version.targets
+++ b/tools/WixBuild.Version.targets
@@ -31,8 +31,9 @@
         <BuildNumber>$(UpperBuildNumber)$(BuildDay)</BuildNumber>
         <BuildRevision>0</BuildRevision>
 
-        <FullBuildVersionString>$(MajorBuildNumber).$(MinorBuildNumber).$(BuildNumber).$(BuildRevision)</FullBuildVersionString>
-        <FullBuildVersionStringDashed>$(MajorBuildNumber)-$(MinorBuildNumber)-$(BuildNumber)-$(BuildRevision)</FullBuildVersionStringDashed>
+        <FullBuildVersionString>$(MajorBuildNumber).$(MinorBuildNumber).$(BuildRevision).$(BuildNumber)</FullBuildVersionString>
+        <FullBuildVersionStringDashed>$(MajorBuildNumber)-$(MinorBuildNumber)-$(BuildRevision)-$(BuildNumber)</FullBuildVersionStringDashed>
+        <MsiProductVersionString>$(MajorBuildNumber).$(MinorBuildNumber).$(BuildNumber)</MsiProductVersionString>
     </PropertyGroup>
 
   <!--
@@ -152,7 +153,11 @@ using System.Reflection%3B
   &lt;?ifdef WixVersion?&gt;
     &lt;?error WixVersion variable is already defined?&gt;
   &lt;?endif?&gt;
-  &lt;?define WixVersion = '%24(var.WixMajorMinor).%24(var.WixBuildNum).0' ?&gt;
+  &lt;?define WixVersion = '%24(var.WixMajorMinor).0.%24(var.WixBuildNum)' ?&gt;
+  &lt;?ifdef WixMsiProductVersion?&gt;
+    &lt;?error WixMsiProductVersion variable is already defined?&gt;
+  &lt;?endif?&gt;
+  &lt;?define WixMsiProductVersion = '%24(var.WixMajorMinor).%24(var.WixBuildNum)' ?&gt;
 &lt;/Include&gt;
 "/>
     </ItemGroup>


### PR DESCRIPTION
Changed bundle version to Major.Minor.0.BuildNumber. This allows us to
publish updates as Major.Minor.(GreaterThanZero).BuildNumber. MSI
product version numbers remain Major.Minor.BuildNumber so major upgrades
continue to work. This bundle will not upgrade from build v3.10.1124.0.
If you've installed v3.10.1124.0, you must uninstall before installing a
later bundle.
