### PR TITLE
Change Burn's behavior to, instead of skipping all related bundles wh…

### DIFF
--- a/history/embedded.related.bundles.md
+++ b/history/embedded.related.bundles.md
@@ -1,0 +1,1 @@
+* BobArnson: Change Burn's behavior to, instead of skipping all related bundles when the current bundle is embedded, skip only dependent bundles when the current bundle is a related bundle. (Burn supports embedded mode in cases other than when being executed as a related bundle.)

--- a/src/burn/engine/core.cpp
+++ b/src/burn/engine/core.cpp
@@ -456,7 +456,7 @@ extern "C" HRESULT CorePlan(
             DWORD dwExecuteActionEarlyIndex = pEngineState->plan.cExecuteActions;
 
             // Plan the related bundles first to support downgrades with ref-counting.
-            hr = PlanRelatedBundlesBegin(&pEngineState->userExperience, &pEngineState->registration, pEngineState->command.relationType, &pEngineState->plan, pEngineState->mode);
+            hr = PlanRelatedBundlesBegin(&pEngineState->userExperience, &pEngineState->registration, pEngineState->command.relationType, &pEngineState->plan);
             ExitOnFailure(hr, "Failed to plan related bundles.");
 
             hr = PlanPackages(&pEngineState->registration, &pEngineState->userExperience, &pEngineState->packages, &pEngineState->plan, &pEngineState->log, &pEngineState->variables, pEngineState->registration.fInstalled, pEngineState->command.display, pEngineState->command.relationType, NULL, &hSyncpointEvent);

--- a/src/burn/engine/engine.mc
+++ b/src/burn/engine/engine.mc
@@ -367,9 +367,9 @@ Planned forward compatible bundle: %1!ls!, default requested: %2!hs!, ba request
 
 MessageId=213
 Severity=Success
-SymbolicName=MSG_PLAN_SKIPPED_RELATED_BUNDLE_EMBEDDED
+SymbolicName=MSG_PLAN_SKIPPED_RELATED_BUNDLE_DEPENDENT
 Language=English
-Plan skipped related bundle: %1!ls!, type: %2!hs!, because it was embedded.
+Plan skipped related bundle: %1!ls!, type: %2!hs!, because it was dependent and the current bundle is being executed as type: %3!hs!.
 .
 
 MessageId=214

--- a/src/burn/engine/plan.cpp
+++ b/src/burn/engine/plan.cpp
@@ -1170,8 +1170,7 @@ extern "C" HRESULT PlanRelatedBundlesBegin(
     __in BURN_USER_EXPERIENCE* pUserExperience,
     __in BURN_REGISTRATION* pRegistration,
     __in BOOTSTRAPPER_RELATION_TYPE relationType,
-    __in BURN_PLAN* pPlan,
-    __in BURN_MODE mode
+    __in BURN_PLAN* pPlan
     )
 {
     HRESULT hr = S_OK;
@@ -1208,24 +1207,11 @@ extern "C" HRESULT PlanRelatedBundlesBegin(
                 ExitOnFailure(hr, "Failed to lookup the bundle ID in the ancestors dictionary.");
             }
         }
-        else if (BURN_MODE_EMBEDDED == mode)
+        else if (BOOTSTRAPPER_RELATION_DEPENDENT == pRelatedBundle->relationType && BOOTSTRAPPER_RELATION_NONE != relationType)
         {
-            BOOL fSkipBundle = TRUE;
-            for (DWORD j = 0; j < pRelatedBundle->package.cDependencyProviders; ++j)
-            {
-                const BURN_DEPENDENCY_PROVIDER* pProvider = pRelatedBundle->package.rgDependencyProviders + j;
-                if (CSTR_EQUAL == ::CompareStringW(LOCALE_INVARIANT, NORM_IGNORECASE, pProvider->sczKey, -1, pRegistration->sczProviderKey, -1))
-                {
-                    fSkipBundle = FALSE;
-                }
-            }
-
-            if (fSkipBundle)
-            {
-                // Protect loops for older bundles that do not handle ancestors.
-                LogId(REPORT_STANDARD, MSG_PLAN_SKIPPED_RELATED_BUNDLE_EMBEDDED, pRelatedBundle->package.sczId, LoggingRelationTypeToString(pRelatedBundle->relationType));
-                continue;
-            }
+            // Avoid repair loops for older bundles that do not handle ancestors.
+            LogId(REPORT_STANDARD, MSG_PLAN_SKIPPED_RELATED_BUNDLE_DEPENDENT, pRelatedBundle->package.sczId, LoggingRelationTypeToString(pRelatedBundle->relationType), LoggingRelationTypeToString(relationType));
+            continue;
         }
 
         // Pass along any ancestors and ourself to prevent infinite loops.

--- a/src/burn/engine/plan.h
+++ b/src/burn/engine/plan.h
@@ -448,8 +448,7 @@ HRESULT PlanRelatedBundlesBegin(
     __in BURN_USER_EXPERIENCE* pUserExperience,
     __in BURN_REGISTRATION* pRegistration,
     __in BOOTSTRAPPER_RELATION_TYPE relationType,
-    __in BURN_PLAN* pPlan,
-    __in BURN_MODE mode
+    __in BURN_PLAN* pPlan
     );
 HRESULT PlanRelatedBundlesComplete(
     __in BURN_REGISTRATION* pRegistration,


### PR DESCRIPTION
…en the current bundle is embedded, skip only dependent bundles when the current bundle is a related bundle. (Burn supports embedded mode in cases other than when being executed as a related bundle.)