### PR TITLE
WIXBUG:4882 - handle all kinds of bad version strings in WixTagExtension

### DIFF
--- a/history/4882.md
+++ b/history/4882.md
@@ -1,0 +1,1 @@
+* RobMen: WIXBUG:4882 - handle all kinds of bad version strings in WixTagExtension.

--- a/src/ext/TagExtension/wixext/TagBinder.cs
+++ b/src/ext/TagExtension/wixext/TagBinder.cs
@@ -206,10 +206,17 @@ namespace Microsoft.Tools.WindowsInstallerXml.Extensions
                                    -1 < version.Build ? version.Build : 0,
                                    -1 < version.Revision ? version.Revision : 0);
             }
+            catch (ArgumentException)
+            {
+            }
             catch (FormatException)
             {
-                return new Version();
             }
+            catch (OverflowException)
+            {
+            }
+
+            return new Version();
         }
 
         private static string NormalizeGuid(string guidString)


### PR DESCRIPTION
Should have added these the first time around.