### PR TITLE
WIXBUG:3902 - Fix ability to find config files in certain circumstances

### DIFF
--- a/history/3902.md
+++ b/history/3902.md
@@ -1,0 +1,1 @@
+* BMurri: WIXBUG:3902 - Fix ability to find config files in certain circumstances.

--- a/src/tools/wix/AppCommon.cs
+++ b/src/tools/wix/AppCommon.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
             // Don't use the default AppSettings reader because
             // the tool may be called from within another process.
             // Instead, read the .exe.config file from the tool location.
-            string toolPath = Assembly.GetCallingAssembly().Location;
+            string toolPath = (new System.Uri(Assembly.GetCallingAssembly().CodeBase)).LocalPath;
             Configuration config = ConfigurationManager.OpenExeConfiguration(toolPath);
             if (config.HasFile)
             {


### PR DESCRIPTION
Bug is [here](http://wixtoolset.org/issues/3902/)

There's a separate pull request for wix4.