### PR TITLE
fix hyperlinks works on Windows XP

### DIFF
--- a/src/libs/dutil/shelutil.cpp
+++ b/src/libs/dutil/shelutil.cpp
@@ -259,6 +259,7 @@ static HRESULT GetDesktopShellView(
     IDispatch* pdisp = NULL;
     VARIANT vEmpty = {}; // VT_EMPTY
     IShellBrowser* psb = NULL;
+    IShellFolder* psf = NULL;
     IShellView* psv = NULL;
 
     // use the shell view for the desktop using the shell windows automation to find the 
@@ -268,20 +269,35 @@ static HRESULT GetDesktopShellView(
     ExitOnFailure(hr, "Failed to get shell view.");
 
     hr = psw->FindWindowSW(&vEmpty, &vEmpty, SWC_DESKTOP, (long*)&hwnd, SWFO_NEEDDISPATCH, &pdisp);
-    ExitOnFailure(hr, "Failed to get desktop window.");
+    if (S_OK == hr)
+    {
+        hr = IUnknown_QueryService(pdisp, SID_STopLevelBrowser, IID_PPV_ARGS(&psb));
+        ExitOnFailure(hr, "Failed to get desktop window.");
 
-    hr = IUnknown_QueryService(pdisp, SID_STopLevelBrowser, IID_PPV_ARGS(&psb));
-    ExitOnFailure(hr, "Failed to get desktop window.");
+        hr = psb->QueryActiveShellView(&psv);
+        ExitOnFailure(hr, "Failed to get active shell view.");
 
-    hr = psb->QueryActiveShellView(&psv);
-    ExitOnFailure(hr, "Failed to get active shell view.");
+        hr = psv->QueryInterface(riid, ppv);
+        ExitOnFailure(hr, "Failed to query for the desktop shell view.");
+    }
+    else if (S_FALSE == hr)
+    {
+        //Windows XP
+        hr = SHGetDesktopFolder(&psf);
+        ExitOnFailure(hr, "Failed to get desktop folder.");
 
-    hr = psv->QueryInterface(riid, ppv);
-    ExitOnFailure(hr, "Failed to query for the desktop shell view.");
+        hr = psf->CreateViewObject(NULL, IID_IShellView, ppv);
+        ExitOnFailure(hr, "Failed to query for the desktop shell view.");
+    }
+    else
+    {
+        ExitOnFailure(hr, "Failed to get desktop window.");
+    }
 
 LExit:
     ReleaseObject(psv);
     ReleaseObject(psb);
+    ReleaseObject(psf);
     ReleaseObject(pdisp);
     ReleaseObject(psw);
 


### PR DESCRIPTION
Now, links on Windows XP does not working at all.
Flag SWC_DESKTOP of method IShellWindows::FindWindow not supported on Windows XP, thats why we need alternative method to get IShellView pointer.