### PR TITLE
Implement ExePackage/CommandLine.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+* BobArnson: WIXFEAT:4719 - Implement ExePackage/CommandLine:
+  * Add WixBundleExecutePackageAction variable: Set to the BOOTSTRAPPER_ACTION_STATE of the package as it's about to executed.
+  * Add ExePackage/CommandLine to compiler and binder.
+  * Update Burn to parse CommandLine table in manifest and apply it during ExePackage execution.
+
 * SeanHall: WIXFEAT:4619 - Include WixUI dialogs and wxl files in core MSI.
 
 * SeanHall: WIXFEAT:4618 - Include WixStdBA and mbapreq themes and wxl files in core MSI.

--- a/src/burn/engine/core.h
+++ b/src/burn/engine/core.h
@@ -47,6 +47,7 @@ const LPCWSTR BURN_BUNDLE_LAYOUT_DIRECTORY = L"WixBundleLayoutDirectory";
 const LPCWSTR BURN_BUNDLE_ACTION = L"WixBundleAction";
 const LPCWSTR BURN_BUNDLE_ACTIVE_PARENT = L"WixBundleActiveParent";
 const LPCWSTR BURN_BUNDLE_EXECUTE_PACKAGE_CACHE_FOLDER = L"WixBundleExecutePackageCacheFolder";
+const LPCWSTR BURN_BUNDLE_EXECUTE_PACKAGE_ACTION = L"WixBundleExecutePackageAction";
 const LPCWSTR BURN_BUNDLE_FORCED_RESTART_PACKAGE = L"WixBundleForcedRestartPackage";
 const LPCWSTR BURN_BUNDLE_INSTALLED = L"WixBundleInstalled";
 const LPCWSTR BURN_BUNDLE_ELEVATED = L"WixBundleElevated";

--- a/src/burn/engine/msiengine.cpp
+++ b/src/burn/engine/msiengine.cpp
@@ -1157,6 +1157,9 @@ extern "C" HRESULT MsiEngineExecutePackage(
         ExitOnFailure(hr, "Failed to build MSI path.");
     }
 
+    // Best effort to set the execute package action variable.
+    VariableSetNumeric(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_ACTION, pExecuteAction->msiPackage.action, TRUE);
+    
     // Wire up the external UI handler and logging.
     hr = WiuInitializeExternalUI(pfnMessageHandler, pExecuteAction->msiPackage.uiLevel, hwndParent, pvContext, fRollback, &context);
     ExitOnFailure(hr, "Failed to initialize external UI handler.");
@@ -1290,8 +1293,9 @@ LExit:
             break;
     }
 
-    // Best effort to clear the execute package cache folder variable.
+    // Best effort to clear the execute package cache folder and action variables.
     VariableSetString(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_CACHE_FOLDER, NULL, TRUE);
+    VariableSetString(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_ACTION, NULL, TRUE);
 
     return hr;
 }

--- a/src/burn/engine/mspengine.cpp
+++ b/src/burn/engine/mspengine.cpp
@@ -503,6 +503,7 @@ extern "C" HRESULT MspEngineExecutePackage(
             hr = CacheGetCompletedPath(pMspPackage->fPerMachine, pMspPackage->sczCacheId, &sczCachedDirectory);
             ExitOnFailure1(hr, "Failed to get cached path for MSP package: %ls", pMspPackage->sczId);
 
+            // TODO: Figure out if this makes sense -- the variable is set to the last patch's path only
             // Best effort to set the execute package cache folder variable.
             VariableSetString(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_CACHE_FOLDER, sczCachedDirectory, TRUE);
 
@@ -525,6 +526,9 @@ extern "C" HRESULT MspEngineExecutePackage(
         hr = StrAllocConcat(&sczPatches, wzAppend, 0);
         ExitOnFailure(hr, "Failed to append patch.");
     }
+
+    // Best effort to set the execute package action variable.
+    VariableSetNumeric(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_ACTION, pExecuteAction->mspTarget.action, TRUE);
 
     // Wire up the external UI handler and logging.
     hr = WiuInitializeExternalUI(pfnMessageHandler, uiLevel, hwndParent, pvContext, fRollback, &context);
@@ -607,8 +611,9 @@ LExit:
             break;
     }
 
-    // Best effort to clear the execute package cache folder variable.
+    // Best effort to clear the execute package cache folder and action variables.
     VariableSetString(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_CACHE_FOLDER, NULL, TRUE);
+    VariableSetString(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_ACTION, NULL, TRUE);
 
     return hr;
 }

--- a/src/burn/engine/package.h
+++ b/src/burn/engine/package.h
@@ -88,6 +88,14 @@ typedef struct _BURN_EXE_EXIT_CODE
     BOOL fWildcard;
 } BURN_EXE_EXIT_CODE;
 
+typedef struct _BURN_EXE_COMMAND_LINE_ARGUMENT
+{
+    LPWSTR sczInstallArgument;
+    LPWSTR sczUninstallArgument;
+    LPWSTR sczRepairArgument;
+    LPWSTR sczCondition;
+} BURN_EXE_COMMAND_LINE_ARGUMENT;
+
 typedef struct _BURN_MSPTARGETPRODUCT
 {
     MSIINSTALLCONTEXT context;
@@ -228,6 +236,9 @@ typedef struct _BURN_PACKAGE
 
             BURN_EXE_EXIT_CODE* rgExitCodes;
             DWORD cExitCodes;
+
+            BURN_EXE_COMMAND_LINE_ARGUMENT* rgCommandLineArguments;
+            DWORD cCommandLineArguments;
         } Exe;
         struct
         {

--- a/src/burn/engine/variable.cpp
+++ b/src/burn/engine/variable.cpp
@@ -262,6 +262,7 @@ extern "C" HRESULT VariableInitialize(
         {L"WindowsVolume", InitializeVariableWindowsVolumeFolder, 0},
         {BURN_BUNDLE_ACTION, InitializeVariableNumeric, 0},
         {BURN_BUNDLE_EXECUTE_PACKAGE_CACHE_FOLDER, InitializeVariableString, NULL},
+        {BURN_BUNDLE_EXECUTE_PACKAGE_ACTION, InitializeVariableNumeric, 0},
         {BURN_BUNDLE_FORCED_RESTART_PACKAGE, InitializeVariableString, NULL, TRUE},
         {BURN_BUNDLE_INSTALLED, InitializeVariableNumeric, 0},
         {BURN_BUNDLE_ELEVATED, InitializeVariableNumeric, 0},

--- a/src/burn/engine/variable.cpp
+++ b/src/burn/engine/variable.cpp
@@ -262,7 +262,7 @@ extern "C" HRESULT VariableInitialize(
         {L"WindowsVolume", InitializeVariableWindowsVolumeFolder, 0},
         {BURN_BUNDLE_ACTION, InitializeVariableNumeric, 0},
         {BURN_BUNDLE_EXECUTE_PACKAGE_CACHE_FOLDER, InitializeVariableString, NULL},
-        {BURN_BUNDLE_EXECUTE_PACKAGE_ACTION, InitializeVariableNumeric, 0},
+        {BURN_BUNDLE_EXECUTE_PACKAGE_ACTION, InitializeVariableString, NULL},
         {BURN_BUNDLE_FORCED_RESTART_PACKAGE, InitializeVariableString, NULL, TRUE},
         {BURN_BUNDLE_INSTALLED, InitializeVariableNumeric, 0},
         {BURN_BUNDLE_ELEVATED, InitializeVariableNumeric, 0},

--- a/src/tools/wix/Binder.cs
+++ b/src/tools/wix/Binder.cs
@@ -3744,6 +3744,26 @@ namespace Microsoft.Tools.WindowsInstallerXml
                 }
             }
 
+            // Load the CommandLine information...
+            Table commandLineTable = bundle.Tables["WixCommandLine"];
+            if (null != commandLineTable && 0 < commandLineTable.Rows.Count)
+            {
+                foreach (Row row in commandLineTable.Rows)
+                {
+                    CommandLineInfo commandLine = new CommandLineInfo(row);
+
+                    ChainPackageInfo package;
+                    if (allPackages.TryGetValue(commandLine.PackageId, out package))
+                    {
+                        package.CommandLines.Add(commandLine);
+                    }
+                    else
+                    {
+                        core.OnMessage(WixErrors.IdentifierNotFound("Package", commandLine.PackageId));
+                    }
+                }
+            }
+
             // Resolve any delayed fields before generating the manifest.
             if (0 < delayedFields.Count)
             {
@@ -4608,6 +4628,16 @@ namespace Microsoft.Tools.WindowsInstallerXml
                         writer.WriteStartElement("ExitCode");
                         writer.WriteAttributeString("Type", exitCode.Type);
                         writer.WriteAttributeString("Code", exitCode.Code);
+                        writer.WriteEndElement();
+                    }
+
+                    foreach (CommandLineInfo commandLine in package.CommandLines)
+                    {
+                        writer.WriteStartElement("CommandLine");
+                        writer.WriteAttributeString("InstallArgument", commandLine.InstallArgument);
+                        writer.WriteAttributeString("UninstallArgument", commandLine.UninstallArgument);
+                        writer.WriteAttributeString("RepairArgument", commandLine.RepairArgument);
+                        writer.WriteAttributeString("Condition", commandLine.Condition);
                         writer.WriteEndElement();
                     }
 

--- a/src/tools/wix/ChainPackageInfo.cs
+++ b/src/tools/wix/ChainPackageInfo.cs
@@ -170,6 +170,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
             this.MsiProperties = new List<MsiPropertyInfo>();
             this.SlipstreamMsps = new List<string>();
             this.ExitCodes = new List<ExitCodeInfo>();
+            this.CommandLines = new List<CommandLineInfo>();
             this.Provides = new ProvidesDependencyCollection();
             this.TargetCodes = new RowDictionary<WixBundlePatchTargetCodeRow>();
 
@@ -569,6 +570,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
         public List<MsiPropertyInfo> MsiProperties { get; private set; }
         public List<string> SlipstreamMsps { get; private set; }
         public List<ExitCodeInfo> ExitCodes { get; private set; }
+        public List<CommandLineInfo> CommandLines { get; private set; }
         public ProvidesDependencyCollection Provides { get; private set; }
         public RowDictionary<WixBundlePatchTargetCodeRow> TargetCodes { get; private set; }
         public bool TargetUnspecified { get; private set; }

--- a/src/tools/wix/ChainPackageInfo.cs
+++ b/src/tools/wix/ChainPackageInfo.cs
@@ -170,7 +170,6 @@ namespace Microsoft.Tools.WindowsInstallerXml
             this.MsiProperties = new List<MsiPropertyInfo>();
             this.SlipstreamMsps = new List<string>();
             this.ExitCodes = new List<ExitCodeInfo>();
-            this.CommandLines = new List<CommandLineInfo>();
             this.Provides = new ProvidesDependencyCollection();
             this.TargetCodes = new RowDictionary<WixBundlePatchTargetCodeRow>();
 
@@ -570,7 +569,6 @@ namespace Microsoft.Tools.WindowsInstallerXml
         public List<MsiPropertyInfo> MsiProperties { get; private set; }
         public List<string> SlipstreamMsps { get; private set; }
         public List<ExitCodeInfo> ExitCodes { get; private set; }
-        public List<CommandLineInfo> CommandLines { get; private set; }
         public ProvidesDependencyCollection Provides { get; private set; }
         public RowDictionary<WixBundlePatchTargetCodeRow> TargetCodes { get; private set; }
         public bool TargetUnspecified { get; private set; }

--- a/src/tools/wix/CommandLineInfo.cs
+++ b/src/tools/wix/CommandLineInfo.cs
@@ -1,0 +1,43 @@
+﻿//-------------------------------------------------------------------------------------------------
+// <copyright file="CommandLineInfo.cs" company="Outercurve Foundation">
+//   Copyright (c) 2004, Outercurve Foundation.
+//   This software is released under Microsoft Reciprocal License (MS-RL).
+//   The license and further copyright text can be found in the file
+//   LICENSE.TXT at the root directory of the distribution.
+// </copyright>
+// 
+// <summary>
+// Utility class for Burn ExePackage CommandLine information.
+// </summary>
+//-------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Tools.WindowsInstallerXml
+{
+    using System;
+
+    /// <summary>
+    /// Utility class for Burn CommandLine information.
+    /// </summary>
+    internal class CommandLineInfo
+    {
+        public CommandLineInfo(Row row)
+            : this((string)row[0], (string)row[1], (string)row[2], (string)row[3], (string)row[4])
+        {
+        }
+
+        public CommandLineInfo(string packageId, string installCommand, string uninstallCommand, string repairCommand, string condition)
+        {
+            this.PackageId = packageId;
+            this.InstallArgument = installCommand;
+            this.UninstallArgument = uninstallCommand;
+            this.RepairArgument = repairCommand;
+            this.Condition = condition;
+        }
+
+        public string PackageId { get; private set; }
+        public string InstallArgument { get; private set; }
+        public string UninstallArgument { get; private set; }
+        public string RepairArgument { get; private set; }
+        public string Condition { get; private set; }
+    }
+}

--- a/src/tools/wix/Compiler.cs
+++ b/src/tools/wix/Compiler.cs
@@ -21947,7 +21947,6 @@ namespace Microsoft.Tools.WindowsInstallerXml
                 }
             }
 
-            // TODO: Consider whether we want to support conditionless
             if (String.IsNullOrEmpty(condition))
             {
                 this.core.OnMessage(WixErrors.ExpectedAttribute(sourceLineNumbers, node.Name, "Condition"));

--- a/src/tools/wix/Compiler.cs
+++ b/src/tools/wix/Compiler.cs
@@ -21099,7 +21099,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
                             behavior = this.core.GetAttributeValue(sourceLineNumbers, attrib);
                             break;
                         default:
-                            // hygene: throw an exception if there are any unknown attributes
+                            // hygiene: throw an exception if there are any unknown attributes
                             this.core.UnexpectedAttribute(sourceLineNumbers, attrib);
                             break;
                     }
@@ -21115,7 +21115,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
                 this.core.OnMessage(WixErrors.ExpectedAttribute(sourceLineNumbers, node.Name, "Behavior"));
             }
 
-            // hygene: throw an exception if there are any subelements
+            // hygiene: throw an exception if there are any subelements
             foreach (XmlNode child in node.ChildNodes)
             {
                 if (XmlNodeType.Element == child.NodeType)
@@ -21776,6 +21776,13 @@ namespace Microsoft.Tools.WindowsInstallerXml
                                     this.ParseExitCodeElement(child, id);
                                 }
                                 break;
+                            case "CommandLine":
+                                allowed = (packageType == ChainPackageType.Exe);
+                                if (allowed)
+                                {
+                                    this.ParseCommandLineElement(child, id);
+                                }
+                                break;
                             case "RemotePayload":
                                 // Handled previously
                                 break;
@@ -21896,6 +21903,81 @@ namespace Microsoft.Tools.WindowsInstallerXml
                 this.CreateChainPackageMetaRows(sourceLineNumbers, parentType, parentId, ComplexReferenceChildType.Package, id, previousType, previousId, after);
             }
             return id;
+        }
+
+        /// <summary>
+        /// Parse CommandLine element.
+        /// </summary>
+        /// <param name="node">Element to parse</param>
+        private void ParseCommandLineElement(XmlNode node, string packageId)
+        {
+            SourceLineNumberCollection sourceLineNumbers = Preprocessor.GetSourceLineNumbers(node);
+            string installArgument = null;
+            string uninstallArgument = null;
+            string repairArgument = null;
+            string condition = null;
+
+            foreach (XmlAttribute attrib in node.Attributes)
+            {
+                if (0 == attrib.NamespaceURI.Length || attrib.NamespaceURI == this.schema.TargetNamespace)
+                {
+                    switch (attrib.LocalName)
+                    {
+                        case "InstallArgument":
+                            installArgument = this.core.GetAttributeValue(sourceLineNumbers, attrib);
+                            break;
+                        case "UninstallArgument":
+                            uninstallArgument = this.core.GetAttributeValue(sourceLineNumbers, attrib);
+                            break;
+                        case "RepairArgument":
+                            repairArgument = this.core.GetAttributeValue(sourceLineNumbers, attrib);
+                            break;
+                        case "Condition":
+                            condition = this.core.GetAttributeValue(sourceLineNumbers, attrib);
+                            break;
+                        default:
+                            // hygiene: throw an exception if there are any unknown attributes
+                            this.core.UnexpectedAttribute(sourceLineNumbers, attrib);
+                            break;
+                    }
+                }
+                else
+                {
+                    this.core.UnsupportedExtensionAttribute(sourceLineNumbers, attrib);
+                }
+            }
+
+            // TODO: Consider whether we want to support conditionless
+            if (String.IsNullOrEmpty(condition))
+            {
+                this.core.OnMessage(WixErrors.ExpectedAttribute(sourceLineNumbers, node.Name, "Condition"));
+            }
+
+            // hygiene: throw an exception if there are any subelements
+            foreach (XmlNode child in node.ChildNodes)
+            {
+                if (XmlNodeType.Element == child.NodeType)
+                {
+                    if (child.NamespaceURI == this.schema.TargetNamespace)
+                    {
+                        this.core.UnexpectedElement(node, child);
+                    }
+                    else
+                    {
+                        this.core.UnsupportedExtensionElement(node, child);
+                    }
+                }
+            }
+
+            if (!this.core.EncounteredError)
+            {
+                Row row = this.core.CreateRow(sourceLineNumbers, "WixCommandLine");
+                row[0] = packageId;
+                row[1] = installArgument;
+                row[2] = uninstallArgument;
+                row[3] = repairArgument;
+                row[4] = condition;
+            }
         }
 
         /// <summary>

--- a/src/tools/wix/Data/tables.xml
+++ b/src/tools/wix/Data/tables.xml
@@ -1790,6 +1790,14 @@
         <columnDefinition name="ChainPackage_Msp" type="string" length="0" category="identifier" primaryKey="yes"
                 keyTable="ChainPackage" keyColumn="1" description="Reference to a ChainPackage entry in the ChainPackage table for the referenced Msp." />
     </tableDefinition>
+    <tableDefinition name="WixCommandLine" unreal="yes">
+        <columnDefinition name="ChainPackage_" type="string" length="0" category="identifier" 
+                keyTable="ChainPackage" keyColumn="1" description="Reference to a ChainPackage entry in the ChainPackage table."/>
+        <columnDefinition name="InstallArgument" type="string" length="0" nullable="yes" />
+        <columnDefinition name="UninstallArgument" type="string" length="0" nullable="yes" />
+        <columnDefinition name="RepairArgument" type="string" length="0" nullable="yes" />
+        <columnDefinition name="Condition" type="string" length="0" nullable="yes" />
+    </tableDefinition>
     <tableDefinition name="RelatedBundle" unreal="yes">
         <columnDefinition name="Id" type="string" length="38" category="guid" primaryKey="yes" />
         <columnDefinition name="Action" type="number" length="4" />

--- a/src/tools/wix/Table.cs
+++ b/src/tools/wix/Table.cs
@@ -178,6 +178,9 @@ namespace Microsoft.Tools.WindowsInstallerXml
                 case "WixCatalog":
                     row = new WixCatalogRow(sourceLineNumbers, this);
                     break;
+                case "WixCommandLine":
+                    row = new WixCommandLineRow(sourceLineNumbers, this);
+                    break;
                 case "WixComplexReference":
                     row = new WixComplexReferenceRow(sourceLineNumbers, this);
                     break;

--- a/src/tools/wix/Wix.csproj
+++ b/src/tools/wix/Wix.csproj
@@ -48,7 +48,6 @@
     <Compile Include="ColumnDefinition.cs" />
     <Compile Include="ColumnDefinitionCollection.cs" />
     <Compile Include="CommandLine.cs" />
-    <Compile Include="CommandLineInfo.cs" />
     <Compile Include="Common.cs" />
     <Compile Include="Compiler.cs" />
     <Compile Include="CompilerCore.cs" />
@@ -169,6 +168,7 @@
     <Compile Include="VerifyInterop.cs" />
     <Compile Include="WarningEventArgs.cs" />
     <Compile Include="AppCommon.cs" />
+    <Compile Include="WixCommandLineRow.cs" />
     <Compile Include="WixExtension.cs" />
     <Compile Include="WixFileRow.cs" />
     <Compile Include="WixGenericMessageEventArgs.cs" />

--- a/src/tools/wix/Wix.csproj
+++ b/src/tools/wix/Wix.csproj
@@ -48,6 +48,7 @@
     <Compile Include="ColumnDefinition.cs" />
     <Compile Include="ColumnDefinitionCollection.cs" />
     <Compile Include="CommandLine.cs" />
+    <Compile Include="CommandLineInfo.cs" />
     <Compile Include="Common.cs" />
     <Compile Include="Compiler.cs" />
     <Compile Include="CompilerCore.cs" />
@@ -272,12 +273,10 @@
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
   </ItemGroup>
-  
   <ItemGroup>
     <ProjectReference Include="..\..\dtf\Libraries\Resources\Resources.csproj" />
     <ProjectReference Include="..\..\dtf\Libraries\WindowsInstaller\WindowsInstaller.csproj" />
     <ProjectReference Include="..\winterop\winterop.vcxproj" />
   </ItemGroup>
-  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), wix.proj))\tools\WixBuild.targets" />
 </Project>

--- a/src/tools/wix/WixCommandLineRow.cs
+++ b/src/tools/wix/WixCommandLineRow.cs
@@ -1,0 +1,89 @@
+﻿//-------------------------------------------------------------------------------------------------
+// <copyright file="WixCommandLineRow.cs" company="Outercurve Foundation">
+//   Copyright (c) 2004, Outercurve Foundation.
+//   This software is released under Microsoft Reciprocal License (MS-RL).
+//   The license and further copyright text can be found in the file
+//   LICENSE.TXT at the root directory of the distribution.
+// </copyright>
+//-------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Tools.WindowsInstallerXml
+{
+    using System;
+
+    /// <summary>
+    /// Specialization of a row for the WixCommandLineRow table.
+    /// </summary>
+    public class WixCommandLineRow : Row
+    {
+        /// <summary>
+        /// Creates a WixCommandLineRow row that does not belong to a table.
+        /// </summary>
+        /// <param name="sourceLineNumbers">Original source lines for this row.</param>
+        /// <param name="tableDef">TableDefinition this WixCommandLineRow row belongs to and should get its column definitions from.</param>
+        public WixCommandLineRow(SourceLineNumberCollection sourceLineNumbers, TableDefinition tableDef) :
+            base(sourceLineNumbers, tableDef)
+        {
+        }
+
+        /// <summary>
+        /// Creates an WixCommandLineRow row that belongs to a table.
+        /// </summary>
+        /// <param name="sourceLineNumbers">Original source lines for this row.</param>
+        /// <param name="table">Table this WixCommandLineRow row belongs to and should get its column definitions from.</param>
+        public WixCommandLineRow(SourceLineNumberCollection sourceLineNumbers, Table table)
+            : base(sourceLineNumbers, table)
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the package identifier.
+        /// </summary>
+        /// <value>The package identifier.</value>
+        public string PackageId
+        {
+            get { return (string)this.Fields[0].Data; }
+            set { this.Fields[0].Data = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the command-line argument for installation.
+        /// </summary>
+        /// <value>The command-line argument.</value>
+        public string InstallArgument
+        {
+            get { return (string)this.Fields[1].Data; }
+            set { this.Fields[1].Data = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the command-line argument for uninstallation.
+        /// </summary>
+        /// <value>The command-line argument.</value>
+        public string UninstallArgument
+        {
+            get { return (string)this.Fields[2].Data; }
+            set { this.Fields[2].Data = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the command-line argument for repair.
+        /// </summary>
+        /// <value>The command-line argument.</value>
+        public string RepairArgument
+        {
+            get { return (string)this.Fields[3].Data; }
+            set { this.Fields[3].Data = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the condition.
+        /// </summary>
+        /// <value>The condition.</value>
+        public string Condition
+        {
+            get { return (string)this.Fields[4].Data; }
+            set { this.Fields[4].Data = value; }
+        }
+    }
+}

--- a/src/tools/wix/Xsd/wix.xsd
+++ b/src/tools/wix/Xsd/wix.xsd
@@ -760,6 +760,7 @@
         <xs:element ref="PayloadGroupRef" />
         <xs:element ref="RemotePayload" />
         <xs:element ref="ExitCode" />
+        <xs:element ref="CommandLine" />
         <xs:any namespace="##other" processContents="lax">
           <xs:annotation>
             <xs:documentation>
@@ -1229,6 +1230,43 @@
             <xs:enumeration value="forceReboot" />
           </xs:restriction>
         </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="CommandLine">
+    <xs:annotation>
+      <xs:documentation>Describes additional, conditional command-line arguments for an ExePackage.</xs:documentation>
+      <xs:appinfo>
+        <xse:parent namespace="http://schemas.microsoft.com/wix/2006/wi" ref="ExePackage" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="InstallArgument" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Additional command-line arguments to apply during package installation if Condition is true.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="UninstallArgument" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Additional command-line arguments to apply during package uninstallation if Condition is true.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="RepairArgument" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Additional command-line arguments to apply during package repair if Condition is true.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Condition" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+              The condition that controls whether the command-line arguments specified in the
+              InstallArgument, UninstallArgument, or RepairArgument attributes are appended to the
+              command line passed to the ExePackage. Which attribute is used depends on the
+              action being applied to the ExePackage. For example, when the ExePackage is
+              being installed, the InstallArgument attribute value is appended to the command
+              line when the ExePackage is executed.
+          </xs:documentation>
+        </xs:annotation>
       </xs:attribute>
     </xs:complexType>
   </xs:element>

--- a/src/tools/wix/Xsd/wix.xsd
+++ b/src/tools/wix/Xsd/wix.xsd
@@ -1236,9 +1236,6 @@
   <xs:element name="CommandLine">
     <xs:annotation>
       <xs:documentation>Describes additional, conditional command-line arguments for an ExePackage.</xs:documentation>
-      <xs:appinfo>
-        <xse:parent namespace="http://schemas.microsoft.com/wix/2006/wi" ref="ExePackage" />
-      </xs:appinfo>
     </xs:annotation>
     <xs:complexType>
       <xs:attribute name="InstallArgument" type="xs:string">


### PR DESCRIPTION
- Add WixBundleExecutePackageAction variable: Set to the BOOTSTRAPPER_ACTION_STATE of the package as it's about to executed.
- Add ExePackage/CommandLine to compiler and binder.
- Update Burn to parse CommandLine table in manifest and apply it during ExePackage execution.