### PR TITLE
Added ServiceInstall.Account fully qualified documentation

### DIFF
--- a/src/tools/wix/Xsd/wix.xsd
+++ b/src/tools/wix/Xsd/wix.xsd
@@ -6861,7 +6861,7 @@
       </xs:attribute>
       <xs:attribute name="Account" type="xs:string">
         <xs:annotation>
-          <xs:documentation>The account under which to start the service. Valid only when ServiceType is ownProcess.</xs:documentation>
+          <xs:documentation>Fully qualified names must be used even for local accounts, e.g.: ".\LOCAL_ACCOUNT". Valid only when ServiceType is ownProcess.</xs:documentation>
         </xs:annotation>
       </xs:attribute>
       <xs:attribute name="Password" type="xs:string">


### PR DESCRIPTION
To help everyone who's looking for answers regarding local accounts and why the service is not properly installing or getting "insufficient privileges"

http://angledontech.blogspot.ca/2011/09/wix-troubleshooting-verify-that-you.html