### PR TITLE
Turns out we need RemoveUnreferencedCodeData after all for VS2015. While...

### DIFF
--- a/src/burn/stub/Stub.vcxproj
+++ b/src/burn/stub/Stub.vcxproj
@@ -55,9 +55,8 @@
   <ItemGroup>
     <ClCompile Include="stub.cpp" />
     <ClCompile Include="StubSection.cpp">
-      <!-- Workaround for VS2015 RC bug that omits the .wixburn section. Pick one.
-      <RemoveUnreferencedCodeData>false</RemoveUnreferencedCodeData> -->
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <!-- Workaround for VS2015 behavior change that omits the .wixburn section. -->
+      <RemoveUnreferencedCodeData>false</RemoveUnreferencedCodeData>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/tools/WixBuild.props
+++ b/tools/WixBuild.props
@@ -169,6 +169,7 @@
 
   <PropertyGroup>
     <VS2015Path Condition=" '$(VS2015Path)'=='' ">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\14.0', 'InstallDir', null, RegistryView.Registry64, RegistryView.Registry32))</VS2015Path>
+    <VS2015Path Condition=" '$(VS2015Path)'=='' ">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\WDExpress\14.0', 'InstallDir', null, RegistryView.Registry64, RegistryView.Registry32))</VS2015Path>
     <VS2015SdkPath Condition=" '$(VS2015SdkPath)'=='' ">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\VSIP\14.0', 'InstallDir', null, RegistryView.Registry64, RegistryView.Registry32))</VS2015SdkPath>
     <VS2015SdkTargetsPath Condition=" '$(VS2015SdkTargetsPath)' == '' AND '$(MSBuildExtensionsPath32)' != '' ">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v14.0\VSSDK\Microsoft.VsSDK.targets</VS2015SdkTargetsPath>
     <VS2015SdkTargetsPath Condition=" '$(VS2015SdkTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v14.0\VSSDK\Microsoft.VsSDK.targets</VS2015SdkTargetsPath>


### PR DESCRIPTION
... I'm in there, I added support for Visual Studio 2015 Express for Windows Desktop.