### PR TITLE
Added description for ERROR_FAIL_NOACTION_REBOOT on Windows XP

### DIFF
--- a/src/libs/dutil/strutil.cpp
+++ b/src/libs/dutil/strutil.cpp
@@ -1169,11 +1169,21 @@ extern "C" HRESULT DAPI StrAllocFromError(
 
     if (0 == cchMessage)
     {
-        ExitWithLastError1(hr, "Failed to format message for error: 0x%x", hrError);
+        if(ERROR_FAIL_NOACTION_REBOOT == HRESULT_CODE(hrError)) // Windows XP
+        {
+            hr = StrAllocString(ppwzMessage, L"No action was taken as a system reboot is required.", 0);
+            ExitOnFailure(hr, "Failed to allocate string for message.");
+        }
+        else
+        {
+            ExitWithLastError1(hr, "Failed to format message for error: 0x%x", hrError);
+        }
     }
-
-    hr = StrAllocString(ppwzMessage, reinterpret_cast<LPCWSTR>(pvMessage), cchMessage);
-    ExitOnFailure(hr, "Failed to allocate string for message.");
+    else
+    {
+        hr = StrAllocString(ppwzMessage, reinterpret_cast<LPCWSTR>(pvMessage), cchMessage);
+        ExitOnFailure(hr, "Failed to allocate string for message.");
+    }
 
 LExit:
     if (pvMessage)


### PR DESCRIPTION
Ticket [here](http://wixtoolset.org/issues/4933/)

Since dutil does not have own string resources (to add them for only this would be a big overhead), let's add at least an English description of the error. That will help many of users to undrestand situation.
