### PR TITLE
Issue4727

### DIFF
--- a/src/tools/wix/Data/messages.xml
+++ b/src/tools/wix/Data/messages.xml
@@ -793,7 +793,7 @@
         </Message>
         <Message Id="IllegalAttributeWhenNested" Number="62">
             <Instance>
-                The {0}/@{1} attribute cannot be specified when the {0} element is nested underneath a {2} element.
+                The {0}/@{1} attribute cannot be specified when the {0} element is nested underneath a {2} element. If this {0} is a member of a ComponentGroup where ComponentGroup/@{1} is set, then the {0}/@{1} attribute should be removed.
                 <Parameter Type="System.String" Name="elementName" />
                 <Parameter Type="System.String" Name="attributeName" />
                 <Parameter Type="System.String" Name="parentElement" />


### PR DESCRIPTION
Additional error text to explain the situation when the Component is not actually contained by a directory, but is contained by a ComponentGroup with a Directory attribute.