### PR TITLE
WIXBUG:4614 OutputName in wixproj can not be parameterized because it's always rewritten

### DIFF
--- a/src/Votive/votive2010/src/WixProjectNode.cs
+++ b/src/Votive/votive2010/src/WixProjectNode.cs
@@ -810,8 +810,11 @@ namespace Microsoft.Tools.WindowsInstallerXml.VisualStudio
         /// </remarks>
         protected override void InitializeProjectProperties()
         {
-            string projectName = Path.GetFileNameWithoutExtension(this.FileName);
-            this.SetProjectProperty(WixProjectFileConstants.OutputName, projectName);
+            if(String.IsNullOrWhiteSpace(this.GetProjectProperty(WixProjectFileConstants.OutputName)))
+            {
+                string projectName = Path.GetFileNameWithoutExtension(this.FileName);
+                this.SetProjectProperty(WixProjectFileConstants.OutputName, projectName);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Validation added for the case when the project property is not empty (as stated in the comments to this method)