### PR TITLE
Create Silent Exec Custom Action

### DIFF
--- a/src/chm/documents/customactions/qtexec.html.md
+++ b/src/chm/documents/customactions/qtexec.html.md
@@ -10,10 +10,10 @@ The QtExec custom action allows you to run an arbitrary command line in an MSI-b
 
 ## Immediate execution
 
-When the QtExec action is run as an immediate custom action, it will try to execute the command stored in the QtExecCmdLine property. The following is an example of authoring an immediate QtExec custom action:
+When the QtExec action is run as an immediate custom action, it will try to execute the command stored in the WixQuietExecCmdLine property. The following is an example of authoring an immediate QtExec custom action:
 
-    <Property Id="QtExecCmdLine" Value="command line to run"/>
-    <CustomAction Id="QtExecExample" BinaryKey="WixCA" DllEntry="CAQuietExec" Execute="immediate" Return="check"/>
+    <Property Id="WixQuietExecCmdLine" Value="command line to run"/>
+    <CustomAction Id="QtExecExample" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="immediate" Return="check"/>
     .
     .
     .
@@ -23,14 +23,29 @@ When the QtExec action is run as an immediate custom action, it will try to exec
 
 This will result in running the command line in the immediate sequence. If the exit code of the command line in this example indicates an error (meaning that the return code is not equal to 0) then the setup will fail because the Return value is set to &ldquo;check.&quot; Changing the Return value to &quot;ignore&quot; will cause the setup to log the failure but skip it and continue instead of failing the entire setup.
 
-If you want to run more than one command line in the immediate sequence then you will need to schedule multiple QtExec custom actions and set the QtExecCmdLine property to a new value by scheduling a property-setting custom action immediately before each instance of the QtExec custom action.
+If you want to run more than one command line in the immediate sequence then you will need to schedule multiple QtExec custom actions and set the WixQuietExecCmdLine property to a new value by scheduling a property-setting custom action immediately before each instance of the QtExec custom action.
+
+## Silent execution
+
+If you need to run a program without logging any of the input parameters or output of the executable, for example for security or privacy reasons, you want WixSilentExec:
+
+    <Property Id="WixSilentExecCmdLine" Value="command line to run" Hidden="yes"/>
+    <CustomAction Id="SilentExecExample" BinaryKey="WixCA" DllEntry="WixSilentExec" Execute="immediate" Return="check"/>
+    .
+    .
+    .
+    <InstallExecuteSequence>
+      <Custom Action="SilentExecExample" After="TheActionYouWantItAfter"/>
+    </InstallExecuteSequence>
+
+The *only* difference in behavior between WixQuietExec and WixSilentExec is that WixSilentExec never logs the input or output of the commandline. Take special note to mark the input property and other properties as hidden if you do not want them logged automatically by MSI.
 
 ## Deferred execution
 
 When the QtExec action is run as a deferred custom action, it will try to execute the command line stored in the value of the custom action data. For deferred QtExec custom actions, the custom action data is a property that has the same Id value as the custom action Id. The following is an example of authoring a deferred QtExec custom action:
 
     <Property Id="QtExecDeferredExample" Value="command line to run"/>
-    <CustomAction Id="QtExecDeferredExample" BinaryKey="WixCA" DllEntry="CAQuietExec"
+    <CustomAction Id="QtExecDeferredExample" BinaryKey="WixCA" DllEntry="WixQuietExec"
                 Execute="deferred" Return="check" Impersonate="no"/>
     .
     .
@@ -43,7 +58,7 @@ If you need to set a command line that uses other Windows Installer properties, 
 
     <CustomAction Id="QtExecDeferredExampleWithProperty_Cmd" Property="QtExecDeferredExampleWithProperty"
                 Value="&quot;[#MyExecutable.exe]&quot;" Execute="immediate"/>
-    <CustomAction Id="QtExecDeferredExampleWithProperty" BinaryKey="WixCA" DllEntry="CAQuietExec"
+    <CustomAction Id="QtExecDeferredExampleWithProperty" BinaryKey="WixCA" DllEntry="WixQuietExec"
                 Execute="deferred" Return="check" Impersonate="no"/>
     .
     .
@@ -55,16 +70,16 @@ If you need to set a command line that uses other Windows Installer properties, 
 
 ## Running 64-bit executables
 
-If you need to run a 64-bit executable, use the 64-bit aware QtExec. To use the 64-bit QtExec change the CustomAction element&apos;s DllEntry attribute to &quot;CAQuietExec64&quot; and for immediate execution use the &quot;QtExec64CmdLine&quot; property. The following example combines the examples above the 64-bit aware QtExec for both. Notice that the CustomAction element&apos;s Id attributes do not need to change:
+If you need to run a 64-bit executable, use the 64-bit aware QtExec. To use the 64-bit QtExec change the CustomAction element&apos;s DllEntry attribute to &quot;WixQuietExec64&quot; and for immediate execution use the &quot;QtExec64CmdLine&quot; property. The following example combines the examples above the 64-bit aware QtExec for both. Notice that the CustomAction element&apos;s Id attributes do not need to change:
 
-    <Property Id="QtExec64CmdLine" Value="64-bit command line to run"/>
-    <CustomAction Id="QtExecExample" BinaryKey="WixCA" DllEntry="CAQuietExec64" Execute="immediate" Return="check"/>
+    <Property Id="WixQuietExec64CmdLine" Value="64-bit command line to run"/>
+    <CustomAction Id="QtExecExample" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="immediate" Return="check"/>
     .
     .
     .
     <CustomAction Id="QtExecDeferredExampleWithProperty_Cmd" Property="QtExecDeferredExampleWithProperty"
                 Value="&quot;[#MyExecutable.exe]&quot;" Execute="immediate" Return="ignore"/>
-    <CustomAction Id="QtExecDeferredExampleWithProperty" BinaryKey="WixCA" DllEntry="CAQuietExec64"
+    <CustomAction Id="QtExecDeferredExampleWithProperty" BinaryKey="WixCA" DllEntry="WixQuietExec64"
                 Execute="deferred" Return="check" Impersonate="no"/>
     .
     .

--- a/src/chm/documents/customactions/qtexec.html.md
+++ b/src/chm/documents/customactions/qtexec.html.md
@@ -27,7 +27,7 @@ If you want to run more than one command line in the immediate sequence then you
 
 ## Silent execution
 
-If you need to run a program without logging any of the input parameters or output of the executable, for example for security or privacy reasons, you want WixSilentExec:
+If you need to run a program without logging any of the input parameters or output of the executable __for example, for security or privacy reasons,__ you want WixSilentExec:
 
     <Property Id="WixSilentExecCmdLine" Value="command line to run" Hidden="yes"/>
     <CustomAction Id="SilentExecExample" BinaryKey="WixCA" DllEntry="WixSilentExec" Execute="immediate" Return="check"/>
@@ -42,7 +42,7 @@ The *only* difference in behavior between WixQuietExec and WixSilentExec is that
 
 ## Deferred execution
 
-When the QtExec action is run as a deferred custom action, it will try to execute the command line stored in the value of the custom action data. For deferred QtExec custom actions, the custom action data is a property that has the same Id value as the custom action Id. The following is an example of authoring a deferred QtExec custom action:
+When the WixQuietExec (or WixSilentExec) action is run as a deferred custom action, it will try to execute the command line stored in the value of the custom action data. For deferred QtExec custom actions, the custom action data is a property that has the same Id value as the custom action Id. The following is an example of authoring a deferred QtExec custom action:
 
     <Property Id="QtExecDeferredExample" Value="command line to run"/>
     <CustomAction Id="QtExecDeferredExample" BinaryKey="WixCA" DllEntry="WixQuietExec"
@@ -70,7 +70,7 @@ If you need to set a command line that uses other Windows Installer properties, 
 
 ## Running 64-bit executables
 
-If you need to run a 64-bit executable, use the 64-bit aware QtExec. To use the 64-bit QtExec change the CustomAction element&apos;s DllEntry attribute to &quot;WixQuietExec64&quot; and for immediate execution use the &quot;QtExec64CmdLine&quot; property. The following example combines the examples above the 64-bit aware QtExec for both. Notice that the CustomAction element&apos;s Id attributes do not need to change:
+If you need to run a 64-bit executable, use the 64-bit aware QtExec. To use the 64-bit QtExec (or WixSilentExec) change the CustomAction element&apos;s DllEntry attribute to &quot;WixQuietExec64&quot; (or &quot;WixSilentExec64&quot;) and for immediate execution use the &quot;WixQuietExec64CmdLine&quot; (or &quot;WixSilentExec64CmdLine&quot;) property. The following example combines the examples above the 64-bit aware QtExec for both. Notice that the CustomAction element&apos;s Id attributes do not need to change:
 
     <Property Id="WixQuietExec64CmdLine" Value="64-bit command line to run"/>
     <CustomAction Id="QtExecExample" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="immediate" Return="check"/>

--- a/src/ext/NetFxExtension/ca/netfxca.cpp
+++ b/src/ext/NetFxExtension/ca/netfxca.cpp
@@ -810,7 +810,7 @@ extern "C" UINT __stdcall ExecNetFx(
         hr = WcaReadIntegerFromCaData(&pwz, &iCost);
         ExitOnFailure(hr, "failed to read cost from custom action data");
 
-        hr = QuietExec(pwzData, NGEN_TIMEOUT);
+        hr = QuietExec(pwzData, NGEN_TIMEOUT, TRUE, TRUE);
         // If we fail here it isn't critical - keep looping through to try to act on the other assemblies on our list
         if (FAILED(hr))
         {

--- a/src/ext/UtilExtension/wixlib/UtilExtension.wxs
+++ b/src/ext/UtilExtension/wixlib/UtilExtension.wxs
@@ -401,4 +401,25 @@
         <PropertyRef Id="QtExec64CmdLine" />
         <CustomAction Id="QtExec64" BinaryKey="WixCA" DllEntry="CAQuietExec64" Execute="immediate" Return="check" Impersonate="yes" />
     </Fragment>
+
+    <Fragment>
+        <PropertyRef Id="WixQuietExecCmdLine" />
+        <CustomAction Id="WixQuietExec" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="immediate" Return="check" Impersonate="yes" />
+    </Fragment>
+
+    <Fragment>
+        <PropertyRef Id="WixQuietExec64CmdLine" />
+        <CustomAction Id="WixQuietExec64" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="immediate" Return="check" Impersonate="yes" />
+    </Fragment>
+
+    <!-- SilentExec custom actions differ from QtExec in that they do not log the commandline or output of the exe -->
+    <Fragment>
+        <PropertyRef Id="WixSilentExecCmdLine" />
+        <CustomAction Id="WixSilentExec" BinaryKey="WixCA" DllEntry="WixSilentExec" Execute="immediate" Return="check" Impersonate="yes" />
+    </Fragment>
+
+    <Fragment>
+        <PropertyRef Id="WixSilentExec64CmdLine" />
+        <CustomAction Id="WixSilentExec64" BinaryKey="WixCA" DllEntry="WixSilentExec64" Execute="immediate" Return="check" Impersonate="yes" />
+    </Fragment>
 </Wix>

--- a/src/ext/ca/wixca/dll/qtexecca.cpp
+++ b/src/ext/ca/wixca/dll/qtexecca.cpp
@@ -16,40 +16,28 @@
 #define OUTPUT_BUFFER 1024
 
 // These old "CA" prefix names are deprecated, and intended to go away in wix 4.0, only staying now for compatibility reasons
-const LPCSTR CAQUIET_TIMEOUT_PROPERTY = "QtExecCmdTimeout";
-const LPCWSTR CAQUIET_TIMEOUT_PROPERTY_WIDE = L"QtExecCmdTimeout";
-const LPCSTR CAQUIET_ARGUMENTS_PROPERTY = "QtExecCmdLine";
-const LPCSTR CAQUIET64_ARGUMENTS_PROPERTY = "QtExec64CmdLine";
-const LPCWSTR CAQUIET_ARGUMENTS_PROPERTY_WIDE = L"QtExecCmdLine";
-const LPCWSTR CAQUIET64_ARGUMENTS_PROPERTY_WIDE = L"QtExec64CmdLine";
+const LPCWSTR CAQUIET_TIMEOUT_PROPERTY = L"QtExecCmdTimeout";
+const LPCWSTR CAQUIET_ARGUMENTS_PROPERTY = L"QtExecCmdLine";
+const LPCWSTR CAQUIET64_ARGUMENTS_PROPERTY = L"QtExec64CmdLine";
 // end deprecated section
 
 // WixCA name quiet commandline argument properties
-const LPCSTR WIX_QUIET_ARGUMENTS_PROPERTY = "WixQuietExecCmdLine";
-const LPCSTR WIX_QUIET64_ARGUMENTS_PROPERTY = "WixQuietExec64CmdLine";
-const LPCWSTR WIX_QUIET_ARGUMENTS_PROPERTY_WIDE = L"WixQuietExecCmdLine";
-const LPCWSTR WIX_QUIET64_ARGUMENTS_PROPERTY_WIDE = L"WixQuietExec64CmdLine";
+const LPCWSTR WIX_QUIET_ARGUMENTS_PROPERTY = L"WixQuietExecCmdLine";
+const LPCWSTR WIX_QUIET64_ARGUMENTS_PROPERTY = L"WixQuietExec64CmdLine";
 
 // WixCA quiet timeout properties
-const LPCSTR WIX_QUIET_TIMEOUT_PROPERTY = "WixQuietExecCmdTimeout";
-const LPCSTR WIX_QUIET64_TIMEOUT_PROPERTY = "WixQuietExec64CmdTimeout";
-const LPCWSTR WIX_QUIET_TIMEOUT_PROPERTY_WIDE = L"WixQuietExecCmdTimeout";
-const LPCWSTR WIX_QUIET64_TIMEOUT_PROPERTY_WIDE = L"WixQuietExec64CmdTimeout";
+const LPCWSTR WIX_QUIET_TIMEOUT_PROPERTY = L"WixQuietExecCmdTimeout";
+const LPCWSTR WIX_QUIET64_TIMEOUT_PROPERTY = L"WixQuietExec64CmdTimeout";
 
 // WixCA silent commandline argument properties
-const LPCSTR WIX_SILENT_ARGUMENTS_PROPERTY = "WixSilentExecCmdLine";
-const LPCSTR WIX_SILENT64_ARGUMENTS_PROPERTY = "WixSilentExec64CmdLine";
-const LPCWSTR WIX_SILENT_ARGUMENTS_PROPERTY_WIDE = L"WixSilentExecCmdLine";
-const LPCWSTR WIX_SILENT64_ARGUMENTS_PROPERTY_WIDE = L"WixSilentExec64CmdLine";
+const LPCWSTR WIX_SILENT_ARGUMENTS_PROPERTY = L"WixSilentExecCmdLine";
+const LPCWSTR WIX_SILENT64_ARGUMENTS_PROPERTY = L"WixSilentExec64CmdLine";
 
 // WixCA silent timeout properties
-const LPCSTR WIX_SILENT_TIMEOUT_PROPERTY = "WixSilentExecCmdTimeout";
-const LPCSTR WIX_SILENT64_TIMEOUT_PROPERTY = "WixSilentExec64CmdTimeout";
-const LPCWSTR WIX_SILENT_TIMEOUT_PROPERTY_WIDE = L"WixSilentExecCmdTimeout";
-const LPCWSTR WIX_SILENT64_TIMEOUT_PROPERTY_WIDE = L"WixSilentExec64CmdTimeout";
+const LPCWSTR WIX_SILENT_TIMEOUT_PROPERTY = L"WixSilentExecCmdTimeout";
+const LPCWSTR WIX_SILENT64_TIMEOUT_PROPERTY = L"WixSilentExec64CmdTimeout";
 
 HRESULT BuildCommandLine(
-    __in LPCSTR szProperty,
     __in LPCWSTR wzProperty,
     __out LPWSTR *ppwzCommand
     )
@@ -69,7 +57,7 @@ HRESULT BuildCommandLine(
             ExitOnFailure(hr, "failed to get CustomActionData");
         }
     }
-    else if (WcaIsPropertySet(szProperty))
+    else if (WcaIsUnicodePropertySet(wzProperty))
     {
         hr = WcaGetFormattedProperty(wzProperty, ppwzCommand);
         ExitOnFailure1(hr, "failed to get %ls", wzProperty);
@@ -94,14 +82,14 @@ LExit:
 
 #define ONEMINUTE 60000
 
-DWORD GetTimeout(LPCSTR szPropertyName, LPCWSTR wzPropertyName)
+DWORD GetTimeout(LPCWSTR wzPropertyName)
 {
     DWORD dwTimeout = ONEMINUTE;
     HRESULT hr = S_OK;
 
     LPWSTR pwzData = NULL;
 
-    if (WcaIsPropertySet(szPropertyName))
+    if (WcaIsUnicodePropertySet(wzPropertyName))
     {
         hr = WcaGetProperty(wzPropertyName, &pwzData);
         ExitOnFailure1(hr, "failed to get %ls", wzPropertyName);
@@ -120,9 +108,7 @@ LExit:
 }
 
 HRESULT ExecCommon(
-    __in LPCSTR szArgumentsProperty,
     __in LPCWSTR wzArgumentsProperty,
-    __in LPCSTR szTimeoutProperty,
     __in LPCWSTR wzTimeoutProperty,
     __in BOOL fLogCommand,
     __in BOOL fLogOutput
@@ -132,10 +118,10 @@ HRESULT ExecCommon(
     LPWSTR pwzCommand = NULL;
     DWORD dwTimeout = 0;
 
-    hr = BuildCommandLine(szArgumentsProperty, wzArgumentsProperty, &pwzCommand);
+    hr = BuildCommandLine(wzArgumentsProperty, &pwzCommand);
     ExitOnFailure(hr, "failed to get Command Line");
 
-    dwTimeout = GetTimeout(szTimeoutProperty, wzTimeoutProperty);
+    dwTimeout = GetTimeout(wzTimeoutProperty);
 
     hr = QuietExec(pwzCommand, dwTimeout, fLogCommand, fLogOutput);
     ExitOnFailure(hr, "QuietExec Failed");
@@ -147,9 +133,7 @@ LExit:
 }
 
 HRESULT ExecCommon64(
-    __in LPCSTR szArgumentsProperty,
     __in LPCWSTR wzArgumentsProperty,
-    __in LPCSTR szTimeoutProperty,
     __in LPCWSTR wzTimeoutProperty,
     __in BOOL fLogCommand,
     __in BOOL fLogOutput
@@ -173,10 +157,10 @@ HRESULT ExecCommon64(
     ExitOnFailure(hr, "failed to enable filesystem redirection.");
     fRedirected = TRUE;
 
-    hr = BuildCommandLine(szArgumentsProperty, wzArgumentsProperty, &pwzCommand);
+    hr = BuildCommandLine(wzArgumentsProperty, &pwzCommand);
     ExitOnFailure(hr, "failed to get Command Line");
 
-    dwTimeout = GetTimeout(szTimeoutProperty, wzTimeoutProperty);
+    dwTimeout = GetTimeout(wzTimeoutProperty);
 
     hr = QuietExec(pwzCommand, dwTimeout, fLogCommand, fLogOutput);
     ExitOnFailure(hr, "QuietExec64 Failed");
@@ -210,7 +194,7 @@ extern "C" UINT __stdcall CAQuietExec(
     hr = WcaInitialize(hInstall, "CAQuietExec");
     ExitOnFailure(hr, "failed to initialize");
 
-    hr = ExecCommon(CAQUIET_ARGUMENTS_PROPERTY, CAQUIET_ARGUMENTS_PROPERTY_WIDE, CAQUIET_TIMEOUT_PROPERTY, CAQUIET_TIMEOUT_PROPERTY_WIDE, TRUE, TRUE);
+    hr = ExecCommon(CAQUIET_ARGUMENTS_PROPERTY, CAQUIET_TIMEOUT_PROPERTY, TRUE, TRUE);
     ExitOnFailure(hr, "Failed in ExecCommon method");
 
 LExit:
@@ -234,8 +218,8 @@ extern "C" UINT __stdcall CAQuietExec64(
     hr = WcaInitialize(hInstall, "CAQuietExec64");
     ExitOnFailure(hr, "failed to initialize");
 
-    hr = ExecCommon64(CAQUIET64_ARGUMENTS_PROPERTY, CAQUIET64_ARGUMENTS_PROPERTY_WIDE, CAQUIET_TIMEOUT_PROPERTY, CAQUIET_TIMEOUT_PROPERTY_WIDE, TRUE, TRUE);
-    ExitOnFailure(hr, "Failed in ExecCommon method");
+    hr = ExecCommon64(CAQUIET64_ARGUMENTS_PROPERTY, CAQUIET_TIMEOUT_PROPERTY, TRUE, TRUE);
+    ExitOnFailure(hr, "Failed in  method");
 
 LExit:
     if (FAILED(hr))
@@ -257,7 +241,7 @@ extern "C" UINT __stdcall WixQuietExec(
     hr = WcaInitialize(hInstall, "WixQuietExec");
     ExitOnFailure(hr, "failed to initialize");
 
-    hr = ExecCommon(WIX_QUIET_ARGUMENTS_PROPERTY, WIX_QUIET_ARGUMENTS_PROPERTY_WIDE, WIX_QUIET_TIMEOUT_PROPERTY, WIX_QUIET_TIMEOUT_PROPERTY_WIDE, TRUE, TRUE);
+    hr = ExecCommon(WIX_QUIET_ARGUMENTS_PROPERTY, WIX_QUIET_TIMEOUT_PROPERTY, TRUE, TRUE);
     ExitOnFailure(hr, "Failed in ExecCommon method");
 
 LExit:
@@ -280,7 +264,7 @@ extern "C" UINT __stdcall WixQuietExec64(
     hr = WcaInitialize(hInstall, "WixQuietExec64");
     ExitOnFailure(hr, "failed to initialize");
 
-    hr = ExecCommon64(WIX_QUIET64_ARGUMENTS_PROPERTY, WIX_QUIET64_ARGUMENTS_PROPERTY_WIDE, WIX_QUIET64_TIMEOUT_PROPERTY, WIX_QUIET64_TIMEOUT_PROPERTY_WIDE, TRUE, TRUE);
+    hr = ExecCommon64(WIX_QUIET64_ARGUMENTS_PROPERTY, WIX_QUIET64_TIMEOUT_PROPERTY, TRUE, TRUE);
     ExitOnFailure(hr, "Failed in ExecCommon method");
 
 LExit:
@@ -303,7 +287,7 @@ extern "C" UINT __stdcall WixSilentExec(
     hr = WcaInitialize(hInstall, "WixSilentExec");
     ExitOnFailure(hr, "failed to initialize");
 
-    hr = ExecCommon(WIX_SILENT_ARGUMENTS_PROPERTY, WIX_SILENT_ARGUMENTS_PROPERTY_WIDE, WIX_SILENT_TIMEOUT_PROPERTY, WIX_SILENT_TIMEOUT_PROPERTY_WIDE, FALSE, FALSE);
+    hr = ExecCommon(WIX_SILENT_ARGUMENTS_PROPERTY, WIX_SILENT_TIMEOUT_PROPERTY, FALSE, FALSE);
     ExitOnFailure(hr, "Failed in ExecCommon method");
 
 LExit:
@@ -326,7 +310,7 @@ extern "C" UINT __stdcall WixSilentExec64(
     hr = WcaInitialize(hInstall, "WixSilentExec64");
     ExitOnFailure(hr, "failed to initialize");
 
-    hr = ExecCommon64(WIX_SILENT64_ARGUMENTS_PROPERTY, WIX_SILENT64_ARGUMENTS_PROPERTY_WIDE, WIX_SILENT64_TIMEOUT_PROPERTY, WIX_SILENT64_TIMEOUT_PROPERTY_WIDE, FALSE, FALSE);
+    hr = ExecCommon64(WIX_SILENT64_ARGUMENTS_PROPERTY, WIX_SILENT64_TIMEOUT_PROPERTY, FALSE, FALSE);
     ExitOnFailure(hr, "Failed in ExecCommon method");
 
 LExit:

--- a/src/ext/ca/wixca/dll/qtexecca.cpp
+++ b/src/ext/ca/wixca/dll/qtexecca.cpp
@@ -54,20 +54,20 @@ HRESULT BuildCommandLine(
         if (WcaIsPropertySet("CustomActionData"))
         {
             hr = WcaGetProperty( L"CustomActionData", ppwzCommand);
-            ExitOnFailure(hr, "failed to get CustomActionData");
+            ExitOnFailure(hr, "Failed to get CustomActionData");
         }
     }
     else if (WcaIsUnicodePropertySet(wzProperty))
     {
         hr = WcaGetFormattedProperty(wzProperty, ppwzCommand);
-        ExitOnFailure1(hr, "failed to get %ls", wzProperty);
+        ExitOnFailure(hr, "Failed to get %ls", wzProperty);
         hr = WcaSetProperty(wzProperty, L""); // clear out the property now that we've read it
-        ExitOnFailure1(hr, "failed to set %ls", wzProperty);
+        ExitOnFailure(hr, "Failed to set %ls", wzProperty);
     }
 
     if (!*ppwzCommand)
     {
-        ExitOnFailure(hr = E_INVALIDARG, "failed to get command line data");
+        ExitOnFailure(hr = E_INVALIDARG, "Failed to get command line data");
     }
 
     if (L'"' != **ppwzCommand)
@@ -92,7 +92,7 @@ DWORD GetTimeout(LPCWSTR wzPropertyName)
     if (WcaIsUnicodePropertySet(wzPropertyName))
     {
         hr = WcaGetProperty(wzPropertyName, &pwzData);
-        ExitOnFailure1(hr, "failed to get %ls", wzPropertyName);
+        ExitOnFailure(hr, "Failed to get %ls", wzPropertyName);
 
         if ((dwTimeout = (DWORD)_wtoi(pwzData)) == 0)
         {
@@ -119,7 +119,7 @@ HRESULT ExecCommon(
     DWORD dwTimeout = 0;
 
     hr = BuildCommandLine(wzArgumentsProperty, &pwzCommand);
-    ExitOnFailure(hr, "failed to get Command Line");
+    ExitOnFailure(hr, "Failed to get Command Line");
 
     dwTimeout = GetTimeout(wzTimeoutProperty);
 
@@ -150,15 +150,15 @@ HRESULT ExecCommon64(
     {
         hr = TYPE_E_DLLFUNCTIONNOTFOUND;
     }
-    ExitOnFailure(hr, "failed to intialize WOW64.");
+    ExitOnFailure(hr, "Failed to intialize WOW64.");
     fIsWow64Initialized = TRUE;
 
     hr = WcaDisableWow64FSRedirection();
-    ExitOnFailure(hr, "failed to enable filesystem redirection.");
+    ExitOnFailure(hr, "Failed to enable filesystem redirection.");
     fRedirected = TRUE;
 
     hr = BuildCommandLine(wzArgumentsProperty, &pwzCommand);
-    ExitOnFailure(hr, "failed to get Command Line");
+    ExitOnFailure(hr, "Failed to get Command Line");
 
     dwTimeout = GetTimeout(wzTimeoutProperty);
 
@@ -192,7 +192,7 @@ extern "C" UINT __stdcall CAQuietExec(
     UINT er = ERROR_SUCCESS;
 
     hr = WcaInitialize(hInstall, "CAQuietExec");
-    ExitOnFailure(hr, "failed to initialize");
+    ExitOnFailure(hr, "Failed to initialize");
 
     hr = ExecCommon(CAQUIET_ARGUMENTS_PROPERTY, CAQUIET_TIMEOUT_PROPERTY, TRUE, TRUE);
     ExitOnFailure(hr, "Failed in ExecCommon method");
@@ -216,10 +216,10 @@ extern "C" UINT __stdcall CAQuietExec64(
     UINT er = ERROR_SUCCESS;
 
     hr = WcaInitialize(hInstall, "CAQuietExec64");
-    ExitOnFailure(hr, "failed to initialize");
+    ExitOnFailure(hr, "Failed to initialize");
 
     hr = ExecCommon64(CAQUIET64_ARGUMENTS_PROPERTY, CAQUIET_TIMEOUT_PROPERTY, TRUE, TRUE);
-    ExitOnFailure(hr, "Failed in  method");
+    ExitOnFailure(hr, "Failed in ExecCommon64 method");
 
 LExit:
     if (FAILED(hr))
@@ -239,7 +239,7 @@ extern "C" UINT __stdcall WixQuietExec(
     UINT er = ERROR_SUCCESS;
 
     hr = WcaInitialize(hInstall, "WixQuietExec");
-    ExitOnFailure(hr, "failed to initialize");
+    ExitOnFailure(hr, "Failed to initialize");
 
     hr = ExecCommon(WIX_QUIET_ARGUMENTS_PROPERTY, WIX_QUIET_TIMEOUT_PROPERTY, TRUE, TRUE);
     ExitOnFailure(hr, "Failed in ExecCommon method");
@@ -262,7 +262,7 @@ extern "C" UINT __stdcall WixQuietExec64(
     UINT er = ERROR_SUCCESS;
 
     hr = WcaInitialize(hInstall, "WixQuietExec64");
-    ExitOnFailure(hr, "failed to initialize");
+    ExitOnFailure(hr, "Failed to initialize");
 
     hr = ExecCommon64(WIX_QUIET64_ARGUMENTS_PROPERTY, WIX_QUIET64_TIMEOUT_PROPERTY, TRUE, TRUE);
     ExitOnFailure(hr, "Failed in ExecCommon method");
@@ -285,7 +285,7 @@ extern "C" UINT __stdcall WixSilentExec(
     UINT er = ERROR_SUCCESS;
 
     hr = WcaInitialize(hInstall, "WixSilentExec");
-    ExitOnFailure(hr, "failed to initialize");
+    ExitOnFailure(hr, "Failed to initialize");
 
     hr = ExecCommon(WIX_SILENT_ARGUMENTS_PROPERTY, WIX_SILENT_TIMEOUT_PROPERTY, FALSE, FALSE);
     ExitOnFailure(hr, "Failed in ExecCommon method");
@@ -308,7 +308,7 @@ extern "C" UINT __stdcall WixSilentExec64(
     UINT er = ERROR_SUCCESS;
 
     hr = WcaInitialize(hInstall, "WixSilentExec64");
-    ExitOnFailure(hr, "failed to initialize");
+    ExitOnFailure(hr, "Failed to initialize");
 
     hr = ExecCommon64(WIX_SILENT64_ARGUMENTS_PROPERTY, WIX_SILENT64_TIMEOUT_PROPERTY, FALSE, FALSE);
     ExitOnFailure(hr, "Failed in ExecCommon method");

--- a/src/ext/ca/wixca/dll/wixca.def
+++ b/src/ext/ca/wixca/dll/wixca.def
@@ -32,6 +32,10 @@ EXPORTS
 ; qtexecca.cpp
     CAQuietExec
     CAQuietExec64
+    WixQuietExec
+    WixQuietExec64
+    WixSilentExec
+    WixSilentExec64
 ; RemoveFolders.cpp
     WixRemoveFoldersEx
 ; RestartManager.cpp

--- a/src/libs/wcautil/qtexec.cpp
+++ b/src/libs/wcautil/qtexec.cpp
@@ -52,12 +52,12 @@ static HRESULT CreatePipes(
     // Create pipes
     if (!::CreatePipe(&hOutTemp, &hOutWrite, &sa, 0))
     {
-        ExitOnLastError(hr, "failed to create output pipe");
+        ExitOnLastError(hr, "Failed to create output pipe");
     }
 
     if (!::CreatePipe(&hInRead, &hInTemp, &sa, 0))
     {
-        ExitOnLastError(hr, "failed to create input pipe");
+        ExitOnLastError(hr, "Failed to create input pipe");
     }
 
 
@@ -65,19 +65,19 @@ static HRESULT CreatePipes(
     // the same pipe
     if (!::DuplicateHandle(::GetCurrentProcess(), hOutWrite, ::GetCurrentProcess(), &hErrWrite, 0, TRUE, DUPLICATE_SAME_ACCESS))
     {
-        ExitOnLastError(hr, "failed to duplicate write handle");
+        ExitOnLastError(hr, "Failed to duplicate write handle");
     }
 
     // We need to create new output read and input write handles that are
     // non inheritable.  Otherwise it creates handles that can't be closed.
     if (!::DuplicateHandle(::GetCurrentProcess(), hOutTemp, ::GetCurrentProcess(), &hOutRead, 0, FALSE, DUPLICATE_SAME_ACCESS))
     {
-        ExitOnLastError(hr, "failed to duplicate output pipe");
+        ExitOnLastError(hr, "Failed to duplicate output pipe");
     }
 
     if (!::DuplicateHandle(::GetCurrentProcess(), hInTemp, ::GetCurrentProcess(), &hInWrite, 0, FALSE, DUPLICATE_SAME_ACCESS))
     {
-        ExitOnLastError(hr, "failed to duplicate input pipe");
+        ExitOnLastError(hr, "Failed to duplicate input pipe");
     }
 
     // now that everything has succeeded, assign to the outputs
@@ -157,14 +157,14 @@ static HRESULT HandleOutput(
             if (bUnicode)
             {
                 hr = StrAllocConcat(&szLog, (LPCWSTR)pBuffer, 0);
-                ExitOnFailure(hr, "failed to concatenate output strings");
+                ExitOnFailure(hr, "Failed to concatenate output strings");
             }
             else
             {
                 hr = StrAllocStringAnsi(&szTemp, (LPCSTR)pBuffer, 0, CP_OEMCP);
-                ExitOnFailure(hr, "failed to allocate output string");
+                ExitOnFailure(hr, "Failed to allocate output string");
                 hr = StrAllocConcat(&szLog, szTemp, 0);
-                ExitOnFailure(hr, "failed to concatenate output strings");
+                ExitOnFailure(hr, "Failed to concatenate output strings");
             }
 
             // Log each line of the output
@@ -192,7 +192,7 @@ static HRESULT HandleOutput(
                 ExitOnFailure(hr, "Failed to escape percent signs in string");
 
                 hr = StrAnsiAllocString(&szWrite, sczEscaped, 0, CP_OEMCP);
-                ExitOnFailure(hr, "failed to convert output to ANSI");
+                ExitOnFailure(hr, "Failed to convert output to ANSI");
                 WcaLog(LOGMSG_STANDARD, szWrite);
 
                 // Next line
@@ -205,10 +205,10 @@ static HRESULT HandleOutput(
             }
 
             hr = StrAllocString(&szTemp, pNext, 0);
-            ExitOnFailure(hr, "failed to allocate string");
+            ExitOnFailure(hr, "Failed to allocate string");
 
             hr = StrAllocString(&szLog, szTemp, 0);
-            ExitOnFailure(hr, "failed to allocate string");
+            ExitOnFailure(hr, "Failed to allocate string");
         }
     }
 
@@ -219,7 +219,7 @@ static HRESULT HandleOutput(
         ExitOnFailure(hr, "Failed to escape percent signs in string");
 
         hr = StrAnsiAllocString(&szWrite, szLog, 0, CP_OEMCP);
-        ExitOnFailure(hr, "failed to convert output to ANSI");
+        ExitOnFailure(hr, "Failed to convert output to ANSI");
 
         WcaLog(LOGMSG_VERBOSE, szWrite);
     }
@@ -257,7 +257,7 @@ HRESULT WIXAPI QuietExec(
 
     // Create output redirect pipes
     hr = CreatePipes(&hOutRead, &hOutWrite, &hErrWrite, &hInRead, &hInWrite);
-    ExitOnFailure(hr, "failed to create output pipes");
+    ExitOnFailure(hr, "Failed to create output pipes");
 
     // Set up startup structure
     oStartInfo.cb = sizeof(STARTUPINFOW);

--- a/src/libs/wcautil/qtexec.cpp
+++ b/src/libs/wcautil/qtexec.cpp
@@ -291,7 +291,7 @@ HRESULT WIXAPI QuietExec(
         ReleaseFile(hErrWrite);
         ReleaseFile(hInRead);
 
-        // Log output if we were asked to do so
+        // Log output if we were asked to do so; otherwise just read the output handle
         HandleOutput(fLogOutput, hOutRead);
 
         // Wait for everything to finish

--- a/src/libs/wcautil/qtexec.cpp
+++ b/src/libs/wcautil/qtexec.cpp
@@ -108,7 +108,7 @@ LExit:
     return hr;
 }
 
-static HRESULT LogOutput(
+static HRESULT HandleOutput(
     __in BOOL fLogOutput,
     __in HANDLE hRead
     )
@@ -292,7 +292,7 @@ HRESULT WIXAPI QuietExec(
         ReleaseFile(hInRead);
 
         // Log output if we were asked to do so
-        LogOutput(fLogOutput, hOutRead);
+        HandleOutput(fLogOutput, hOutRead);
 
         // Wait for everything to finish
         ::WaitForSingleObject(oProcInfo.hProcess, dwTimeout);

--- a/src/libs/wcautil/qtexec.cpp
+++ b/src/libs/wcautil/qtexec.cpp
@@ -233,7 +233,9 @@ LExit:
 
 HRESULT WIXAPI QuietExec(
     __inout_z LPWSTR wzCommand,
-    __in DWORD dwTimeout
+    __in DWORD dwTimeout,
+    __in BOOL fLogCommand,
+    __in BOOL fLogOutput
     )
 {
     HRESULT hr = S_OK;
@@ -260,7 +262,11 @@ HRESULT WIXAPI QuietExec(
     oStartInfo.hStdOutput = hOutWrite;
     oStartInfo.hStdError = hErrWrite;
 
-    WcaLog(LOGMSG_VERBOSE, "%ls", wzCommand);
+    // Log command if we were asked to do so
+    if (fLogCommand)
+    {
+        WcaLog(LOGMSG_VERBOSE, "%ls", wzCommand);
+    }
 
 #pragma prefast(suppress:25028)
     if (::CreateProcessW(NULL,
@@ -281,8 +287,11 @@ HRESULT WIXAPI QuietExec(
         ReleaseFile(hErrWrite);
         ReleaseFile(hInRead);
 
-        // Log output
-        LogOutput(hOutRead);
+        // Log output if we were asked to do so
+        if (fLogOutput)
+        {
+            LogOutput(hOutRead);
+        }
 
         // Wait for everything to finish
         ::WaitForSingleObject(oProcInfo.hProcess, dwTimeout);

--- a/src/libs/wcautil/wcautil.h
+++ b/src/libs/wcautil/wcautil.h
@@ -360,7 +360,9 @@ void WIXAPI WcaCaScriptCleanup(
 
 HRESULT WIXAPI QuietExec(
     __inout_z LPWSTR wzCommand,
-    __in DWORD dwTimeout
+    __in DWORD dwTimeout,
+    __in BOOL fLogCommand,
+    __in BOOL fLogOutput
     );
 
 WCA_TODO WIXAPI WcaGetComponentToDo(


### PR DESCRIPTION
QuietExec outputs both the command and the standard output to the log, which is problematic if you are passing in a password or similar. The new SilentExec custom action allows one to run an executable without outputting the command or the standard output of the program.

Also, provide a new, more consistent name for quiet exec functionality (WixQuietExec instead of CAQuietExec). It behaves no different than the old name, and the old name still works.