### PR TITLE
Fix bootstrapper silent hanging behaviour in case access to TMPDIR is denied

### DIFF
--- a/src/burn/engine/cache.cpp
+++ b/src/burn/engine/cache.cpp
@@ -183,6 +183,10 @@ extern "C" HRESULT CacheEnsureWorkingFolder(
     ExitOnFailure(hr, "Failed to calculate working folder to ensure it exists.");
 
     hr = DirEnsureExists(sczWorkingFolder, NULL);
+    if (HRESULT_FROM_WIN32(ERROR_ACCESS_DENIED) == hr || HRESULT_FROM_WIN32(ERROR_DISK_FULL) == hr)
+    {
+        hr = HRESULT_FROM_WIN32(ERROR_INSTALL_TEMP_UNWRITABLE);
+    }
     ExitOnFailure(hr, "Failed create working folder.");
 
     // Best effort to ensure our working folder is not encrypted.

--- a/src/burn/engine/engine.cpp
+++ b/src/burn/engine/engine.cpp
@@ -175,6 +175,10 @@ extern "C" HRESULT EngineRun(
 LExit:
     ReleaseStr(sczExePath);
 
+    if (FAILED(hr)) {
+        SplashScreenDisplayError(engineState.command.display, engineState.registration.sczDisplayName, hr);
+    }
+
     // If anything went wrong but the log was never open, try to open a "failure" log
     // and that will dump anything captured in the log memory buffer to the log.
     if (FAILED(hr) && BURN_LOGGING_STATE_CLOSED == engineState.log.state)

--- a/src/libs/dutil/pathutil.cpp
+++ b/src/libs/dutil/pathutil.cpp
@@ -14,6 +14,7 @@
 #include "precomp.h"
 
 #define PATH_GOOD_ENOUGH 64
+static const DWORD TEMP_FILE_CREATE_RETRY_COUNT = 300;
 
 
 DAPI_(HRESULT) PathCommandLineAppend(
@@ -634,6 +635,7 @@ DAPI_(HRESULT) PathCreateTimeBasedTempFile(
 {
     HRESULT hr = S_OK;
     BOOL fRetry = FALSE;
+    DWORD cRetry = 0;
     WCHAR wzTempPath[MAX_PATH] = { };
     LPWSTR sczPrefix = NULL;
     LPWSTR sczPrefixFolder = NULL;
@@ -689,8 +691,12 @@ DAPI_(HRESULT) PathCreateTimeBasedTempFile(
             {
                 ::Sleep(100);
 
-                er = ERROR_SUCCESS;
-                fRetry = TRUE;
+                ++cRetry;
+                if (cRetry <= TEMP_FILE_CREATE_RETRY_COUNT)
+                {
+                    fRetry = TRUE;
+                    er = ERROR_SUCCESS;
+                }
             }
 
             hr = HRESULT_FROM_WIN32(er);


### PR DESCRIPTION
Updated version of closed #308 (https://github.com/wixtoolset/wix3/pull/308) PR due to problems to reopen the first one after amending.

The set of commits fixes the problem, described below:
1. Make TMP directory read-only for user.
2. Run bootstrapper application

Expected: bootstrapper either works normally or informs about an error.
Observed: bootstrapper hangs silently.

Bug #4929 - Bootstrapper silently hangs if TMPDIR is read-only (http://wixtoolset.org/issues/4929/)
