### PR TITLE
Add VSIX property for VS2015 and fix older searches

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* HeathS: Add VSIX property for VS2015 and fix searches for previous versions.
+
 * BobArnson: Add libs_minimal.proj with just the libraries needed for tools/ tree build. This prevents the build from backing up behind a full libs/ tree build, which gets more painful the more versions of Visual Studio that are installed.
 
 * BobArnson: WIXBUG:4750 - Add a note about binary (in)compatibility.

--- a/src/ext/VSExtension/wixlib/VsixPackage.wxs
+++ b/src/ext/VSExtension/wixlib/VsixPackage.wxs
@@ -21,29 +21,43 @@
             </RegistrySearch>
         </Property>
 
-        <!-- VS2013 is the latest VSIX at this point in time, so search for that by default. -->
-        <Property Id="VS_VSIX_INSTALLER_PATH" Secure="yes">
+        <Property Id="VS2013_VSIX_INSTALLER_PATH" Secure="yes">
             <RegistrySearch Id="WixVS2013EnvDir" Root="HKLM" Key="SOFTWARE\Microsoft\VisualStudio\12.0\Setup\VS" Name="EnvironmentDirectory" Type="directory">
                 <FileSearch Id="WixVS2013VsixInstaller" Name="VSIXInstaller.exe" />
             </RegistrySearch>
         </Property>
 
+        <!-- VS2015 is the latest VSIX at this point in time, so search for that by default. -->
+        <Property Id="VS_VSIX_INSTALLER_PATH" Secure="yes">
+            <RegistrySearch Id="WixVS2015EnvDir" Root="HKLM" Key="SOFTWARE\Microsoft\VisualStudio\14.0\Setup\VS" Name="EnvironmentDirectory" Type="directory">
+                <FileSearch Id="WixVS2015VsixInstaller" Name="VSIXInstaller.exe" />
+            </RegistrySearch>
+        </Property>
+
         <!-- VWD2012 registers differently than the rest of Visual Studio, so search for it in the case VS2012 is missing. -->
         <Property Id="VWD2012_VSIX_INSTALL_ROOT">
-            <RegistrySearch Id="Vwd2012Search" Root="HKLM" Key="SOFTWARE\Microsoft\VisualStudio\11.0\Setup\VS" Name="ProductDir" Type="raw" />
+            <RegistrySearch Id="Vwd2012Search" Root="HKLM" Key="SOFTWARE\Microsoft\VWDExpress\11.0\Setup\VS" Name="ProductDir" Type="raw" />
         </Property>
 
         <!-- VWD2013 registers differently than the rest of Visual Studio, so search for it in the case VS2013 is missing. -->
         <Property Id="VWD2013_VSIX_INSTALL_ROOT">
-            <RegistrySearch Id="Vwd2013Search" Root="HKLM" Key="SOFTWARE\Microsoft\VisualStudio\12.0\Setup\VS" Name="ProductDir" Type="raw" />
+            <RegistrySearch Id="Vwd2013Search" Root="HKLM" Key="SOFTWARE\Microsoft\VWDExpress\12.0\Setup\VS" Name="ProductDir" Type="raw" />
         </Property>
 
-        <!-- If we didn't find VSIX in the latest Visual Studio or VWD, use an older version. -->
-        <SetProperty Action="SetVS2010Vsix" Id="VS_VSIX_INSTALLER_PATH" Value="[VS2010_VSIX_INSTALLER_PATH]" Sequence="both" After="AppSearch">NOT VS_VSIX_INSTALLER_PATH AND NOT VS2012_VSIX_INSTALLER_PATH</SetProperty>
-        <SetProperty Action="SetVS2012Vsix" Id="VS_VSIX_INSTALLER_PATH" Value="[VS2012_VSIX_INSTALLER_PATH]" Sequence="both" After="AppSearch">NOT VS_VSIX_INSTALLER_PATH AND VS2012_VSIX_INSTALLER_PATH</SetProperty>
+        <!-- VWD2015 registers differently than the rest of Visual Studio, so search for it in the case VS2015 is missing. -->
+        <Property Id="VWD2015_VSIX_INSTALL_ROOT">
+            <RegistrySearch Id="Vwd2015Search" Root="HKLM" Key="SOFTWARE\Microsoft\VWDExpress\14.0\Setup\VS" Name="ProductDir" Type="raw" />
+        </Property>
 
-        <!-- If we didn't find the latest Visual Studio but VWD is present, use VWD's VSIX. -->
-        <SetProperty Action="Vwd2012VsixWhenVSAbsent" Id="VS_VSIX_INSTALLER_PATH" After="SetVS2012Vsix" Value="[VWD2012_VSIX_INSTALLER_ROOT]\Common7\IDE\VSIXInstaller.exe" Sequence="both">NOT VS_VSIX_INSTALLER_PATH AND VWD2012_VSIX_INSTALLER_ROOT AND NOT VWD2013_VSIX_INSTALLER_ROOT</SetProperty>
-        <SetProperty Action="Vwd2013VsixWhenVSAbsent" Id="VS_VSIX_INSTALLER_PATH" After="SetVS2012Vsix" Value="[VWD2013_VSIX_INSTALLER_ROOT]\Common7\IDE\VSIXInstaller.exe" Sequence="both">NOT VS_VSIX_INSTALLER_PATH AND VWD2013_VSIX_INSTALLER_ROOT</SetProperty>
+        <!-- Use the latest VS- or VWD-installed VSIXInstaller.exe. -->
+        <SetProperty Action="Vwd2015VsixWhenVSAbsent" Id="VS_VSIX_INSTALLER_PATH" Value="[VWD2015_VSIX_INSTALL_ROOT]\Common7\IDE\VSIXInstaller.exe" Sequence="both" After="AppSearch">NOT VS_VSIX_INSTALLER_PATH AND VWD2015_VSIX_INSTALL_ROOT</SetProperty>
+
+        <SetProperty Action="SetVS2013Vsix" Id="VS_VSIX_INSTALLER_PATH" Value="[VS2013_VSIX_INSTALLER_PATH]" Sequence="both" After="Vwd2015VsixWhenVSAbsent">NOT VS_VSIX_INSTALLER_PATH AND VS2013_VSIX_INSTALLER_PATH</SetProperty>
+        <SetProperty Action="Vwd2013VsixWhenVSAbsent" Id="VS_VSIX_INSTALLER_PATH" Value="[VWD2013_VSIX_INSTALL_ROOT]\Common7\IDE\VSIXInstaller.exe" Sequence="both" After="SetVS2013Vsix">NOT VS_VSIX_INSTALLER_PATH AND VWD2013_VSIX_INSTALL_ROOT</SetProperty>
+
+        <SetProperty Action="SetVS2012Vsix" Id="VS_VSIX_INSTALLER_PATH" Value="[VS2012_VSIX_INSTALLER_PATH]" Sequence="both" After="Vwd2013VsixWhenVSAbsent">NOT VS_VSIX_INSTALLER_PATH AND VS2012_VSIX_INSTALLER_PATH</SetProperty>
+        <SetProperty Action="Vwd2012VsixWhenVSAbsent" Id="VS_VSIX_INSTALLER_PATH" Value="[VWD2012_VSIX_INSTALL_ROOT]\Common7\IDE\VSIXInstaller.exe" Sequence="both" After="SetVS2012Vsix">NOT VS_VSIX_INSTALLER_PATH AND VWD2012_VSIX_INSTALL_ROOT</SetProperty>
+
+        <SetProperty Action="SetVS2010Vsix" Id="VS_VSIX_INSTALLER_PATH" Value="[VS2010_VSIX_INSTALLER_PATH]" Sequence="both" After="Vwd2012VsixWhenVSAbsent">NOT VS_VSIX_INSTALLER_PATH AND VS2010_VSIX_INSTALLER_PATH</SetProperty>
     </Fragment>
 </Wix>


### PR DESCRIPTION
The older VWD searches were looking in the wrong place (wasn't VWD-specific) and the CA conditions were checking the wrong property. Also reorganized the CAs to execution in release / edition succession decending for ease.