### PR TITLE
Fix Wix Bug #4852

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* MikeGC: WIXBUG:4852 - Keep QuietExec function definition the same as in prior versions to avoid breaking anyone. The new function (with more parameters) is now named QuietExecEx.
+
 ## WixBuild: Version 3.10.0.1823
 
 * @barnson: WIXFEAT:4789 - Phase I of .NET Framework 4.6 support (RC, full redist).

--- a/src/ext/NetFxExtension/ca/netfxca.cpp
+++ b/src/ext/NetFxExtension/ca/netfxca.cpp
@@ -810,7 +810,7 @@ extern "C" UINT __stdcall ExecNetFx(
         hr = WcaReadIntegerFromCaData(&pwz, &iCost);
         ExitOnFailure(hr, "failed to read cost from custom action data");
 
-        hr = QuietExec(pwzData, NGEN_TIMEOUT, TRUE, TRUE);
+        hr = QuietExecEx(pwzData, NGEN_TIMEOUT, TRUE, TRUE);
         // If we fail here it isn't critical - keep looping through to try to act on the other assemblies on our list
         if (FAILED(hr))
         {

--- a/src/ext/ca/wixca/dll/qtexecca.cpp
+++ b/src/ext/ca/wixca/dll/qtexecca.cpp
@@ -123,7 +123,7 @@ HRESULT ExecCommon(
 
     dwTimeout = GetTimeout(wzTimeoutProperty);
 
-    hr = QuietExec(pwzCommand, dwTimeout, fLogCommand, fLogOutput);
+    hr = QuietExecEx(pwzCommand, dwTimeout, fLogCommand, fLogOutput);
     ExitOnFailure(hr, "QuietExec Failed");
 
 LExit:
@@ -162,7 +162,7 @@ HRESULT ExecCommon64(
 
     dwTimeout = GetTimeout(wzTimeoutProperty);
 
-    hr = QuietExec(pwzCommand, dwTimeout, fLogCommand, fLogOutput);
+    hr = QuietExecEx(pwzCommand, dwTimeout, fLogCommand, fLogOutput);
     ExitOnFailure(hr, "QuietExec64 Failed");
 
 LExit:

--- a/src/libs/wcautil/qtexec.cpp
+++ b/src/libs/wcautil/qtexec.cpp
@@ -237,6 +237,14 @@ LExit:
 
 HRESULT WIXAPI QuietExec(
     __inout_z LPWSTR wzCommand,
+    __in DWORD dwTimeout
+    )
+{
+    return QuietExecEx(wzCommand, dwTimeout, TRUE, TRUE);
+}
+
+HRESULT WIXAPI QuietExecEx(
+    __inout_z LPWSTR wzCommand,
     __in DWORD dwTimeout,
     __in BOOL fLogCommand,
     __in BOOL fLogOutput

--- a/src/libs/wcautil/wcautil.h
+++ b/src/libs/wcautil/wcautil.h
@@ -360,6 +360,11 @@ void WIXAPI WcaCaScriptCleanup(
 
 HRESULT WIXAPI QuietExec(
     __inout_z LPWSTR wzCommand,
+    __in DWORD dwTimeout
+    );
+
+HRESULT WIXAPI QuietExecEx(
+    __inout_z LPWSTR wzCommand,
     __in DWORD dwTimeout,
     __in BOOL fLogCommand,
     __in BOOL fLogOutput


### PR DESCRIPTION
keep QuietExec function definition the same as in prior releases to avoid breaking anyone