### PR TITLE
Bug 4532 - InstallPrivileges and InstallScope can specify contradicting values

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* BMurri: WIXBUG:4532 - Make it an error for InstallPrivileges and InstallScope to specify contradictory values.
+
 ## WixBuild: Version 3.10.0.1726
 
 * creativbox: WIXFEAT:4382 - Added files-in-use UI to WixStdBA

--- a/src/tools/wix/Compiler.cs
+++ b/src/tools/wix/Compiler.cs
@@ -11926,17 +11926,17 @@ namespace Microsoft.Tools.WindowsInstallerXml
                                 switch (installPrivilegesType)
                                 {
                                     case Wix.Package.InstallPrivilegesType.elevated:
-                                        if (installScopeSeen && (8 == (sourceBits | 8)))
+                                        if (installScopeSeen && (8 == (sourceBits & 8)))
                                         {
-                                            this.core.OnMessage(WixErrors.IllegalAttributeWithOtherAttribute(sourceLineNumbers, node.Name, attrib.Name, "InstallScope", "perUser"));
+                                            this.core.OnMessage(WixErrors.IncompatiblePackageElevationAttributes(sourceLineNumbers, node.Name, "InstallScope", "perUser", attrib.Name, installPrivileges));
                                         }
                                         // this is the default setting
 
                                         break;
                                     case Wix.Package.InstallPrivilegesType.limited:
-                                        if (installScopeSeen && (0 == (sourceBits | 8)))
+                                        if (installScopeSeen && (0 == (sourceBits & 8)))
                                         {
-                                            this.core.OnMessage(WixErrors.IllegalAttributeWithOtherAttribute(sourceLineNumbers, node.Name, attrib.Name, "InstallScope", "perMachine"));
+                                            this.core.OnMessage(WixErrors.IncompatiblePackageElevationAttributes(sourceLineNumbers, node.Name, "InstallScope", "perMachine", attrib.Name, installPrivileges));
                                         }
                                         sourceBits = sourceBits | 8;
                                         break;
@@ -11955,18 +11955,18 @@ namespace Microsoft.Tools.WindowsInstallerXml
                                 switch (installScopeType)
                                 {
                                     case Wix.Package.InstallScopeType.perMachine:
-                                        if (installPrivilegeSeen && (8 == (sourceBits | 8)))
+                                        if (installPrivilegeSeen && (8 == (sourceBits & 8)))
                                         {
-                                            this.core.OnMessage(WixErrors.IllegalAttributeWithOtherAttribute(sourceLineNumbers, node.Name, attrib.Name, "InstallPrivileges", "limited"));
+                                            this.core.OnMessage(WixErrors.IncompatiblePackageElevationAttributes(sourceLineNumbers, node.Name, attrib.Name, installScope, "InstallPrivileges", "limited"));
                                         }
                                         row = this.core.CreateRow(sourceLineNumbers, "Property");
                                         row[0] = "ALLUSERS";
                                         row[1] = "1";
                                         break;
                                     case Wix.Package.InstallScopeType.perUser:
-                                        if (installPrivilegeSeen && (0 == (sourceBits | 8)))
+                                        if (installPrivilegeSeen && (0 == (sourceBits & 8)))
                                         {
-                                            this.core.OnMessage(WixErrors.IllegalAttributeWithOtherAttribute(sourceLineNumbers, node.Name, attrib.Name, "InstallPrivileges", "elevated"));
+                                            this.core.OnMessage(WixErrors.IncompatiblePackageElevationAttributes(sourceLineNumbers, node.Name, attrib.Name, installScope, "InstallPrivileges", "elevated"));
                                         }
                                         sourceBits = sourceBits | 8;
                                         break;

--- a/src/tools/wix/Compiler.cs
+++ b/src/tools/wix/Compiler.cs
@@ -11860,6 +11860,8 @@ namespace Microsoft.Tools.WindowsInstallerXml
             YesNoDefaultType security = YesNoDefaultType.Default;
             int sourceBits = (this.compilingModule ? 2 : 0);
             Row row;
+            bool installPrivilegeSeen = false;
+            bool installScopeSeen = false;
 
             switch (this.currentPlatform)
             {
@@ -11919,13 +11921,23 @@ namespace Microsoft.Tools.WindowsInstallerXml
                             string installPrivileges = this.core.GetAttributeValue(sourceLineNumbers, attrib);
                             if (0 < installPrivileges.Length)
                             {
+                                installPrivilegeSeen = true;
                                 Wix.Package.InstallPrivilegesType installPrivilegesType = Wix.Package.ParseInstallPrivilegesType(installPrivileges);
                                 switch (installPrivilegesType)
                                 {
                                     case Wix.Package.InstallPrivilegesType.elevated:
+                                        if (installScopeSeen && (8 == (sourceBits | 8)))
+                                        {
+                                            this.core.OnMessage(WixErrors.IllegalAttributeWithOtherAttribute(sourceLineNumbers, node.Name, attrib.Name, "InstallScope", "perUser"));
+                                        }
                                         // this is the default setting
+
                                         break;
                                     case Wix.Package.InstallPrivilegesType.limited:
+                                        if (installScopeSeen && (0 == (sourceBits | 8)))
+                                        {
+                                            this.core.OnMessage(WixErrors.IllegalAttributeWithOtherAttribute(sourceLineNumbers, node.Name, attrib.Name, "InstallScope", "perMachine"));
+                                        }
                                         sourceBits = sourceBits | 8;
                                         break;
                                     default:
@@ -11938,15 +11950,24 @@ namespace Microsoft.Tools.WindowsInstallerXml
                             string installScope = this.core.GetAttributeValue(sourceLineNumbers, attrib);
                             if (0 < installScope.Length)
                             {
+                                installScopeSeen = true;
                                 Wix.Package.InstallScopeType installScopeType = Wix.Package.ParseInstallScopeType(installScope);
                                 switch (installScopeType)
                                 {
                                     case Wix.Package.InstallScopeType.perMachine:
+                                        if (installPrivilegeSeen && (8 == (sourceBits | 8)))
+                                        {
+                                            this.core.OnMessage(WixErrors.IllegalAttributeWithOtherAttribute(sourceLineNumbers, node.Name, attrib.Name, "InstallPrivileges", "limited"));
+                                        }
                                         row = this.core.CreateRow(sourceLineNumbers, "Property");
                                         row[0] = "ALLUSERS";
                                         row[1] = "1";
                                         break;
                                     case Wix.Package.InstallScopeType.perUser:
+                                        if (installPrivilegeSeen && (0 == (sourceBits | 8)))
+                                        {
+                                            this.core.OnMessage(WixErrors.IllegalAttributeWithOtherAttribute(sourceLineNumbers, node.Name, attrib.Name, "InstallPrivileges", "elevated"));
+                                        }
                                         sourceBits = sourceBits | 8;
                                         break;
                                     default:

--- a/src/tools/wix/Data/messages.xml
+++ b/src/tools/wix/Data/messages.xml
@@ -2957,6 +2957,16 @@
           <Parameter Type="System.Int32" Name="supportedColumnCount" />
         </Instance>
       </Message>
+      <Message Id="IncompatiblePackageElevationAttributes" Number="387">
+          <Instance>
+              The {0}/@{1} attribute's value, '{2}', is not compatible with attribute @{3}'s value, '{4}'. It is recommended that only the InstallScope attribute be used.
+              <Parameter Type="System.String" Name="elementName" />
+              <Parameter Type="System.String" Name="attribute1Name" />
+              <Parameter Type="System.String" Name="attribute1Value" />
+              <Parameter Type="System.String" Name="attribute2Name" />
+              <Parameter Type="System.String" Name="attribute2Value" />
+          </Instance>
+      </Message>
     </Class>
 
     <Class Name="WixWarnings" ContainerName="WixWarningEventArgs" BaseContainerName="MessageEventArgs" Level="Warning">


### PR DESCRIPTION
This is the wix3 version of the fix for this bug. I felt that I couldn't simply return an error when both attributes are supplied, but since the error is opened in 3.x, I felt that I can still return an error.

This code will continue to accept both attributes being present as long as the respective values are compatible. If they are not, an error that recommends keeping only the InstallScope attribute.

The wix4 version of the fix is [here](https://github.com/wixtoolset/wix4/pull/142).