### PR TITLE
WIXBUG:4804 - Add DAPI to get the right calling convention.

### DIFF
--- a/history/4804.md
+++ b/history/4804.md
@@ -1,0 +1,1 @@
+* BobArnson: WIXBUG:4804 - Add DAPI to get the right calling convention.

--- a/src/libs/dutil/inc/strutil.h
+++ b/src/libs/dutil/inc/strutil.h
@@ -233,7 +233,7 @@ HRESULT DAPI MultiSzReplaceString(
     __in_z LPCWSTR pwzString
     );
 
-LPCWSTR wcsistr(
+LPCWSTR DAPI wcsistr(
     __in_z LPCWSTR wzString,
     __in_z LPCWSTR wzCharSet
     );

--- a/src/libs/dutil/strutil.cpp
+++ b/src/libs/dutil/strutil.cpp
@@ -2235,7 +2235,7 @@ LExit:
 wcsistr - case insensitive find a substring
 
 ****************************************************************************/
-extern "C" LPCWSTR wcsistr(
+extern "C" LPCWSTR DAPI wcsistr(
     __in_z LPCWSTR wzString,
     __in_z LPCWSTR wzCharSet
     )


### PR DESCRIPTION
This isn't strictly necessary since both header and module have the same calling convention. But now they match everything else.