### PR TITLE
Allow processes to terminate with 0 exit code

### DIFF
--- a/history/5229.md
+++ b/history/5229.md
@@ -1,0 +1,1 @@
+* HeathS: WIXBUG:5229 - Allow processes to terminate with 0 exit code

--- a/src/ext/UtilExtension/wixext/Data/tables.xml
+++ b/src/ext/UtilExtension/wixext/Data/tables.xml
@@ -26,7 +26,7 @@
         <columnDefinition name="Property" type="string" length="72" nullable="yes" localizable="yes" modularize="property"
                 category="identifier" description="Optional property that is set to the number of running instances of the app."/>
         <columnDefinition name="TerminateExitCode" type="number" length="4" nullable="yes"
-                minValue="1" maxValue="2147483647" description="Exit code to return from a terminated application."/>
+                minValue="0" maxValue="2147483647" description="Exit code to return from a terminated application."/>
         <columnDefinition name="Timeout" type="number" length="4" nullable="yes"
                 minValue="1" maxValue="2147483647" description="Timeout in milliseconds before scheduling restart or terminating application."/>
     </tableDefinition>


### PR DESCRIPTION
Resolves wixtoolset/issues#5229 to allow processes to be closed without error. This is handy for service-like applications, like systray applications running like a service.

Will make corresponding fix in wix4 if/when accepted.