### PR TITLE
Fix build break with VS2015 RTM

### DIFF
--- a/test/src/UnitTests/Burn/ElevationTest.cpp
+++ b/test/src/UnitTests/Burn/ElevationTest.cpp
@@ -147,7 +147,7 @@ static DWORD CALLBACK ElevateTest_ThreadProc(
     StrAlloc(&connection.sczSecret, MAX_PATH);
 
     // parse command line arguments
-    if (3 != swscanf_s(sczArguments, L"-q -burn.elevated %s %s %u", connection.sczName, MAX_PATH, connection.sczSecret, MAX_PATH, &connection.dwProcessId, sizeof(connection.dwProcessId)))
+    if (3 != swscanf_s(sczArguments, L"-q -burn.elevated %s %s %u", connection.sczName, MAX_PATH, connection.sczSecret, MAX_PATH, &connection.dwProcessId))
     {
         hr = E_INVALIDARG;
         ExitOnFailure(hr, "Failed to parse argument string.");


### PR DESCRIPTION
Fix swscanf_s calls to pass sizes only for characters and strings.