### PR TITLE
WIXBUG:4774 - fix performance problem when caching

### DIFF
--- a/history/4774.md
+++ b/history/4774.md
@@ -1,0 +1,1 @@
+* SeanHall: WIXBUG:4774 - fix performance problem when caching thousands of payloads in a single package.

--- a/src/burn/engine/apply.cpp
+++ b/src/burn/engine/apply.cpp
@@ -514,6 +514,23 @@ extern "C" HRESULT ApplyCache(
                 {
                     LogErrorId(hr, MSG_USER_CANCELED, L"begin cache package", pStartedPackage->sczId, NULL);
                 }
+                else
+                {
+                    if (INVALID_HANDLE_VALUE != hPipe)
+                    {
+                        hr = ElevationCachePreparePackage(hPipe, pStartedPackage);
+                    }
+                    else
+                    {
+                        hr = CachePreparePackage(pStartedPackage);
+                    }
+
+                    if (FAILED(hr))
+                    {
+                        LogErrorId(hr, MSG_CACHE_PREPARE_PACKAGE_FAILED, pStartedPackage->sczId, NULL, NULL);
+                    }
+                }
+
                 break;
 
             case BURN_CACHE_ACTION_TYPE_ACQUIRE_CONTAINER:

--- a/src/burn/engine/cache.h
+++ b/src/burn/engine/cache.h
@@ -87,6 +87,9 @@ void CacheSendErrorCallback(
     __out_opt BOOL* pfRetry
     );
 BOOL CacheBundleRunningFromCache();
+HRESULT CachePreparePackage(
+    __in BURN_PACKAGE* pPackage
+    );
 HRESULT CacheBundleToWorkingDirectory(
     __in_z LPCWSTR wzBundleId,
     __in_z LPCWSTR wzExecutableName,

--- a/src/burn/engine/elevation.h
+++ b/src/burn/engine/elevation.h
@@ -67,6 +67,10 @@ HRESULT ElevationLayoutBundle(
     __in_z LPCWSTR wzLayoutDirectory,
     __in_z LPCWSTR wzUnverifiedPath
     );
+HRESULT ElevationCachePreparePackage(
+    __in HANDLE hPipe,
+    __in BURN_PACKAGE* pPackage
+    );
 HRESULT ElevationCacheOrLayoutContainerOrPayload(
     __in HANDLE hPipe,
     __in_opt BURN_CONTAINER* pContainer,

--- a/src/burn/engine/engine.mc
+++ b/src/burn/engine/engine.mc
@@ -618,6 +618,13 @@ Language=English
 Could not remove bundle dependency provider: %1!ls!, error: 0x%2!x!
 .
 
+MessageId=334
+Severity=Error
+SymbolicName=MSG_CACHE_PREPARE_PACKAGE_FAILED
+Language=English
+Failed to prepare package: %2!ls!, error: 0x%1!ls!
+.
+
 MessageId=335
 Severity=Success
 SymbolicName=MSG_ACQUIRE_BUNDLE_PAYLOAD


### PR DESCRIPTION
Resetting the permissions on the cache folder for every payload was expensive. This reduces the time from 30 minutes to 26 seconds.
