### PR TITLE
Fix app.config name translation for projects with no exe output

### DIFF
--- a/src/ext/VSExtension/wixext/VSProjectHarvester.cs
+++ b/src/ext/VSExtension/wixext/VSProjectHarvester.cs
@@ -481,6 +481,7 @@ namespace Microsoft.Tools.WindowsInstallerXml.Extensions
             int fileCount = 0;
 
             Wix.ISchemaElement exeFile = null;
+            Wix.ISchemaElement dllFile = null;
             Wix.ISchemaElement appConfigFile = null;
 
             // Keep track of files inserted
@@ -550,6 +551,10 @@ namespace Microsoft.Tools.WindowsInstallerXml.Extensions
                     {
                         exeFile = file;
                     }
+                    else if (String.Equals(Path.GetExtension(file.Source), ".dll", StringComparison.OrdinalIgnoreCase))
+                    {
+                        dllFile = file;
+                    }
                     else if (file.Source.EndsWith("app.config", StringComparison.OrdinalIgnoreCase))
                     {
                         appConfigFile = file;
@@ -557,6 +562,12 @@ namespace Microsoft.Tools.WindowsInstallerXml.Extensions
                 }
 
                 fileCount++;
+            }
+
+            // if there was no exe file found fallback on the dll file found
+            if (exeFile == null && dllFile != null)
+            {
+                exeFile = dllFile;
             }
 
             // Special case for the app.config file in the Binaries POG...


### PR DESCRIPTION
http://wixtoolset.org/issues/4335/