### PR TITLE
WIXBUG:4589

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* BobArnson: WIXBUG:4589 - Catch exceptions from Version when passing in arbitrary strings. For bundles, try to recover a three-part version number.
+
 * STunney: WIXBUG:4187 - Melt doesn't export Binary or Icon tables
 
 * BobArnson: WIXBUG:4553 - Fix Lux generator to exclude any files with non-fragment sections. Fix Lux custom actions to have proper config.

--- a/src/tools/wix/ChainPackageInfo.cs
+++ b/src/tools/wix/ChainPackageInfo.cs
@@ -611,7 +611,23 @@ namespace Microsoft.Tools.WindowsInstallerXml
 
                     if (!Common.IsValidModuleOrBundleVersion(this.Version))
                     {
-                        this.core.OnMessage(WixErrors.InvalidProductVersion(this.PackagePayload.SourceLineNumbers, this.Version, sourcePath));
+                        // not a proper .NET version (i.e., five fields); can we get a valid three-part version number?
+                        string version = null;
+                        string[] versionParts = this.Version.Split('.');
+                        if (2 < versionParts.Length)
+                        {
+                            version = String.Concat(versionParts[0], ".", versionParts[1], ".", versionParts[2]);
+                        }
+
+                        if (!String.IsNullOrEmpty(version) && Common.IsValidModuleOrBundleVersion(version))
+                        {
+                            this.core.OnMessage(WixWarnings.VersionTruncated(this.PackagePayload.SourceLineNumbers, this.Version, sourcePath, version));
+                            this.Version = version;
+                        }
+                        else
+                        {
+                            this.core.OnMessage(WixErrors.InvalidProductVersion(this.PackagePayload.SourceLineNumbers, this.Version, sourcePath));
+                        }
                     }
 
                     if (String.IsNullOrEmpty(this.CacheId))

--- a/src/tools/wix/Common.cs
+++ b/src/tools/wix/Common.cs
@@ -324,7 +324,16 @@ namespace Microsoft.Tools.WindowsInstallerXml
         {
             if (!Common.IsValidBinderVariable(version))
             {
-                Version ver = new Version(version);
+                Version ver = null;
+
+                try
+                {
+                    ver = new Version(version);
+                }
+                catch (ArgumentException)
+                {
+                    return false;
+                }
 
                 if (65535 < ver.Major || 65535 < ver.Minor || 65535 < ver.Build || 65535 < ver.Revision)
                 {

--- a/src/tools/wix/Data/messages.xml
+++ b/src/tools/wix/Data/messages.xml
@@ -3784,6 +3784,14 @@
                 The transform did not contain any valid product changes and will not be included in the patch.
             </Instance>
         </Message>
+        <Message Id="VersionTruncated" Number="1148">
+            <Instance>
+                Product version {0} in package '{1}' is not valid per the MSI SDK and cannot be represented in a bundle. It has been truncated to {2}.
+                <Parameter Type="System.String" Name="originalVersion" />
+                <Parameter Type="System.String" Name="package" />
+                <Parameter Type="System.String" Name="truncatedVersion" />
+            </Instance>
+        </Message>
     </Class>
 
     <Class Name="WixVerboses" ContainerName="WixVerboseEventArgs" BaseContainerName="MessageEventArgs" Level="Information">


### PR DESCRIPTION
Catch exceptions from Version when passing in arbitrary strings. For bundles, try to recover a three-part version number.