### PR TITLE
WIXBUG:4661 - Removed IntermediateOutputPath

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* BobArnson: WIXBUG:4661 - Removed IntermediateOutputPath defaults from template .wixproj.
+
 * SeanHall: WIXBUG:4689 - Fix hidden numeric and version variables.
 
 ## WixBuild: Version 3.10.0.1502

--- a/src/Votive/votive2010/src/Templates/Projects/WixProject/SetupProject.wixproj
+++ b/src/Votive/votive2010/src/Templates/Projects/WixProject/SetupProject.wixproj
@@ -12,12 +12,10 @@
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
 		<OutputPath>bin\$(Configuration)\</OutputPath>
-		<IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
 		<DefineConstants>Debug</DefineConstants>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
 		<OutputPath>bin\$(Configuration)\</OutputPath>
-		<IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
 	</PropertyGroup>
 	<ItemGroup>
 		<Compile Include="Product.wxs" />


### PR DESCRIPTION
WIXBUG:4661 - Removed IntermediateOutputPath defaults from template .wixproj.