### PR TITLE
4592-RestartManager-AddPriviledges

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* PhillHogland: WIXBUG:4592 - Register named process, in another user's context with Restart Manager.  If Access Denied, continue install rather than fail.
+
 * HeathS: Redefine Exit\* macros as variadic macros
 
 * SeanHall: WIXFEAT:4505 - WixHttpExtension for URL reservations.

--- a/src/ext/ca/wixca/dll/RestartManager.cpp
+++ b/src/ext/ca/wixca/dll/RestartManager.cpp
@@ -52,6 +52,7 @@ extern "C" UINT __stdcall WixRegisterRestartResources(
     __in MSIHANDLE hInstall
     )
 {
+
     HRESULT hr = S_OK;
     UINT er = ERROR_SUCCESS;
 
@@ -148,8 +149,17 @@ extern "C" UINT __stdcall WixRegisterRestartResources(
         case etApplication:
             WcaLog(LOGMSG_VERBOSE, "Registering process name %ls with the Restart Manager.", wzResource);
             hr = RmuAddProcessesByName(pSession, wzResource);
-            ExitOnFailure(hr, "Failed to register the process name with the Restart Manager session.");
-            break;
+			if (E_NOTFOUND == hr)
+			{
+				//At least one instance of this process, running under another user returned access denied.  Since other instances may have been registered, continue this setup.
+				WcaLog(LOGMSG_VERBOSE, "An instance of the process named %ls could not be registered.  This setup will continue.", wzResource);
+				hr = S_OK;
+			}
+			else
+			{
+				ExitOnFailure(hr, "Failed to register the process name with the Restart Manager session.");
+			}
+			break;
 
         case etServiceName:
             WcaLog(LOGMSG_VERBOSE, "Registering service name %ls with the Restart Manager.", wzResource);

--- a/src/ext/ca/wixca/dll/RestartManager.cpp
+++ b/src/ext/ca/wixca/dll/RestartManager.cpp
@@ -149,17 +149,18 @@ extern "C" UINT __stdcall WixRegisterRestartResources(
         case etApplication:
             WcaLog(LOGMSG_VERBOSE, "Registering process name %ls with the Restart Manager.", wzResource);
             hr = RmuAddProcessesByName(pSession, wzResource);
-			if (E_NOTFOUND == hr)
-			{
-				//At least one instance of this process, running under another user returned access denied.  Since other instances may have been registered, continue this setup.
-				WcaLog(LOGMSG_VERBOSE, "An instance of the process named %ls could not be registered.  This setup will continue.", wzResource);
-				hr = S_OK;
-			}
-			else
-			{
-				ExitOnFailure(hr, "Failed to register the process name with the Restart Manager session.");
-			}
-			break;
+            if (E_NOTFOUND == hr)
+            {
+                // ERROR_ACCESS_DENIED was returned when trying to register this process.
+                // Since other instances may have been registered, log a message and continue the setup rather than failing.
+                WcaLog(LOGMSG_STANDARD, "The process, %ls, could not be registered with the Restart Manager (probably because the setup is not elevated and the process is in another user context.  A reboot may be requested later.", wzResource);
+                hr = S_OK;
+            }
+                else
+            {
+                ExitOnFailure(hr, "Failed to register the process name with the Restart Manager session.");
+            }
+            break;
 
         case etServiceName:
             WcaLog(LOGMSG_VERBOSE, "Registering service name %ls with the Restart Manager.", wzResource);

--- a/src/libs/dutil/rmutil.cpp
+++ b/src/libs/dutil/rmutil.cpp
@@ -158,25 +158,78 @@ extern "C" HRESULT DAPI RmuAddProcessById(
     FILETIME UserTime = {};
     BOOL fLocked = FALSE;
 
-    hProcess = ::OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, dwProcessId);
-    ExitOnNullWithLastError1(hProcess, hr, "Failed to open the process ID %d.", dwProcessId);
+	HANDLE hToken = NULL;
+	TOKEN_PRIVILEGES priv = { 0 };
+	TOKEN_PRIVILEGES* pPrevPriv = NULL;
+	DWORD cbPrevPriv = 0;
 
-    if (!::GetProcessTimes(hProcess, &CreationTime, &ExitTime, &KernelTime, &UserTime))
-    {
-        ExitWithLastError1(hr, "Failed to get the process times for process ID %d.", dwProcessId);
-    }
+	BOOL fElevated = FALSE;
+	ProcElevated(::GetCurrentProcess(), &fElevated);
+	
+	// Must be elevated to adjust process privileges
+	if (TRUE == fElevated) {
 
-    ::EnterCriticalSection(&pSession->cs);
-    fLocked = TRUE;
+		// This process must have SeDebugPrivilege, in the event that the process to be registered is runing under a different user,
+		// otherwise OpenProcess will fail (when using either PROCESS_QUERY_INFORMATION or PROCESS_QUERY_LIMITED_INFORMATION).
+		if (!::OpenProcessToken(::GetCurrentProcess(), TOKEN_QUERY | TOKEN_ADJUST_PRIVILEGES, &hToken))
+		{
+			ExitWithLastError(hr, "Failed to get process token.");
+		}
 
-    hr = RmuApplicationArrayAlloc(&pSession->rgApplications, &pSession->cApplications, dwProcessId, CreationTime);
-    ExitOnFailure(hr, "Failed to add the application to the array.");
+		priv.PrivilegeCount = 1;
+		priv.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
+		if (!::LookupPrivilegeValueW(NULL, L"SeDebugPrivilege", &priv.Privileges[0].Luid))
+		{
+			ExitWithLastError(hr, "Failed to get debug privilege LUID.");
+		}
+
+		cbPrevPriv = sizeof(TOKEN_PRIVILEGES);
+		pPrevPriv = static_cast<TOKEN_PRIVILEGES*>(MemAlloc(cbPrevPriv, TRUE));
+		ExitOnNull(pPrevPriv, hr, E_OUTOFMEMORY, "Failed to allocate memory for empty previous privileges.");
+
+		if (!::AdjustTokenPrivileges(hToken, FALSE, &priv, cbPrevPriv, pPrevPriv, &cbPrevPriv))
+		{
+			LPVOID pv = MemReAlloc(pPrevPriv, cbPrevPriv, TRUE);
+			ExitOnNull(pv, hr, E_OUTOFMEMORY, "Failed to allocate memory for previous privileges.");
+			pPrevPriv = static_cast<TOKEN_PRIVILEGES*>(pv);
+
+			if (!::AdjustTokenPrivileges(hToken, FALSE, &priv, cbPrevPriv, pPrevPriv, &cbPrevPriv))
+			{
+				ExitWithLastError(hr, "Failed to get debug privilege LUID.");
+			}
+		}
+	}
+
+	// Calling process needs SeDebugPrivilege if the process to be opened running under a different user account.
+	hProcess = ::OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, dwProcessId);
+	if (TRUE == fElevated)
+	{
+		ExitOnNullWithLastError(hProcess, hr, "Failed to open the process ID %d.", dwProcessId);
+		if (!::GetProcessTimes(hProcess, &CreationTime, &ExitTime, &KernelTime, &UserTime))
+		{
+			ExitWithLastError(hr, "Failed to get the process times for process ID %d.", dwProcessId);
+		}
+
+		::EnterCriticalSection(&pSession->cs);
+		fLocked = TRUE;
+
+		hr = RmuApplicationArrayAlloc(&pSession->rgApplications, &pSession->cApplications, dwProcessId, CreationTime);
+		ExitOnFailure(hr, "Failed to add the application to the array.");
+
+	}
+	else
+	{
+		hr = E_NOTFOUND;
+	}
 
 LExit:
     if (hProcess)
     {
         ::CloseHandle(hProcess);
     }
+
+	ReleaseMem(pPrevPriv);
+	ReleaseHandle(hToken);
 
     if (fLocked)
     {
@@ -202,20 +255,35 @@ extern "C" HRESULT DAPI RmuAddProcessesByName(
     HRESULT hr = S_OK;
     DWORD *pdwProcessIds = NULL;
     DWORD cProcessIds = 0;
+	BOOL fNotFound = FALSE;
 
     hr = ProcFindAllIdsFromExeName(wzProcessName, &pdwProcessIds, &cProcessIds);
-    ExitOnFailure1(hr, "Failed to enumerate all the processes by name %ls.", wzProcessName);
+    ExitOnFailure(hr, "Failed to enumerate all the processes by name %ls.", wzProcessName);
 
     for (DWORD i = 0; i < cProcessIds; ++i)
     {
         hr = RmuAddProcessById(pSession, pdwProcessIds[i]);
-        ExitOnFailure2(hr, "Failed to add process %ls (%d) to the Restart Manager session.", wzProcessName, pdwProcessIds[i]);
+		if (E_NOTFOUND == hr)
+		{
+			// RmuAddProcessById returns E_NOTFOUND when this setup is not elevated and OpenProcess returned access denied (target process running under another user account). 
+			fNotFound = TRUE;
+		}
+		else
+		{
+			ExitOnFailure(hr, "Failed to add process %ls (%d) to the Restart Manager session.", wzProcessName, pdwProcessIds[i]);
+		}
     }
+
+	// If one or more calls to RmuAddProcessById returned E_NOTFOUND, then return E_NOTFOUND even if other calls succeeded, so that caller can log the issue.
+	if (TRUE == fNotFound)
+	{
+		hr =  E_NOTFOUND;
+	}
 
 LExit:
     ReleaseMem(pdwProcessIds);
 
-    return hr;
+	return hr;
 }
 
 /********************************************************************

--- a/src/libs/dutil/rmutil.cpp
+++ b/src/libs/dutil/rmutil.cpp
@@ -158,69 +158,75 @@ extern "C" HRESULT DAPI RmuAddProcessById(
     FILETIME UserTime = {};
     BOOL fLocked = FALSE;
 
-	HANDLE hToken = NULL;
-	TOKEN_PRIVILEGES priv = { 0 };
-	TOKEN_PRIVILEGES* pPrevPriv = NULL;
-	DWORD cbPrevPriv = 0;
+    HANDLE hToken = NULL;
+    TOKEN_PRIVILEGES priv = { 0 };
+    TOKEN_PRIVILEGES* pPrevPriv = NULL;
+    DWORD cbPrevPriv = 0;
+    DWORD er = ERROR_SUCCESS;
+    BOOL fAdjustedPrivileges = FALSE;
+    BOOL fElevated = FALSE;
+    ProcElevated(::GetCurrentProcess(), &fElevated);
 
-	BOOL fElevated = FALSE;
-	ProcElevated(::GetCurrentProcess(), &fElevated);
-	
-	// Must be elevated to adjust process privileges
-	if (TRUE == fElevated) {
+    // Must be elevated to adjust process privileges
+    if (fElevated) {
+        // Adding SeDebugPrivilege in the event that the process targeted by ::OpenProcess() is in a another user context.
+        if (!::OpenProcessToken(::GetCurrentProcess(), TOKEN_QUERY | TOKEN_ADJUST_PRIVILEGES, &hToken))
+        {
+            ExitWithLastError(hr, "Failed to get process token.");
+        }
 
-		// This process must have SeDebugPrivilege, in the event that the process to be registered is runing under a different user,
-		// otherwise OpenProcess will fail (when using either PROCESS_QUERY_INFORMATION or PROCESS_QUERY_LIMITED_INFORMATION).
-		if (!::OpenProcessToken(::GetCurrentProcess(), TOKEN_QUERY | TOKEN_ADJUST_PRIVILEGES, &hToken))
-		{
-			ExitWithLastError(hr, "Failed to get process token.");
-		}
+        priv.PrivilegeCount = 1;
+        priv.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
+        if (!::LookupPrivilegeValueW(NULL, L"SeDebugPrivilege", &priv.Privileges[0].Luid))
+        {
+            ExitWithLastError(hr, "Failed to get debug privilege LUID.");
+        }
 
-		priv.PrivilegeCount = 1;
-		priv.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
-		if (!::LookupPrivilegeValueW(NULL, L"SeDebugPrivilege", &priv.Privileges[0].Luid))
-		{
-			ExitWithLastError(hr, "Failed to get debug privilege LUID.");
-		}
+        cbPrevPriv = sizeof(TOKEN_PRIVILEGES);
+        pPrevPriv = static_cast<TOKEN_PRIVILEGES*>(MemAlloc(cbPrevPriv, TRUE));
+        ExitOnNull(pPrevPriv, hr, E_OUTOFMEMORY, "Failed to allocate memory for empty previous privileges.");
 
-		cbPrevPriv = sizeof(TOKEN_PRIVILEGES);
-		pPrevPriv = static_cast<TOKEN_PRIVILEGES*>(MemAlloc(cbPrevPriv, TRUE));
-		ExitOnNull(pPrevPriv, hr, E_OUTOFMEMORY, "Failed to allocate memory for empty previous privileges.");
+        if (!::AdjustTokenPrivileges(hToken, FALSE, &priv, cbPrevPriv, pPrevPriv, &cbPrevPriv))
+        {
+            LPVOID pv = MemReAlloc(pPrevPriv, cbPrevPriv, TRUE);
+            ExitOnNull(pv, hr, E_OUTOFMEMORY, "Failed to allocate memory for previous privileges.");
+            pPrevPriv = static_cast<TOKEN_PRIVILEGES*>(pv);
 
-		if (!::AdjustTokenPrivileges(hToken, FALSE, &priv, cbPrevPriv, pPrevPriv, &cbPrevPriv))
-		{
-			LPVOID pv = MemReAlloc(pPrevPriv, cbPrevPriv, TRUE);
-			ExitOnNull(pv, hr, E_OUTOFMEMORY, "Failed to allocate memory for previous privileges.");
-			pPrevPriv = static_cast<TOKEN_PRIVILEGES*>(pv);
+            if (!::AdjustTokenPrivileges(hToken, FALSE, &priv, cbPrevPriv, pPrevPriv, &cbPrevPriv))
+            {
+                ExitWithLastError(hr, "Failed to get debug privilege LUID.");
+            }
+        }
+        
+        fAdjustedPrivileges = TRUE;
+    }
 
-			if (!::AdjustTokenPrivileges(hToken, FALSE, &priv, cbPrevPriv, pPrevPriv, &cbPrevPriv))
-			{
-				ExitWithLastError(hr, "Failed to get debug privilege LUID.");
-			}
-		}
-	}
+    hProcess = ::OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, dwProcessId);
+    if (NULL != hProcess)
+    {
+        if (!::GetProcessTimes(hProcess, &CreationTime, &ExitTime, &KernelTime, &UserTime))
+        {
+        ExitWithLastError(hr, "Failed to get the process times for process ID %d.", dwProcessId);
+        }
 
-	// Calling process needs SeDebugPrivilege if the process to be opened running under a different user account.
-	hProcess = ::OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, dwProcessId);
-	if (TRUE == fElevated)
-	{
-		ExitOnNullWithLastError(hProcess, hr, "Failed to open the process ID %d.", dwProcessId);
-		if (!::GetProcessTimes(hProcess, &CreationTime, &ExitTime, &KernelTime, &UserTime))
-		{
-			ExitWithLastError(hr, "Failed to get the process times for process ID %d.", dwProcessId);
-		}
-
-		::EnterCriticalSection(&pSession->cs);
-		fLocked = TRUE;
-
-		hr = RmuApplicationArrayAlloc(&pSession->rgApplications, &pSession->cApplications, dwProcessId, CreationTime);
-		ExitOnFailure(hr, "Failed to add the application to the array.");
-
-	}
-	else
-	{
-		hr = E_NOTFOUND;
-	}
+        ::EnterCriticalSection(&pSession->cs);
+        fLocked = TRUE;
+        hr = RmuApplicationArrayAlloc(&pSession->rgApplications, &pSession->cApplications, dwProcessId, CreationTime);
+        ExitOnFailure(hr, "Failed to add the application to the array.");
+    }
+    else
+    {
+        er = ::GetLastError();
+        if (ERROR_ACCESS_DENIED == er)
+        {
+            // OpenProcess will fail when not elevated and the target process is in another user context. Let the caller log and continue.
+			hr = E_NOTFOUND;
+        }
+        else
+        {
+            ExitOnWin32Error(er, hr, "Failed to open the process ID %d.", dwProcessId);
+        }
+    }
 
 LExit:
     if (hProcess)
@@ -228,8 +234,12 @@ LExit:
         ::CloseHandle(hProcess);
     }
 
-	ReleaseMem(pPrevPriv);
-	ReleaseHandle(hToken);
+    if (fAdjustedPrivileges)
+    {
+        ::AdjustTokenPrivileges(hToken, FALSE, pPrevPriv, 0, NULL, NULL);
+    }
+    ReleaseMem(pPrevPriv);
+    ReleaseHandle(hToken);
 
     if (fLocked)
     {
@@ -255,7 +265,7 @@ extern "C" HRESULT DAPI RmuAddProcessesByName(
     HRESULT hr = S_OK;
     DWORD *pdwProcessIds = NULL;
     DWORD cProcessIds = 0;
-	BOOL fNotFound = FALSE;
+    BOOL fNotFound = FALSE;
 
     hr = ProcFindAllIdsFromExeName(wzProcessName, &pdwProcessIds, &cProcessIds);
     ExitOnFailure(hr, "Failed to enumerate all the processes by name %ls.", wzProcessName);
@@ -263,27 +273,27 @@ extern "C" HRESULT DAPI RmuAddProcessesByName(
     for (DWORD i = 0; i < cProcessIds; ++i)
     {
         hr = RmuAddProcessById(pSession, pdwProcessIds[i]);
-		if (E_NOTFOUND == hr)
-		{
-			// RmuAddProcessById returns E_NOTFOUND when this setup is not elevated and OpenProcess returned access denied (target process running under another user account). 
-			fNotFound = TRUE;
-		}
-		else
-		{
-			ExitOnFailure(hr, "Failed to add process %ls (%d) to the Restart Manager session.", wzProcessName, pdwProcessIds[i]);
-		}
+    if (E_NOTFOUND == hr)
+    {
+        // RmuAddProcessById returns E_NOTFOUND when this setup is not elevated and OpenProcess returned access denied (target process running under another user account). 
+        fNotFound = TRUE;
+    }
+    else
+    {
+        ExitOnFailure(hr, "Failed to add process %ls (%d) to the Restart Manager session.", wzProcessName, pdwProcessIds[i]);
+    }
     }
 
-	// If one or more calls to RmuAddProcessById returned E_NOTFOUND, then return E_NOTFOUND even if other calls succeeded, so that caller can log the issue.
-	if (TRUE == fNotFound)
-	{
-		hr =  E_NOTFOUND;
-	}
+    // If one or more calls to RmuAddProcessById returned E_NOTFOUND, then return E_NOTFOUND even if other calls succeeded, so that caller can log the issue.
+    if (fNotFound)
+    {
+        hr =  E_NOTFOUND;
+    }
 
 LExit:
     ReleaseMem(pdwProcessIds);
 
-	return hr;
+    return hr;
 }
 
 /********************************************************************


### PR DESCRIPTION
If the named process is running under another user, then OpenProcess must be called using a process token which includes SeDebugPriviledge.  To set SeDebugPriviledge the caller must have elevated privileges.  If cannot set SeDebugPriviledge, log a message and continue.  Let caller handle a reboot request rather than returning a failure.

Tested these changes on Win 7 SP1 x64 Prof, Win 8 Prof x64, Win 7 SP1 Ultimate N German x64, Win 7 SP1 Ultimate N Korean x86,  WS2008R2 SP1 Standard, WS2012R2 Korean.