### PR TITLE
Optionally allow duplicate directory identifiers

### DIFF
--- a/history/5227.md
+++ b/history/5227.md
@@ -1,0 +1,1 @@
+* HeathS: WIXBUG:5227 - Allow for merging of directories from different wixlibs and sources

--- a/src/chm/documents/msbuild/task_reference/light.html.md
+++ b/src/chm/documents/msbuild/task_reference/light.html.md
@@ -123,6 +123,14 @@ The following table describes the parameters that are specific to the <b>Light</
   </tr>
 
   <tr>
+    <td><b>AllowDuplicateDirectoryIds</b></td>
+
+    <td>Optional <b>boolean</b> parameter.<br />
+    <br />
+    Specifies that the linker should allow duplicate directory identifiers. This allows duplicate directories from different libraries to be merged into the product. This is equivalent to the -ad switch in light.exe.</td>
+  </tr>
+
+  <tr>
     <td><b>AllowUnresolvedReferences</b></td>
 
     <td>Optional <b>boolean</b> parameter.<br />

--- a/src/tools/WixTasks/Light.cs
+++ b/src/tools/WixTasks/Light.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Tools.WindowsInstallerXml.Build.Tasks
 
         private string additionalCub;
         private bool allowIdenticalRows;
+        private bool allowDuplicateDirectoryIds;
         private bool allowUnresolvedReferences;
         private string[] baseInputPaths;
         private ITaskItem[] bindInputPaths;
@@ -104,6 +105,12 @@ namespace Microsoft.Tools.WindowsInstallerXml.Build.Tasks
         {
             get { return this.allowIdenticalRows; }
             set { this.allowIdenticalRows = value; }
+        }
+
+        public bool AllowDuplicateDirectoryIds
+        {
+            get { return this.allowDuplicateDirectoryIds; }
+            set { this.allowDuplicateDirectoryIds = value; }
         }
 
         public bool AllowUnresolvedReferences
@@ -443,6 +450,7 @@ namespace Microsoft.Tools.WindowsInstallerXml.Build.Tasks
             base.BuildCommandLine(commandLineBuilder);
 
             commandLineBuilder.AppendIfTrue("-ai", this.AllowIdenticalRows);
+            commandLineBuilder.AppendIfTrue("-ad", this.AllowDuplicateDirectoryIds);
             commandLineBuilder.AppendIfTrue("-au", this.AllowUnresolvedReferences);
             commandLineBuilder.AppendArrayIfNotNull("-b ", this.baseInputPaths);
 

--- a/src/tools/WixTasks/wix200x.targets
+++ b/src/tools/WixTasks/wix200x.targets
@@ -2497,6 +2497,7 @@
       ObjectFiles="@(CompileObjOutput);@(WixObject);@(WixLibProjects);@(_ResolvedWixLibraryPaths)"
       AdditionalOptions="$(LinkerAdditionalOptions)" 
       AllowIdenticalRows="$(AllowIdenticalRows)"
+      AllowDuplicateDirectoryIds="$(AllowDuplicateDirectoryIds)"
       AllowUnresolvedReferences="$(AllowUnresolvedReferences)"
       AdditionalCub="$(AdditionalCub)" 
       BackwardsCompatibleGuidGeneration="$(BackwardsCompatibleGuidGeneration)" 

--- a/src/tools/WixTasks/wix2010.targets
+++ b/src/tools/WixTasks/wix2010.targets
@@ -2473,6 +2473,7 @@
       ObjectFiles="@(CompileObjOutput);@(WixObject);@(WixLibProjects);@(_ResolvedWixLibraryPaths)"
       AdditionalOptions="$(LinkerAdditionalOptions)" 
       AllowIdenticalRows="$(AllowIdenticalRows)"
+      AllowDuplicateDirectoryIds="$(AllowDuplicateDirectoryIds)"
       AllowUnresolvedReferences="$(AllowUnresolvedReferences)"
       AdditionalCub="$(AdditionalCub)" 
       BackwardsCompatibleGuidGeneration="$(BackwardsCompatibleGuidGeneration)" 

--- a/src/tools/light/LightStrings.Designer.cs
+++ b/src/tools/light/LightStrings.Designer.cs
@@ -62,6 +62,7 @@ namespace Microsoft.Tools.WindowsInstallerXml.Tools {
         
         /// <summary>
         ///   Looks up a localized string similar to    -ai        allow identical rows, identical rows will be treated as a warning
+        ///   -ad        allow duplicate directory identities from other libraries
         ///   -au        (experimental) allow unresolved references
         ///              (will not create a valid output)
         ///   -b &lt;path&gt;  specify a base path to locate all files

--- a/src/tools/light/LightStrings.Designer.cs
+++ b/src/tools/light/LightStrings.Designer.cs
@@ -61,10 +61,10 @@ namespace Microsoft.Tools.WindowsInstallerXml.Tools {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to    -ai        allow identical rows, identical rows will be treated as a warning
-        ///   -ad        allow duplicate directory identities from other libraries
+        ///   Looks up a localized string similar to    -ai        allow identical rows, identical rows will be treated as a warning (deprecated)
+        ///   -ad        allow duplicate directory identities from other libraries (deprecated)
         ///   -au        (experimental) allow unresolved references
-        ///              (will not create a valid output)
+        ///              (will not create a valid output) (deprecated)
         ///   -b &lt;path&gt;  specify a base path to locate all files
         ///              (default: current directory)
         ///   -bf        bind files into a wixout (only valid with -xo option)

--- a/src/tools/light/LightStrings.resx
+++ b/src/tools/light/LightStrings.resx
@@ -118,10 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CommandLineArguments" xml:space="preserve">
-    <value>   -ai        allow identical rows, identical rows will be treated as a warning
-   -ad        allow duplicate directory identities from other libraries
+    <value>   -ai        allow identical rows, identical rows will be treated as a warning (deprecated)
+   -ad        allow duplicate directory identities from other libraries (deprecated)
    -au        (experimental) allow unresolved references
-              (will not create a valid output)
+              (will not create a valid output) (deprecated)
    -b &lt;path&gt;  specify a binder path to locate all files
               (default: current directory)
               prefix the path with 'name=' where 'name' is the name of your

--- a/src/tools/light/LightStrings.resx
+++ b/src/tools/light/LightStrings.resx
@@ -119,6 +119,7 @@
   </resheader>
   <data name="CommandLineArguments" xml:space="preserve">
     <value>   -ai        allow identical rows, identical rows will be treated as a warning
+   -ad        allow duplicate directory identities from other libraries
    -au        (experimental) allow unresolved references
               (will not create a valid output)
    -b &lt;path&gt;  specify a binder path to locate all files

--- a/src/tools/light/light.cs
+++ b/src/tools/light/light.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Tools.WindowsInstallerXml.Tools
     {
         private string[] cultures;
         private bool allowIdenticalRows;
+        private bool allowDuplicateDirectoryIds;
         private bool allowUnresolvedReferences;
         private bool bindFiles;
         private WixBinder binder;
@@ -211,6 +212,7 @@ namespace Microsoft.Tools.WindowsInstallerXml.Tools
                 }
 
                 linker.AllowIdenticalRows = this.allowIdenticalRows;
+                linker.AllowDuplicateDirectoryIds = this.allowDuplicateDirectoryIds;
                 linker.AllowUnresolvedReferences = this.allowUnresolvedReferences;
                 linker.Cultures = this.cultures;
                 linker.UnreferencedSymbolsFile = this.unreferencedSymbolsFile;
@@ -517,6 +519,10 @@ namespace Microsoft.Tools.WindowsInstallerXml.Tools
                     {
                         this.messageHandler.Display(this, WixWarnings.DeprecatedCommandLineSwitch("ai"));
                         this.allowIdenticalRows = true;
+                    }
+                    else if (parameter.Equals("ad", StringComparison.Ordinal))
+                    {
+                        this.allowDuplicateDirectoryIds = true;
                     }
                     else if (parameter.Equals("au", StringComparison.Ordinal))
                     {

--- a/src/tools/light/light.cs
+++ b/src/tools/light/light.cs
@@ -522,6 +522,7 @@ namespace Microsoft.Tools.WindowsInstallerXml.Tools
                     }
                     else if (parameter.Equals("ad", StringComparison.Ordinal))
                     {
+                        this.messageHandler.Display(this, WixWarnings.DeprecatedCommandLineSwitch("ad"));
                         this.allowDuplicateDirectoryIds = true;
                     }
                     else if (parameter.Equals("au", StringComparison.Ordinal))

--- a/src/tools/wix/Librarian.cs
+++ b/src/tools/wix/Librarian.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
             Section entrySection;
             SymbolCollection allSymbols;
 
-            library.Sections.FindEntrySectionAndLoadSymbols(false, this, OutputType.Unknown, out entrySection, out allSymbols);
+            library.Sections.FindEntrySectionAndLoadSymbols(false, this, OutputType.Unknown, false, out entrySection, out allSymbols);
 
             foreach (Section section in library.Sections)
             {

--- a/src/tools/wix/Linker.cs
+++ b/src/tools/wix/Linker.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
         private bool dropUnrealTables;
         private bool encounteredError;
         private bool allowIdenticalRows;
+        private bool allowDuplicateDirectoryIds;
         private bool allowUnresolvedReferences;
         private ArrayList extensions;
         private List<InspectorExtension> inspectorExtensions;
@@ -101,6 +102,16 @@ namespace Microsoft.Tools.WindowsInstallerXml
         {
             get { return this.allowIdenticalRows; }
             set { this.allowIdenticalRows = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets whether to allow duplicate directory IDs.
+        /// </summary>
+        /// <value>Whether to allow duplicate directory IDs.</value>
+        public bool AllowDuplicateDirectoryIds
+        {
+            get { return this.allowDuplicateDirectoryIds; }
+            set { this.allowDuplicateDirectoryIds = value; }
         }
 
         /// <summary>
@@ -361,7 +372,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
                 }
 
                 // first find the entry section and create the symbols hash for all the sections
-                sections.FindEntrySectionAndLoadSymbols(this.allowIdenticalRows, this, expectedOutputType, out entrySection, out allSymbols);
+                sections.FindEntrySectionAndLoadSymbols(this.allowIdenticalRows, this, expectedOutputType, this.allowDuplicateDirectoryIds, out entrySection, out allSymbols);
 
                 // should have found an entry section by now
                 if (null == entrySection)

--- a/src/tools/wix/SectionCollection.cs
+++ b/src/tools/wix/SectionCollection.cs
@@ -200,12 +200,14 @@ namespace Microsoft.Tools.WindowsInstallerXml
         /// <param name="allowIdenticalRows">Flag specifying whether identical rows are allowed or not.</param>
         /// <param name="messageHandler">Message handler object to route all errors through.</param>
         /// <param name="expectedOutputType">Expected entry output type, based on output file extension provided to the linker.</param>
+        /// <param name="allowDuplicateDirectoryIds">Allow duplicate directory IDs instead of erring.</param>
         /// <param name="entrySection">Located entry section.</param>
         /// <param name="allSymbols">Collection of symbols loaded.</param>
         internal void FindEntrySectionAndLoadSymbols(
             bool allowIdenticalRows,
             IMessageHandler messageHandler,
             OutputType expectedOutputType,
+            bool allowDuplicateDirectoryIds,
             out Section entrySection,
             out SymbolCollection allSymbols)
         {
@@ -259,7 +261,11 @@ namespace Microsoft.Tools.WindowsInstallerXml
                         }
                         else
                         {
-                            allSymbols.AddDuplicate(symbol);
+                            // Allow linking wixlibs with the same directory definitions.
+                            if (!allowDuplicateDirectoryIds || symbol.Row.TableDefinition.Name != "Directory")
+                            {
+                                allSymbols.AddDuplicate(symbol);
+                            }
                         }
                     }
                     catch (DuplicateSymbolsException)

--- a/test/data/Tools/Light/Input/WixlibTests/MultipleWixlibsWithDirs/Package.wxs
+++ b/test/data/Tools/Light/Input/WixlibTests/MultipleWixlibsWithDirs/Package.wxs
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  <copyright file="Package.wxs" company="Outercurve Foundation">
+    Copyright (c) 2004, Outercurve Foundation.
+    This software is released under Microsoft Reciprocal License (MS-RL).
+    The license and further copyright text can be found in the file
+    LICENSE.TXT at the root directory of the distribution.
+  </copyright>
+-->
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Product Id="0fa028f1-3c9e-40e0-bd29-71f7b419b63e" Name="MultipleSwrProjs" Language="1033" Version="1.1.2.3" Manufacturer="Microsoft Corporation" UpgradeCode="{e8b0f42b-2c73-47de-ac79-6c978b66e261}">
+        <Package InstallScope="perMachine" Description="Test building against multiple swix" InstallerVersion="200" Compressed="yes" />
+        <MediaTemplate EmbedCab="yes" />
+        <Directory Id="TARGETDIR" Name="SourceDir" />
+        <DirectoryRef Id="TARGETDIR">
+            <Directory Id="ProgramFilesFolder" Name="Program Files" />
+        </DirectoryRef>
+        <Feature Id="Test" Title="Test" Level="1">
+            <ComponentGroupRef Id="ProjectOneGroup" />
+            <ComponentGroupRef Id="ProjectTwoGroup" />
+        </Feature>
+    </Product>
+</Wix>

--- a/test/data/Tools/Light/Input/WixlibTests/MultipleWixlibsWithDirs/ProjectOne.wxs
+++ b/test/data/Tools/Light/Input/WixlibTests/MultipleWixlibsWithDirs/ProjectOne.wxs
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  <copyright file="ProjectOne.wxs" company="Outercurve Foundation">
+    Copyright (c) 2004, Outercurve Foundation.
+    This software is released under Microsoft Reciprocal License (MS-RL).
+    The license and further copyright text can be found in the file
+    LICENSE.TXT at the root directory of the distribution.
+  </copyright>
+-->
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Fragment Id="ProjectOneDirSection">
+        <DirectoryRef Id="ProgramFilesFolder">
+            <Directory Id="Foo" Name="Foo">
+                <Directory Id="Bar" Name="Bar" />
+            </Directory>
+        </DirectoryRef>
+    </Fragment>
+    <Fragment>
+        <ComponentGroup Id="ProjectOneGroup">
+            <ComponentRef Id="ProjectOne" />
+        </ComponentGroup>
+        <DirectoryRef Id="Bar">
+            <Component Id="ProjectOne">
+                <File Id="ProjectOne" Name="ProjectOne.wxs" />
+            </Component>
+        </DirectoryRef>
+    </Fragment>
+</Wix>

--- a/test/data/Tools/Light/Input/WixlibTests/MultipleWixlibsWithDirs/ProjectTwo.wxs
+++ b/test/data/Tools/Light/Input/WixlibTests/MultipleWixlibsWithDirs/ProjectTwo.wxs
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  <copyright file="ProjectTwo.wxs" company="Outercurve Foundation">
+    Copyright (c) 2004, Outercurve Foundation.
+    This software is released under Microsoft Reciprocal License (MS-RL).
+    The license and further copyright text can be found in the file
+    LICENSE.TXT at the root directory of the distribution.
+  </copyright>
+-->
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Fragment Id="ProjectTwoDirSection">
+        <DirectoryRef Id="ProgramFilesFolder">
+            <Directory Id="Foo" Name="Foo">
+                <Directory Id="Bar" Name="Bar" />
+            </Directory>
+        </DirectoryRef>
+    </Fragment>
+    <Fragment>
+        <ComponentGroup Id="ProjectTwoGroup">
+            <ComponentRef Id="ProjectTwo" />
+        </ComponentGroup>
+        <DirectoryRef Id="Bar">
+            <Component Id="ProjectTwo">
+                <File Id="ProjectTwo" Name="ProjectTwo.wxs" />
+            </Component>
+        </DirectoryRef>
+    </Fragment>
+</Wix>

--- a/test/src/WixTestTools/Verifiers/Verifier.cs
+++ b/test/src/WixTestTools/Verifiers/Verifier.cs
@@ -911,6 +911,7 @@ namespace WixTest
                 switch ((string)row[0])
                 {
                     case "ProductCode":
+                    case "WixPdbPath":
                         return true;
                 }
             }

--- a/test/src/WixTests/Tools/Light/Input.WixlibTests.cs
+++ b/test/src/WixTests/Tools/Light/Input.WixlibTests.cs
@@ -106,5 +106,52 @@ namespace WixTest.Tests.Tools.Light.Input
             Verifier.VerifyResults(expectedMSI, light2.OutputFile);
         }
 
+        [NamedFact]
+        [Description("Verify that Light can link multiple wixlibs with same directories")]
+        [Priority(2)]
+        public void MultipleWixlibsWithSameDirectories()
+        {
+            // Create Temp Directory
+            string outputDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Utilities.FileUtilities.CreateOutputDirectory(outputDirectory);
+
+            string testDir = Path.Combine(WixlibTests.TestDataDirectory, "MultipleWixlibsWithDirs");
+
+            // Build the package
+            Candle candle1 = new Candle();
+            candle1.SourceFiles.Add(Path.Combine(testDir, "Package.wxs"));
+            candle1.OutputFile = Path.Combine(outputDirectory, "Package.wixobj");
+            candle1.Run();
+
+            // Build the first wixlib
+            Candle candle2 = new Candle();
+            candle2.SourceFiles.Add(Path.Combine(testDir, "ProjectOne.wxs"));
+            candle2.OutputFile = Path.Combine(outputDirectory, "ProjectOne.wixobj");
+            candle2.Run();
+
+            Lit lit2 = new Lit(candle2);
+            lit2.OutputFile = Path.Combine(outputDirectory, "ProjectOne.wixlib");
+            lit2.Run();
+
+            // Build the second wixlib
+            Candle candle3 = new Candle();
+            candle3.SourceFiles.Add(Path.Combine(testDir, "ProjectTwo.wxs"));
+            candle3.OutputFile = Path.Combine(outputDirectory, "ProjectTwo.wixobj");
+            candle3.Run();
+
+            Lit lit3 = new Lit(candle3);
+            lit3.OutputFile = Path.Combine(outputDirectory, "ProjectTwo.wixlib");
+            lit3.Run();
+
+            // Link everything together - will have duplicate directories
+            Light light = new Light();
+            light.ObjectFiles.Add(candle1.OutputFile);
+            light.ObjectFiles.Add(lit2.OutputFile);
+            light.ObjectFiles.Add(lit3.OutputFile);
+            light.OutputFile = Path.Combine(outputDirectory, "actual.msi");
+            light.Run("-ad");
+
+            // Verifier.VerifyResults(Path.Combine(testDir, "expected.msi"), light.OutputFile);
+        }
     }
 }


### PR DESCRIPTION
Resolves wixtoolset/issues#5227 to allow merging wixlibs from swix into
products linked using traditional wix.