### PR TITLE
fix messing controls background  when Alt pressed

### DIFF
--- a/src/libs/dutil/thmutil.cpp
+++ b/src/libs/dutil/thmutil.cpp
@@ -887,6 +887,25 @@ extern "C" LRESULT CALLBACK ThemeDefWindowProc(
     {
         switch (uMsg)
         {
+        // if we have image (or other owner-draw ctrl) on page, controls with over it and Alt pressed:
+        case WM_SYSCOMMAND:
+            if(SC_KEYMENU == wParam)
+            {
+                ::RedrawWindow(hWnd, NULL, NULL, RDW_INVALIDATE);
+            }
+            break;
+
+        // if we have image (or other owner-draw ctrl) on page, controls with over it and Alt+Click:
+        case WM_LBUTTONDOWN:
+        case WM_RBUTTONDOWN:
+        case WM_MBUTTONDOWN:
+        case WM_MOUSEACTIVATE:
+            if(GetKeyState(VK_MENU) < 0)
+            {
+                ::RedrawWindow(hWnd, NULL, NULL, RDW_INVALIDATE);
+            }
+            break;
+
         case WM_NCHITTEST:
             if (pTheme->dwStyle & WS_POPUP)
             {


### PR DESCRIPTION
Problem occurs if we have image on page, controls over it and Alt(+Click) pressed.
The situation are the same as discribed [here](http://windows-installer-xml-wix-toolset.687559.n2.nabble.com/alt-key-in-bootstrapper-messes-up-the-foreground-background-of-controls-td7592823.html)

What happend when the ALT key pressed:
Window contorls must be highlighted by undrelining access key (for access by Alt+<key>).
If we have owner-draw controls (such as image) on the page they are always redrawn if ALT pressed via receiving WM_DRAWITEM. Controls without SS_OWNERDRAW does not do this. Therefore, their background is erased. 

The simplest solution is to redraw the whole window after ALT pressed.

Example to reproduce:

``` javascript
<Theme xmlns="http://wixtoolset.org/schemas/thmutil/2010">
  <Window Width="614" Height="415" HexStyle="100a0000" FontId="0" SourceX="0" SourceY="0">#(loc.Caption)</Window>
  <Page Name="Help">
    <Image X="0" Y="0" Width="614" Height="415" ImageFile="bgClear.png"/>
    <Text X="25" Y="85" Width="-25" Height="32" FontId="1" DisablePrefix="yes">#(loc.HelpHeader)</Text>
    <Text X="25" Y="120" Width="-25" Height="-101" FontId="3" DisablePrefix="yes">#(loc.HelpText)</Text>
    <Button Name="HelpCancelButton" X="-25" Y="-35" Width="103" Height="23" TabStop="yes" FontId="0" DisablePrefix="yes">#(loc.HelpCloseButton)</Button>
  </Page>
```
