### PR TITLE
WIXBUG:4737 - fixed condition of showing InvalidDirDlg from BrowseDlg

### DIFF
--- a/src/ext/UIExtension/wixlib/WixUI_InstallDir.wxs
+++ b/src/ext/UIExtension/wixlib/WixUI_InstallDir.wxs
@@ -50,7 +50,7 @@ Patch dialog sequence:
             <DialogRef Id="UserExit" />
             
             <Publish Dialog="BrowseDlg" Control="OK" Event="DoAction" Value="WixUIValidatePath" Order="3">1</Publish>
-            <Publish Dialog="BrowseDlg" Control="OK" Event="SpawnDialog" Value="InvalidDirDlg" Order="4"><![CDATA[WIXUI_INSTALLDIR_VALID<>"1"]]></Publish>
+            <Publish Dialog="BrowseDlg" Control="OK" Event="SpawnDialog" Value="InvalidDirDlg" Order="4"><![CDATA[NOT WIXUI_DONTVALIDATEPATH AND WIXUI_INSTALLDIR_VALID<>"1"]]></Publish>
 
             <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999">1</Publish>
 


### PR DESCRIPTION
Another pull request exists in wix4 for the same issue