### PR TITLE
WIXBUG:4499 - Bind MBApreq language to correct langid

### DIFF
--- a/history/4499.md
+++ b/history/4499.md
@@ -1,0 +1,1 @@
+* BMurri: WIXBUG:4499 - Bind MBApreq language to user language instead of user locale setting

--- a/history/5285.md
+++ b/history/5285.md
@@ -1,0 +1,1 @@
+* BMurri: WIXBUG:5285 - Add UserUILanguageID variable

--- a/src/Setup/Bundle/Bundle.wxs
+++ b/src/Setup/Bundle/Bundle.wxs
@@ -19,7 +19,7 @@
         <swid:Tag Regid="!(loc.Regid)" InstallPath="[ProgramFilesFolder]WiX Toolset v$(var.WixMajorMinor)" />
         <Update Location='!(loc.UpdateUrl)' />
 
-        <BootstrapperApplicationRef Id='ManagedBootstrapperApplicationHost'>
+        <BootstrapperApplicationRef Id='ManagedBootstrapperApplicationHost' bal:UseUILanguages='yes'>
           <Payload Name='BootstrapperCore.config' SourceFile='WixBA.BootstrapperCore.config' />
 
           <Payload SourceFile='WixBA.dll' />

--- a/src/Setup/Bundle/WixStdBundle.wxs
+++ b/src/Setup/Bundle/WixStdBundle.wxs
@@ -17,7 +17,7 @@
         <swid:Tag Regid="!(loc.Regid)" InstallPath="[ProgramFilesFolder]WiX Toolset v$(var.WixMajorMinor)" />
         <Update Location='!(loc.UpdateUrl)' />
 
-        <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.HyperlinkLicense">
+        <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.HyperlinkLicense" bal:UseUILanguages="yes">
             <bal:WixStandardBootstrapperApplication LicenseUrl="http://wixtoolset.org/about/license/" />
         </BootstrapperApplicationRef>
 

--- a/src/Votive/votive2010/src/Templates/Projects/WixBundleProject/Bundle.wxs
+++ b/src/Votive/votive2010/src/Templates/Projects/WixBundleProject/Bundle.wxs
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
 	<Bundle Name="$wixsafeprojectname$" Version="1.0.0.0" Manufacturer="$registeredorganization$" UpgradeCode="$guid1$">
-		<BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.RtfLicense" />
+		<BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.RtfLicense" bal:UseUILanguages="yes" />
 
 		<Chain>
 			<!-- $loc_WXS_TODO$ -->

--- a/src/burn/engine/variable.cpp
+++ b/src/burn/engine/variable.cpp
@@ -134,6 +134,10 @@ static HRESULT InitializeSystemLanguageID(
     __in DWORD_PTR dwpData,
     __inout BURN_VARIANT* pValue
     );
+static HRESULT InitializeUserUILanguageID(
+    __in DWORD_PTR dwpData,
+    __inout BURN_VARIANT* pValue
+    );
 static HRESULT InitializeUserLanguageID(
     __in DWORD_PTR dwpData,
     __inout BURN_VARIANT* pValue
@@ -244,6 +248,7 @@ extern "C" HRESULT VariableInitialize(
         {L"TempFolder", InitializeVariableTempFolder, 0},
         {L"TemplateFolder", InitializeVariableCsidlFolder, CSIDL_TEMPLATES},
         {L"TerminalServer", InitializeVariableOsInfo, OS_INFO_VARIABLE_TerminalServer},
+        {L"UserUILanguageID", InitializeUserUILanguageID, 0},
         {L"UserLanguageID", InitializeUserLanguageID, 0},
         {L"VersionMsi", InitializeVariableVersionMsi, 0},
         {L"VersionNT", InitializeVariableVersionNT, OS_INFO_VARIABLE_VersionNT},
@@ -2050,6 +2055,23 @@ static HRESULT InitializeSystemLanguageID(
 
     HRESULT hr = S_OK;
     LANGID langid = ::GetSystemDefaultLangID();
+
+    hr = BVariantSetNumeric(pValue, langid);
+    ExitOnFailure(hr, "Failed to set variant value.");
+
+LExit:
+    return hr;
+}
+
+static HRESULT InitializeUserUILanguageID(
+    __in DWORD_PTR dwpData,
+    __inout BURN_VARIANT* pValue
+    )
+{
+    UNREFERENCED_PARAMETER(dwpData);
+
+    HRESULT hr = S_OK;
+    LANGID langid = ::GetUserDefaultUILanguage();
 
     hr = BVariantSetNumeric(pValue, langid);
     ExitOnFailure(hr, "Failed to set variant value.");

--- a/src/chm/documents/bundle/bundle_built_in_variables.html.md
+++ b/src/chm/documents/bundle/bundle_built_in_variables.html.md
@@ -49,7 +49,8 @@ The Burn engine offers a set of commonly-used variables so you can use them with
 * TempFolder - gets the well-known folder for temp location.
 * TemplateFolder - gets the well-known folder for CSIDL\_TEMPLATES.
 * TerminalServer - non-zero if the system is running in application server mode of Remote Desktop Services.
-* UserLanguageID - gets the language ID for the current user locale.
+* UserUILanguageID - gets the selection language ID for the current user locale.
+* UserLanguageID - gets the formatting language ID for the current user locale.
 * VersionMsi - version value representing the Windows Installer engine version.
 * VersionNT - version value representing the OS version. The result is a version variable (v#.#.#.#) which differs from the MSI Property &apos;VersionNT&apos; which is an integer. For example, to use this variable in a Bundle condition try: &quot;VersionNT &gt; v6.1&quot;.
 * VersionNT64 - version value representing the OS version if 64-bit. Undefined if running a 32-bit operating system. The result is a version variable (v#.#.#.#) which differs from the MSI Property &apos;VersionNT64&apos; which is an integer. For example, to use this variable in a Bundle condition try: &quot;VersionNT64 &gt; v6.1&quot;.

--- a/src/ext/BalExtension/wixext/BalCompiler.cs
+++ b/src/ext/BalExtension/wixext/BalCompiler.cs
@@ -87,6 +87,39 @@ namespace Microsoft.Tools.WindowsInstallerXml.Extensions
         /// <param name="sourceLineNumbers">Source line number for the parent element.</param>
         /// <param name="parentElement">Parent element of element to process.</param>
         /// <param name="attribute">Attribute to process.</param>
+        public override void ParseAttribute(SourceLineNumberCollection sourceLineNumbers, XmlElement parentElement, XmlAttribute attribute)
+        {
+            switch (parentElement.LocalName)
+            {
+                case "BootstrapperApplication":
+                case "BootstrapperApplicationRef":
+                    switch (attribute.LocalName)
+                    {
+                        case "UseUILanguages":
+                            if (YesNoType.Yes == this.Core.GetAttributeYesNoValue(sourceLineNumbers, attribute))
+                            {
+                                Row row = this.Core.CreateRow(sourceLineNumbers, "WixStdbaOptionVariables");
+                                row[0] = "UseUILanguages";
+                                row[1] = "1";
+                            }
+                            break;
+                        default:
+                            this.Core.UnexpectedAttribute(sourceLineNumbers, attribute);
+                            break;
+                    }
+                    break;
+                default:
+                    this.Core.UnexpectedAttribute(sourceLineNumbers, attribute);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Processes an attribute for the Compiler.
+        /// </summary>
+        /// <param name="sourceLineNumbers">Source line number for the parent element.</param>
+        /// <param name="parentElement">Parent element of element to process.</param>
+        /// <param name="attribute">Attribute to process.</param>
         /// <param name="contextValues">Extra information about the context in which this element is being parsed.</param>
         public override void ParseAttribute(SourceLineNumberCollection sourceLineNumbers, XmlElement parentElement, XmlAttribute attribute, Dictionary<string, string> contextValues)
         {
@@ -117,7 +150,7 @@ namespace Microsoft.Tools.WindowsInstallerXml.Extensions
                                 break;
                         }
                     }
-                        break;
+                    break;
                 case "Variable":
                     // at the time the extension attribute is parsed, the compiler might not yet have
                     // parsed the Name attribute, so we need to get it directly from the parent element.

--- a/src/ext/BalExtension/wixext/Xsd/bal.xsd
+++ b/src/ext/BalExtension/wixext/Xsd/bal.xsd
@@ -190,6 +190,19 @@
         </xs:annotation>
     </xs:attribute>
 
+    <xs:attribute name="UseUILanguages" type="YesNoType">
+        <xs:annotation>
+            <xs:documentation>
+                When set to "yes", causes WixStdBA/Prereq BA to use the user's control panel language settings. Otherwise, the previous API (which uses locale instead of language) is used to maintain compatiblity with previous versions of WiX.
+                On Vista and newer platforms, this value set to "yes" will search all specified user languages, including fallback languages, in order.
+            </xs:documentation>
+            <xs:appinfo>
+                <xse:parent namespace="http://schemas.microsoft.com/wix/2006/wi" ref="BootstrapperApplication" />
+                <xse:parent namespace="http://schemas.microsoft.com/wix/2006/wi" ref="BootstrapperApplicationRef" />
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:attribute>
+
     <xs:element name="WixManagedBootstrapperApplicationHost">
         <xs:annotation>
             <xs:documentation>

--- a/src/ext/BalExtension/wixext/data/tables.xml
+++ b/src/ext/BalExtension/wixext/data/tables.xml
@@ -30,6 +30,13 @@
                 maxValue="1" description="If 1, the bundle can be pre-cached using the /cache command line argument."/>
     </tableDefinition>
 
+    <tableDefinition name="WixStdbaOptionVariables" bootstrapperApplicationData="yes">
+        <columnDefinition name="Name" type="string" length="255" primaryKey="yes" 
+                category="identifier" description="Option variable name."/>
+        <columnDefinition name="Value" type="string" length="0" nullable="yes"
+                category="text" description="Option variable value"/>
+    </tableDefinition>
+
     <tableDefinition name="WixStdbaOverridableVariable" bootstrapperApplicationData="yes">
         <columnDefinition name="Name" type="string" length="255" primaryKey="yes" 
                 category="identifier" description="Variable name user can override."/>

--- a/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
+++ b/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
@@ -983,6 +983,22 @@ public: // IBootstrapperApplication
         return __super::OnExecuteFilesInUse(wzPackageId, cFiles, rgwzFiles);
     }
 
+
+protected: // internals
+    //
+    // FindLocFile - locates the desired localization file
+    //
+    HRESULT FindLocFile(
+        __in_z LPCWSTR wzBasePath,
+        __in_z LPCWSTR wzLocFileName,
+        __in_z_opt LPCWSTR wzLanguage,
+        __inout LPWSTR* psczPath
+        )
+    {
+        return LocProbeForFileEx(wzBasePath, wzLocFileName, wzLanguage, psczPath, m_fUseUILanguages);
+    }
+
+
 private: // privates
     //
     // UiThreadProc - entrypoint for UI thread.
@@ -1091,6 +1107,9 @@ private: // privates
 
         hr = BalManifestLoad(m_hModule, &pixdManifest);
         BalExitOnFailure(hr, "Failed to load bootstrapper application manifest.");
+
+        hr = ParseOptionVariablesFromXml(pixdManifest);
+        BalExitOnFailure(hr, "Failed to process bootstrapper option variables.");
 
         hr = ParseOverridableVariablesFromXml(pixdManifest);
         BalExitOnFailure(hr, "Failed to read overridable variables.");
@@ -1232,7 +1251,7 @@ private: // privates
         LPCWSTR wzLocFileName = m_fPrereq ? L"mbapreq.wxl" : L"thm.wxl";
 
         // Find and load .wxl file.
-        hr = LocProbeForFile(wzModulePath, wzLocFileName, wzLanguage, &sczLocPath);
+        hr = FindLocFile(wzModulePath, wzLocFileName, wzLanguage, &sczLocPath);
         BalExitOnFailure2(hr, "Failed to probe for loc file: %ls in path: %ls", wzLocFileName, wzModulePath);
 
         hr = LocLoadFromFile(sczLocPath, &m_pWixLoc);
@@ -1312,7 +1331,7 @@ private: // privates
         LPCWSTR wzThemeFileName = m_fPrereq ? L"mbapreq.thm" : L"thm.xml";
         LPWSTR sczCaption = NULL;
 
-        hr = LocProbeForFile(wzModulePath, wzThemeFileName, wzLanguage, &sczThemePath);
+        hr = FindLocFile(wzModulePath, wzThemeFileName, wzLanguage, &sczThemePath);
         BalExitOnFailure2(hr, "Failed to probe for theme file: %ls in path: %ls", wzThemeFileName, wzModulePath);
 
         hr = ThemeLoadFromFile(sczThemePath, &m_pTheme);
@@ -1334,6 +1353,84 @@ private: // privates
         ReleaseStr(sczCaption);
         ReleaseStr(sczThemePath);
 
+        return hr;
+    }
+
+
+    HRESULT ParseOptionVariablesFromXml(
+        __in IXMLDOMDocument* pixdManifest
+        )
+    {
+        HRESULT hr = S_OK;
+        IXMLDOMNode* pNode = NULL;
+        IXMLDOMNodeList* pNodes = NULL;
+        DWORD cNodes = 0;
+        LPWSTR sczName = NULL;
+        LPWSTR sczValue = NULL;
+
+        hr = XmlSelectNodes(pixdManifest, L"/BootstrapperApplicationData/WixStdbaOptionVariables", &pNodes);
+        if (S_FALSE == hr)
+        {
+            ExitFunction1(hr = S_OK);
+        }
+        ExitOnFailure(hr, "Failed to select option variable nodes.");
+
+        hr = pNodes->get_length((long*)&cNodes);
+        ExitOnFailure(hr, "Failed to get option variable node count.");
+
+        if (cNodes)
+        {
+            for (DWORD i = 0; i < cNodes; ++i)
+            {
+                hr = XmlNextElement(pNodes, &pNode, NULL);
+                ExitOnFailure(hr, "Failed to get next node.");
+
+                // @Value
+                hr = XmlGetAttributeEx(pNode, L"Value", &sczValue);
+                if (E_NOTFOUND == hr)
+                {
+                    ReleaseNullStr(sczValue);
+                }
+                else
+                {
+                    ExitOnFailure(hr, "Failed to get @Value.");
+                }
+
+                // @Name
+                hr = XmlGetAttributeEx(pNode, L"Name", &sczName);
+                ExitOnFailure(hr, "Failed to get @Name.");
+
+                if (0 == ::wcscmp(sczName, L"UseUILanguages"))
+                {
+                    if (sczValue && *sczValue)
+                    {
+                        USHORT us;
+                        hr = StrStringToUInt16(sczValue, 0, &us);
+                        ExitOnFailure(hr, "Failed to parse UseUILanguages.");
+
+                        m_fUseUILanguages = us ? TRUE : FALSE;
+                    }
+                }
+                // ***** extension point for new variables *****
+                // else if (0 == ::wcscmp(sczName, L""))
+                // {
+                // }
+                else
+                {
+                    hr = E_NOTFOUND;
+                    ExitOnFailure1(hr, "Failed to recognize option variable \"%ls\".", sczName);
+                }
+
+                // prepare next iteration
+                ReleaseNullObject(pNode);
+            }
+        }
+
+    LExit:
+        ReleaseObject(pNode);
+        ReleaseObject(pNodes);
+        ReleaseStr(sczName);
+        ReleaseStr(sczValue);
         return hr;
     }
 
@@ -2023,7 +2120,7 @@ private: // privates
                                     hr = StrAllocString(&sczLicenseFilename, PathFile(sczLicenseFormatted), 0);
                                     if (SUCCEEDED(hr))
                                     {
-                                        hr = LocProbeForFile(sczLicenseDirectory, sczLicenseFilename, m_sczLanguage, &sczLicensePath);
+                                        hr = FindLocFile(sczLicenseDirectory, sczLicenseFilename, m_sczLanguage, &sczLicensePath);
                                         if (SUCCEEDED(hr))
                                         {
                                             hr = ThemeLoadRichEditFromFile(m_pTheme, WIXSTDBA_CONTROL_EULA_RICHEDIT, sczLicensePath, m_hModule);
@@ -2809,7 +2906,7 @@ private: // privates
                 hr = PathGetDirectory(sczLicensePath, &sczLicenseDirectory);
                 if (SUCCEEDED(hr))
                 {
-                    hr = LocProbeForFile(sczLicenseDirectory, PathFile(sczLicenseUrl), m_sczLanguage, &sczLicensePath);
+                    hr = FindLocFile(sczLicenseDirectory, PathFile(sczLicenseUrl), m_sczLanguage, &sczLicensePath);
                 }
             }
         }
@@ -3433,6 +3530,8 @@ public:
 
         m_hBAFModule = NULL;
         m_pBAFunction = NULL;
+
+        m_fUseUILanguages = FALSE;
     }
 
 
@@ -3533,6 +3632,8 @@ private:
 
     HMODULE m_hBAFModule;
     IBootstrapperBAFunction* m_pBAFunction;
+
+    BOOL m_fUseUILanguages;
 };
 
 

--- a/src/libs/dutil/inc/locutil.h
+++ b/src/libs/dutil/inc/locutil.h
@@ -39,7 +39,7 @@ struct WIX_LOCALIZATION
 };
 
 /********************************************************************
- LocProbeForFile - Searches for a localization file on disk.
+ LocProbeForFile - Searches for a localization file on disk using incorrect set of APIs.
 
 *******************************************************************/
 HRESULT DAPI LocProbeForFile(
@@ -47,6 +47,18 @@ HRESULT DAPI LocProbeForFile(
     __in_z LPCWSTR wzLocFileName,
     __in_z_opt LPCWSTR wzLanguage,
     __inout LPWSTR* psczPath
+    );
+
+/********************************************************************
+ LocProbeForFileEx - Searches for a localization file on disk.
+ useUILanguage should be set to TRUE.
+*******************************************************************/
+extern "C" HRESULT DAPI LocProbeForFileEx(
+    __in_z LPCWSTR wzBasePath,
+    __in_z LPCWSTR wzLocFileName,
+    __in_z_opt LPCWSTR wzLanguage,
+    __inout LPWSTR* psczPath,
+    __in BOOL useUILanguage
     );
 
 /********************************************************************

--- a/src/libs/dutil/locutil.cpp
+++ b/src/libs/dutil/locutil.cpp
@@ -26,6 +26,23 @@ static HRESULT ParseWxlControl(
     __in WIX_LOCALIZATION* pWixLoc
     );
 
+// from Winnls.h
+#ifndef MUI_LANGUAGE_ID
+#define MUI_LANGUAGE_ID                     0x4      // Use traditional language ID convention
+#endif
+#ifndef MUI_MERGE_USER_FALLBACK
+#define MUI_MERGE_USER_FALLBACK             0x20     // GetThreadPreferredUILanguages merges in user preferred languages
+#endif
+#ifndef MUI_MERGE_SYSTEM_FALLBACK
+#define MUI_MERGE_SYSTEM_FALLBACK           0x10     // GetThreadPreferredUILanguages merges in parent and base languages
+#endif
+typedef WINBASEAPI BOOL (WINAPI *GET_THREAD_PREFERRED_UI_LANGUAGES) (
+    __in DWORD dwFlags,
+    __out PULONG pulNumLanguages,
+    __out_ecount_opt(*pcchLanguagesBuffer) PZZWSTR pwszLanguagesBuffer,
+    __inout PULONG pcchLanguagesBuffer
+);
+
 extern "C" HRESULT DAPI LocProbeForFile(
     __in_z LPCWSTR wzBasePath,
     __in_z LPCWSTR wzLocFileName,
@@ -33,10 +50,25 @@ extern "C" HRESULT DAPI LocProbeForFile(
     __inout LPWSTR* psczPath
     )
 {
+    return LocProbeForFileEx(wzBasePath, wzLocFileName, wzLanguage, psczPath, FALSE);
+}
+
+extern "C" HRESULT DAPI LocProbeForFileEx(
+    __in_z LPCWSTR wzBasePath,
+    __in_z LPCWSTR wzLocFileName,
+    __in_z_opt LPCWSTR wzLanguage,
+    __inout LPWSTR* psczPath,
+    __in BOOL useUILanguage
+    )
+{
     HRESULT hr = S_OK;
     LPWSTR sczProbePath = NULL;
     LANGID langid = 0;
     LPWSTR sczLangIdFile = NULL;
+    LPWSTR sczLangsBuff = NULL;
+    GET_THREAD_PREFERRED_UI_LANGUAGES pvfnGetThreadPreferredUILanguages =
+        reinterpret_cast<GET_THREAD_PREFERRED_UI_LANGUAGES>(
+            ::GetProcAddress(::GetModuleHandle("Kernel32.dll"), "GetThreadPreferredUILanguages"));
 
     // If a language was specified, look for a loc file in that as a directory.
     if (wzLanguage && *wzLanguage)
@@ -53,7 +85,48 @@ extern "C" HRESULT DAPI LocProbeForFile(
         }
     }
 
-    langid = ::GetUserDefaultLangID();
+    if (useUILanguage && pvfnGetThreadPreferredUILanguages)
+    {
+        ULONG nLangs;
+        ULONG cchLangs = 0;
+        if (!(*pvfnGetThreadPreferredUILanguages)(MUI_LANGUAGE_ID | MUI_MERGE_USER_FALLBACK | MUI_MERGE_SYSTEM_FALLBACK,
+                &nLangs, NULL, &cchLangs))
+        {
+            ExitWithLastError(hr, "GetUserPreferredUILanguages failed to return buffer size");
+        }
+
+        hr = StrAlloc(&sczLangsBuff, cchLangs);
+        ExitOnFailure(hr, "Failed to allocate buffer for languages");
+
+        nLangs = 0;
+        if (!(*pvfnGetThreadPreferredUILanguages)(MUI_LANGUAGE_ID | MUI_MERGE_USER_FALLBACK | MUI_MERGE_SYSTEM_FALLBACK,
+                &nLangs, sczLangsBuff, &cchLangs))
+        {
+            ExitWithLastError(hr, "GetUserPreferredUILanguages failed to return language list");
+        }
+
+        LPWSTR szLangs = sczLangsBuff;
+        for (ULONG i = 0; i < nLangs; ++i, szLangs += 5)
+        {
+            // StrHexDecode assumes low byte is first. We'll need to swap the bytes once we parse out the value
+            hr = StrHexDecode(szLangs, reinterpret_cast<BYTE*>(&langid), sizeof(langid));
+            ExitOnFailure(hr, "Failed to parse langId");
+
+            langid = MAKEWORD(HIBYTE(langid), LOBYTE(langid));
+            hr = StrAllocFormatted(&sczLangIdFile, L"%u\\%ls", langid, wzLocFileName); 
+            ExitOnFailure(hr, "Failed to format user preferred langid.");
+
+            hr = PathConcat(wzBasePath, sczLangIdFile, &sczProbePath); 
+            ExitOnFailure(hr, "Failed to concat user preferred langid file name to base path.");
+
+            if (FileExistsEx(sczProbePath, NULL)) 
+            { 
+                ExitFunction(); 
+            }
+        }
+    }
+
+    langid = useUILanguage ? ::GetUserDefaultUILanguage() : ::GetUserDefaultLangID();
 
     hr = StrAllocFormatted(&sczLangIdFile, L"%u\\%ls", langid, wzLocFileName);
     ExitOnFailure(hr, "Failed to format user langid.");
@@ -128,6 +201,7 @@ LExit:
 
     ReleaseStr(sczLangIdFile);
     ReleaseStr(sczProbePath);
+    ReleaseStr(sczLangsBuff);
 
     return hr;
 }

--- a/src/tools/wix/Compiler.cs
+++ b/src/tools/wix/Compiler.cs
@@ -20508,7 +20508,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
                 }
                 else
                 {
-                    this.core.UnsupportedExtensionAttribute(sourceLineNumbers, attrib);
+                    this.core.ParseExtensionAttribute(sourceLineNumbers, node as XmlElement, attrib);
                 }
             }
 
@@ -20749,7 +20749,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
                 }
                 else
                 {
-                    this.core.UnsupportedExtensionAttribute(sourceLineNumbers, attrib);
+                    this.core.ParseExtensionAttribute(sourceLineNumbers, node as XmlElement, attrib);
                 }
             }
 

--- a/src/tools/wix/CompilerCore.cs
+++ b/src/tools/wix/CompilerCore.cs
@@ -199,6 +199,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
                 "TempFolder",
                 "TemplateFolder",
                 "TerminalServer",
+                "UserUILanguageID",
                 "UserLanguageID",
                 "VersionMsi",
                 "VersionNT",

--- a/src/tools/wix/Xsd/wix.xsd
+++ b/src/tools/wix/Xsd/wix.xsd
@@ -387,6 +387,14 @@
           <xs:documentation>The relative destination path and file name for the bootstrapper application DLL. The default is the source file name. Use this attribute to rename the bootstrapper application DLL or extract it into a subfolder.</xs:documentation>
         </xs:annotation>
       </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+              Extensibility point in the WiX XML Schema.  Schema extensions can register additional
+              attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
     </xs:complexType>
   </xs:element>
   <xs:element name="BootstrapperApplicationRef">

--- a/test/src/UnitTests/Burn/VariableTest.cpp
+++ b/test/src/UnitTests/Burn/VariableTest.cpp
@@ -432,6 +432,7 @@ namespace Bootstrapper
                 VariableGetNumericHelper(&variables, L"Privileged");
                 VariableGetNumericHelper(&variables, L"SystemLanguageID");
                 VariableGetNumericHelper(&variables, L"TerminalServer");
+                VariableGetNumericHelper(&variables, L"UserUILanguageID");
                 VariableGetNumericHelper(&variables, L"UserLanguageID");
 
                 // known folders


### PR DESCRIPTION
This is a WiX 3.x only implementation, making fixing the code that determines the user's locale an opt-in (if you don't opt-in, you retain the current behavior). There is a separate implementation in another pull request for 4.0 which doesn't require opting into correct behavior.
