### PR TITLE
WIXBUG:4716 

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* BobArnson: WIXBUG:4716 - If a .wxl file is missing strings added in v3.10, duplicate the generic string from v3.9. Add support for doing so to locutil.
+
 * SeanHall: WIXBUG:4761 - Use the package's exit code to tell if the prereq was installed.
 
 * BobArnson: WIXBUG:4734 - Rewrote type-51 CAs using SetProperty.

--- a/src/libs/dutil/inc/locutil.h
+++ b/src/libs/dutil/inc/locutil.h
@@ -107,12 +107,22 @@ HRESULT DAPI LocGetControl(
     );
 
 /********************************************************************
- LocGetString - returns a string's localization information
+LocGetString - returns a string's localization information
 *******************************************************************/
 extern "C" HRESULT DAPI LocGetString(
     __in const WIX_LOCALIZATION* pWixLoc,
     __in_z LPCWSTR wzId,
     __out LOC_STRING** ppLocString
+    );
+
+/********************************************************************
+LocAddString - adds a localization string
+*******************************************************************/
+extern "C" HRESULT DAPI LocAddString(
+    __in WIX_LOCALIZATION* pWixLoc,
+    __in_z LPCWSTR wzId,
+    __in_z LPCWSTR wzLocString,
+    __in BOOL bOverridable
     );
 
 #ifdef __cplusplus

--- a/src/libs/dutil/locutil.cpp
+++ b/src/libs/dutil/locutil.cpp
@@ -286,6 +286,33 @@ extern "C" HRESULT DAPI LocGetString(
     return hr;
 }
 
+extern "C" HRESULT DAPI LocAddString(
+    __in WIX_LOCALIZATION* pWixLoc,
+    __in_z LPCWSTR wzId,
+    __in_z LPCWSTR wzLocString,
+    __in BOOL bOverridable
+    )
+{
+    HRESULT hr = S_OK;
+
+    ++pWixLoc->cLocStrings;
+    pWixLoc->rgLocStrings = static_cast<LOC_STRING*>(MemReAlloc(pWixLoc->rgLocStrings, sizeof(LOC_STRING) * pWixLoc->cLocStrings, TRUE));
+    ExitOnNull(pWixLoc->rgLocStrings, hr, E_OUTOFMEMORY, "Failed to reallocate memory for localization strings.");
+
+    LOC_STRING* pLocString = pWixLoc->rgLocStrings + (pWixLoc->cLocStrings - 1);
+
+    hr = StrAllocFormatted(&pLocString->wzId, L"#(loc.%s)", wzId);
+    ExitOnFailure(hr, "Failed to set localization string Id.");
+
+    hr = StrAllocString(&pLocString->wzText, wzLocString, 0);
+    ExitOnFailure(hr, "Failed to set localization string Text.");
+
+    pLocString->bOverridable = bOverridable;
+
+LExit:
+    return hr;
+}
+
 // helper functions
 
 static HRESULT ParseWxl(


### PR DESCRIPTION
If a .wxl file is missing strings added in v3.10, duplicate the generic string from v3.9. Add support for doing so to locutil.