### PR TITLE
Fix #5217: Ignore failure to check domain existence on ConfigureUsers

### DIFF
--- a/src/ext/ca/serverca/scasched/scauser.cpp
+++ b/src/ext/ca/serverca/scasched/scauser.cpp
@@ -540,6 +540,8 @@ HRESULT ScaUserExecute(
             ueUserExists = USER_EXISTS_INDETERMINATE;
             hr = HRESULT_FROM_WIN32(er);
             WcaLog(LOGMSG_VERBOSE, "Failed to check existence of domain: %ls, user: %ls (error code 0x%x) - continuing", wzDomain, psu->wzName, hr);
+			hr = S_OK;
+			er = ERROR_SUCCESS;
         }
 
         if (WcaIsInstalling(psu->isInstalled, psu->isAction))

--- a/src/ext/ca/serverca/scasched/scauser.cpp
+++ b/src/ext/ca/serverca/scasched/scauser.cpp
@@ -515,7 +515,7 @@ HRESULT ScaUserExecute(
         if (wzDomain && *wzDomain)
         {
             er = ::DsGetDcNameW(NULL, wzDomain, NULL, NULL, NULL, &pDomainControllerInfo);
-            if (HRESULT_FROM_WIN32(er) == RPC_S_SERVER_UNAVAILABLE)
+            if (RPC_S_SERVER_UNAVAILABLE == er)
             {
                 // MSDN says, if we get the above error code, try again with the "DS_FORCE_REDISCOVERY" flag
                 er = ::DsGetDcNameW(NULL, wzDomain, NULL, NULL, DS_FORCE_REDISCOVERY, &pDomainControllerInfo);


### PR DESCRIPTION
Reset er and hr variables when deciding to continue after failing to check existence of the domain
