### PR TITLE
Fix BalExtension bug: the value of 'LaunchWorkingFolder' is not formatted.

### DIFF
--- a/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
+++ b/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
@@ -2846,6 +2846,7 @@ private: // privates
         LPWSTR sczLaunchTargetElevatedId = NULL;
         LPWSTR sczUnformattedArguments = NULL;
         LPWSTR sczArguments = NULL;
+		LPWSTR sczUnformattedLaunchFolder = NULL;
         LPWSTR sczLaunchFolder = NULL;
         int nCmdShow = SW_SHOWNORMAL;
 
@@ -2874,7 +2875,7 @@ private: // privates
 
         if (BalStringVariableExists(WIXSTDBA_VARIABLE_LAUNCH_WORK_FOLDER))
         {
-            hr = BalGetStringVariable(WIXSTDBA_VARIABLE_LAUNCH_WORK_FOLDER, &sczLaunchFolder);
+            hr = BalGetStringVariable(WIXSTDBA_VARIABLE_LAUNCH_WORK_FOLDER, &sczUnformattedLaunchFolder);
             BalExitOnFailure1(hr, "Failed to get launch working directory variable '%ls'.", WIXSTDBA_VARIABLE_LAUNCH_WORK_FOLDER);
         }
 
@@ -2898,14 +2899,21 @@ private: // privates
                 BalExitOnFailure1(hr, "Failed to format launch arguments variable: %ls", sczUnformattedArguments);
             }
 
+			if (sczUnformattedLaunchFolder)
+			{
+				hr = BalFormatString(sczUnformattedLaunchFolder, &sczLaunchFolder);
+				BalExitOnFailure1(hr, "Failed to format launch working directory variable: %ls", sczUnformattedLaunchFolder);
+			}
+
             hr = ShelExec(sczLaunchTarget, sczArguments, L"open", sczLaunchFolder, nCmdShow, m_hWnd, NULL);
             BalExitOnFailure1(hr, "Failed to launch target: %ls", sczLaunchTarget);
 
             ::PostMessageW(m_hWnd, WM_CLOSE, 0, 0);
         }
 
-    LExit:
-        ReleaseStr(sczLaunchFolder);
+	LExit:
+		StrSecureZeroFreeString(sczLaunchFolder);
+        ReleaseStr(sczUnformattedLaunchFolder);
         StrSecureZeroFreeString(sczArguments);
         ReleaseStr(sczUnformattedArguments);
         ReleaseStr(sczLaunchTargetElevatedId);

--- a/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
+++ b/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
@@ -2846,7 +2846,7 @@ private: // privates
         LPWSTR sczLaunchTargetElevatedId = NULL;
         LPWSTR sczUnformattedArguments = NULL;
         LPWSTR sczArguments = NULL;
-		LPWSTR sczUnformattedLaunchFolder = NULL;
+        LPWSTR sczUnformattedLaunchFolder = NULL;
         LPWSTR sczLaunchFolder = NULL;
         int nCmdShow = SW_SHOWNORMAL;
 
@@ -2899,11 +2899,11 @@ private: // privates
                 BalExitOnFailure1(hr, "Failed to format launch arguments variable: %ls", sczUnformattedArguments);
             }
 
-			if (sczUnformattedLaunchFolder)
-			{
-				hr = BalFormatString(sczUnformattedLaunchFolder, &sczLaunchFolder);
-				BalExitOnFailure1(hr, "Failed to format launch working directory variable: %ls", sczUnformattedLaunchFolder);
-			}
+            if (sczUnformattedLaunchFolder)
+            {
+                hr = BalFormatString(sczUnformattedLaunchFolder, &sczLaunchFolder);
+                BalExitOnFailure1(hr, "Failed to format launch working directory variable: %ls", sczUnformattedLaunchFolder);
+            }
 
             hr = ShelExec(sczLaunchTarget, sczArguments, L"open", sczLaunchFolder, nCmdShow, m_hWnd, NULL);
             BalExitOnFailure1(hr, "Failed to launch target: %ls", sczLaunchTarget);
@@ -2911,8 +2911,8 @@ private: // privates
             ::PostMessageW(m_hWnd, WM_CLOSE, 0, 0);
         }
 
-	LExit:
-		StrSecureZeroFreeString(sczLaunchFolder);
+    LExit:
+        StrSecureZeroFreeString(sczLaunchFolder);
         ReleaseStr(sczUnformattedLaunchFolder);
         StrSecureZeroFreeString(sczArguments);
         ReleaseStr(sczUnformattedArguments);


### PR DESCRIPTION
The value of 'LaunchWorkingFolder' is not formatted.

The specification[[1](http://wixtoolset.org/documentation/manual/v3/xsd/bal/wixstandardbootstrapperapplication.html)] says:

> LaunchWorkingFolder: 
> ...
> WixStdBA will use this working folder when launching the specified application. 
> The string value can be formatted using Burn variables enclosed in brackets, to refer to installation directories and so forth. 
