### PR TITLE
Support adding users to Performance Log users group

### DIFF
--- a/history/5230.md
+++ b/history/5230.md
@@ -1,0 +1,1 @@
+* HeathS: WIXFEAT:5230 - Support adding users to Performance Log users group

--- a/src/chm/documents/customactions/osinfo.html.md
+++ b/src/chm/documents/customactions/osinfo.html.md
@@ -465,7 +465,7 @@ WixUtilExtension will automatically schedule the custom actions as needed after 
 </td>
 
 <td>
-<p>Localized qualified name of the Local System account.</p>
+<p>Localized qualified name of the Local System account (WinLocalSystemSid).</p>
 </td>
 </tr>
 
@@ -475,7 +475,7 @@ WixUtilExtension will automatically schedule the custom actions as needed after 
 </td>
 
 <td>
-<p>Localized qualified name of the Local Service account.</p>
+<p>Localized qualified name of the Local Service account (WinLocalServiceSid).</p>
 </td>
 </tr>
 
@@ -485,7 +485,7 @@ WixUtilExtension will automatically schedule the custom actions as needed after 
 </td>
 
 <td>
-<p>Localized qualified name of the Network Service account.</p>
+<p>Localized qualified name of the Network Service account (WinNetworkServiceSid).</p>
 </td>
 </tr>
 
@@ -495,7 +495,7 @@ WixUtilExtension will automatically schedule the custom actions as needed after 
 </td>
 
 <td>
-<p>Localized qualified name of the Administrators group.</p>
+<p>Localized qualified name of the Administrators group (WinBuiltinAdministratorsSid).</p>
 </td>
 </tr>
 
@@ -505,7 +505,7 @@ WixUtilExtension will automatically schedule the custom actions as needed after 
 </td>
 
 <td>
-<p>Localized qualified name of the Users group.</p>
+<p>Localized qualified name of the Users group (WinBuiltinUsersSid.</p>
 </td>
 </tr>
 
@@ -515,7 +515,17 @@ WixUtilExtension will automatically schedule the custom actions as needed after 
 </td>
 
 <td>
-<p>Localized qualified name of the Users group.</p>
+<p>Localized qualified name of the Users group (WinBuiltinGuestsSid).</p>
+</td>
+</tr>
+
+<tr>
+<td valign="top">
+<p>WIX_ACCOUNT_PERFLOGUSERS, WIX_ACCOUNT_PERFLOGUSERS_NODOMAIN</p>
+</td>
+
+<td>
+<p>Localized qualified name of the Performance Log Users group (WinBuiltinPerfLoggingUsersSid).</p>
 </td>
 </tr>
 </table>

--- a/src/chm/documents/customactions/osinfo.html.md
+++ b/src/chm/documents/customactions/osinfo.html.md
@@ -505,7 +505,7 @@ WixUtilExtension will automatically schedule the custom actions as needed after 
 </td>
 
 <td>
-<p>Localized qualified name of the Users group (WinBuiltinUsersSid.</p>
+<p>Localized qualified name of the Users group (WinBuiltinUsersSid).</p>
 </td>
 </tr>
 

--- a/src/ext/UtilExtension/wixlib/UtilExtension.wxs
+++ b/src/ext/UtilExtension/wixlib/UtilExtension.wxs
@@ -358,6 +358,11 @@
         <Property Id="WIX_ACCOUNT_GUESTS" Secure="yes" />
         <CustomActionRef Id="WixQueryOsWellKnownSID" />
     </Fragment>
+    <Fragment>
+        <Property Id="WIX_ACCOUNT_PERFLOGUSERS" Secure="yes" />
+        <Property Id="WIX_ACCOUNT_PERFLOGUSERS_NODOMAIN" Secure="yes" />
+        <CustomActionRef Id="WixQueryOsWellKnownSID" />
+    </Fragment>
 
     <Fragment>
       <CustomAction Id="WixQueryOsDriverInfo" BinaryKey="WixCA" DllEntry="WixQueryOsDriverInfo" Execute="firstSequence" Return="check" SuppressModularization="yes" />

--- a/src/ext/ca/wixca/dll/OsInfo.cpp
+++ b/src/ext/ca/wixca/dll/OsInfo.cpp
@@ -300,7 +300,8 @@ SetPropertyWellKnownSID
 ********************************************************************/
 static HRESULT SetPropertyWellKnownSID(
     __in WELL_KNOWN_SID_TYPE sidType,
-    __in LPCWSTR wzPropertyName
+    __in LPCWSTR wzPropertyName,
+    __in BOOL fIncludeDomainName
     )
 {
     HRESULT hr = S_OK;
@@ -320,11 +321,19 @@ static HRESULT SetPropertyWellKnownSID(
         ExitWithLastError1(hr, "Failed to look up account for SID; skipping account %ls.", wzPropertyName);
     }
 
-    hr = StrAllocFormatted(&pwzPropertyValue, L"%s\\%s", wzRefDomain, wzName);
-    ExitOnFailure(hr, "Failed to format property value");
+    if (fIncludeDomainName)
+    {
+        hr = StrAllocFormatted(&pwzPropertyValue, L"%s\\%s", wzRefDomain, wzName);
+        ExitOnFailure(hr, "Failed to format property value");
 
-    hr = WcaSetProperty(wzPropertyName, pwzPropertyValue);
-    ExitOnFailure(hr, "Failed write property");
+        hr = WcaSetProperty(wzPropertyName, pwzPropertyValue);
+        ExitOnFailure(hr, "Failed write domain\\name property");
+    }
+    else
+    {
+        hr = WcaSetProperty(wzPropertyName, wzName);
+        ExitOnFailure(hr, "Failed write name-only property");
+    }
  
 LExit:
     if (NULL != psid)
@@ -352,12 +361,14 @@ extern "C" UINT __stdcall WixQueryOsWellKnownSID(
     hr = WcaInitialize(hInstall, "WixQueryOsWellKnownSID");
     ExitOnFailure(hr, "WixQueryOsWellKnownSID failed to initialize");
 
-    SetPropertyWellKnownSID(WinLocalSystemSid, L"WIX_ACCOUNT_LOCALSYSTEM");
-    SetPropertyWellKnownSID(WinLocalServiceSid, L"WIX_ACCOUNT_LOCALSERVICE");
-    SetPropertyWellKnownSID(WinNetworkServiceSid, L"WIX_ACCOUNT_NETWORKSERVICE");
-    SetPropertyWellKnownSID(WinBuiltinAdministratorsSid, L"WIX_ACCOUNT_ADMINISTRATORS");
-    SetPropertyWellKnownSID(WinBuiltinUsersSid, L"WIX_ACCOUNT_USERS");
-    SetPropertyWellKnownSID(WinBuiltinGuestsSid, L"WIX_ACCOUNT_GUESTS");
+    SetPropertyWellKnownSID(WinLocalSystemSid, L"WIX_ACCOUNT_LOCALSYSTEM", TRUE);
+    SetPropertyWellKnownSID(WinLocalServiceSid, L"WIX_ACCOUNT_LOCALSERVICE", TRUE);
+    SetPropertyWellKnownSID(WinNetworkServiceSid, L"WIX_ACCOUNT_NETWORKSERVICE", TRUE);
+    SetPropertyWellKnownSID(WinBuiltinAdministratorsSid, L"WIX_ACCOUNT_ADMINISTRATORS", TRUE);
+    SetPropertyWellKnownSID(WinBuiltinUsersSid, L"WIX_ACCOUNT_USERS", TRUE);
+    SetPropertyWellKnownSID(WinBuiltinGuestsSid, L"WIX_ACCOUNT_GUESTS", TRUE);
+    SetPropertyWellKnownSID(WinBuiltinPerfLoggingUsersSid, L"WIX_ACCOUNT_PERFLOGUSERS", TRUE);
+    SetPropertyWellKnownSID(WinBuiltinPerfLoggingUsersSid, L"WIX_ACCOUNT_PERFLOGUSERS_NODOMAIN", FALSE);
 
 LExit:
     if (FAILED(hr))


### PR DESCRIPTION
Resolves wixtoolset/issues#5230 by supporting the ability to add users to
the Performance Log users group for domain and non-domain accounts.