### PR TITLE
libs_minimal.proj - Just the libraries needed for tools/ tree build.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* BobArnson: Add libs_minimal.proj with just the libraries needed for tools/ tree build. This prevents the build from backing up behind a full libs/ tree build, which gets more painful the more versions of Visual Studio that are installed.
+
 * BobArnson: WIXBUG:4750 - Add a note about binary (in)compatibility.
 
 * RobMen: WIXBUG:4732 - fix documentation links to MsiServiceConfig and MsiServiceConfigFailureActions.

--- a/src/DTF/Tools/SfxCA/SfxCA.vcxproj
+++ b/src/DTF/Tools/SfxCA/SfxCA.vcxproj
@@ -40,8 +40,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), wix.proj))\tools\WixBuild.props" />
 
   <PropertyGroup>
-    <ProjectAdditionalIncludeDirectories>$(WixRoot)src\dutil\inc</ProjectAdditionalIncludeDirectories>
-    <ProjectAdditionalLinkLibraries>msi.lib;cabinet.lib;shlwapi.lib;dutil.lib</ProjectAdditionalLinkLibraries>
+    <ProjectAdditionalLinkLibraries>msi.lib;cabinet.lib;shlwapi.lib</ProjectAdditionalLinkLibraries>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DTF/dtf.proj
+++ b/src/DTF/dtf.proj
@@ -9,10 +9,6 @@
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <ItemGroup>
-    <ProjectReference Include="..\libs\libs.proj">
-      <BuildInParallel>false</BuildInParallel>
-    </ProjectReference>
-
     <ProjectReference Include="Libraries\Compression\Compression.csproj" />
     <ProjectReference Include="Libraries\Compression.Cab\Compression.Cab.csproj" />
     <ProjectReference Include="Libraries\Compression.Zip\Compression.Zip.csproj" />

--- a/src/ext/ext.proj
+++ b/src/ext/ext.proj
@@ -12,6 +12,9 @@
     <ProjectReference Include="..\tools\tools.proj">
       <BuildInParallel>false</BuildInParallel>
     </ProjectReference>
+    <ProjectReference Include="..\libs\libs.proj">
+      <BuildInParallel>false</BuildInParallel>
+    </ProjectReference>
 
     <ProjectReference Include="BalExtension\bal.proj" />
     <ProjectReference Include="ComPlusExtension\complus.proj" />

--- a/src/libs/libs_minimal.proj
+++ b/src/libs/libs_minimal.proj
@@ -1,0 +1,48 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+  <copyright file="multitargetlibs.proj" company="Outercurve Foundation">
+    Copyright (c) 2004, Outercurve Foundation.
+    This software is released under Microsoft Reciprocal License (MS-RL).
+    The license and further copyright text can be found in the file
+    LICENSE.TXT at the root directory of the distribution.
+  </copyright>
+-->
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <ItemGroup Condition=" $(VS2010Available) and !$(VS2012Available) and !$(VS2013Available) and !$(VS2015Available) ">
+    <ProjectReference Include="dutil\dutil.vcxproj">
+      <Properties>PlatformToolset=v100</Properties>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup Condition=" $(VS2012Available) and !$(VS2013Available) and !$(VS2015Available) ">
+    <ProjectReference Include="dutil\dutil.vcxproj">
+      <Properties>PlatformToolset=v110_xp</Properties>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup Condition=" $(VS2013Available) and !$(StaticAnalysisEnabled) and !$(VS2015Available) ">
+    <ProjectReference Include="dutil\dutil.vcxproj">
+      <Properties>PlatformToolset=v120_xp</Properties>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup Condition=" $(VS2013Available) and $(StaticAnalysisEnabled) and !$(VS2015Available) ">
+    <ProjectReference Include="dutil\dutil.vcxproj">
+      <Properties>PlatformToolset=v120</Properties>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup Condition=" $(VS2015Available) and !$(StaticAnalysisEnabled) ">
+    <ProjectReference Include="dutil\dutil.vcxproj">
+      <Properties>PlatformToolset=v140_xp</Properties>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup Condition=" $(VS2015Available) and $(StaticAnalysisEnabled) ">
+    <ProjectReference Include="dutil\dutil.vcxproj">
+      <Properties>PlatformToolset=v140</Properties>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), wix.proj))\tools\Traversal.targets" />
+</Project>

--- a/src/tools/tools.proj
+++ b/src/tools/tools.proj
@@ -9,7 +9,7 @@
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <ItemGroup>
-    <ProjectReference Include="..\libs\libs.proj">
+    <ProjectReference Include="..\libs\libs_minimal.proj">
       <BuildInParallel>false</BuildInParallel>
     </ProjectReference>
 


### PR DESCRIPTION
This prevents the build from backing up behind a full libs/ tree build, which gets more painful the more versions of Visual Studio that are installed.
Remove libs from DTF, which doesn't use them.