### PR TITLE
WIXBUG:4732 - fix documentation links.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* RobMen: WIXBUG:4732 - fix documentation links to MsiServiceConfig and MsiServiceConfigFailureActions.
+
 * BobArnson: WIXFEAT:4719 - Implement ExePackage/CommandLine:
   * Add WixBundleExecutePackageAction variable: Set to the BOOTSTRAPPER_ACTION_STATE of the package as it's about to executed.
   * Add ExePackage/CommandLine to compiler and binder.

--- a/src/tools/wix/Xsd/wix.xsd
+++ b/src/tools/wix/Xsd/wix.xsd
@@ -6966,7 +6966,7 @@
                 Formatted property that resolves to a privilege constant.
             </xs:documentation>
       <xs:appinfo>
-        <xse:msiRef table="MsiServiceConfig" href="http://msdn.microsoft.com/library/aa371634.aspx" />
+        <xse:msiRef table="MsiServiceConfig" href="http://msdn.microsoft.com/en-us/library/windows/desktop/dd408038.aspx" />
       </xs:appinfo>
     </xs:annotation>
   </xs:element>
@@ -7092,7 +7092,7 @@
                 Configures the failure actions for a service being installed or one that already exists. This element's functionality is available starting with MSI 5.0.
             </xs:documentation>
       <xs:appinfo>
-        <xse:msiRef table="MsiServiceConfigFailureActions" href="http://msdn.microsoft.com/library/aa371637.aspx" />
+        <xse:msiRef table="MsiServiceConfigFailureActions" href="http://msdn.microsoft.com/en-us/library/dd408037.aspx" />
       </xs:appinfo>
     </xs:annotation>
     <xs:complexType>


### PR DESCRIPTION
Simple fixes to documentation for MsiServiceConfig and MsiServiceConfigFailureActions.