### PR TITLE
WIXBUG:5185 - correct LPWSTR to LPCWSTR

### DIFF
--- a/history/5185.md
+++ b/history/5185.md
@@ -1,0 +1,1 @@
+* @barnson: WIXBUG:5185 - correct LPWSTR to LPCWSTR

--- a/src/burn/engine/EngineForApplication.cpp
+++ b/src/burn/engine/EngineForApplication.cpp
@@ -491,8 +491,8 @@ public: // IBootstrapperEngine
         __in_z LPCWSTR wzPackageOrContainerId,
         __in_z_opt LPCWSTR wzPayloadId,
         __in_z LPCWSTR wzUrl,
-        __in_z_opt LPWSTR wzUser,
-        __in_z_opt LPWSTR wzPassword
+        __in_z_opt LPCWSTR wzUser,
+        __in_z_opt LPCWSTR wzPassword
         )
     {
         HRESULT hr = S_OK;

--- a/src/burn/inc/IBootstrapperEngine.h
+++ b/src/burn/inc/IBootstrapperEngine.h
@@ -182,8 +182,8 @@ DECLARE_INTERFACE_IID_(IBootstrapperEngine, IUnknown, "6480D616-27A0-44D7-905B-8
         __in_z LPCWSTR wzPackageOrContainerId,
         __in_z_opt LPCWSTR wzPayloadId,
         __in_z LPCWSTR wzUrl,
-        __in_z_opt LPWSTR wzUser,
-        __in_z_opt LPWSTR wzPassword
+        __in_z_opt LPCWSTR wzUser,
+        __in_z_opt LPCWSTR wzPassword
         ) = 0;
 
     STDMETHOD(SetVariableNumeric)(


### PR DESCRIPTION
Fixes wixtoolset/issues#5185.