### PR TITLE
WIXBUG:5234 - WiX 3.10.1 failing to update to 3.10.2

### DIFF
--- a/history/5234.md
+++ b/history/5234.md
@@ -1,0 +1,1 @@
+* SeanHall: WIXBUG5234 - Make Burn grab a file handle to the original bundle so it can still access compressed payloads even if the original bundle was deleted after initialization (e.g. when a bundle uses Burn's built-in update mechanism).

--- a/src/burn/engine/apply.h
+++ b/src/burn/engine/apply.h
@@ -89,7 +89,7 @@ HRESULT ApplyUnregister(
     __in BOOTSTRAPPER_APPLY_RESTART restart
     );
 HRESULT ApplyCache(
-    __in HANDLE hEngineFile,
+    __in HANDLE hSourceEngineFile,
     __in BURN_USER_EXPERIENCE* pUX,
     __in BURN_VARIABLES* pVariables,
     __in BURN_PLAN* pPlan,

--- a/src/burn/engine/container.h
+++ b/src/burn/engine/container.h
@@ -83,6 +83,7 @@ typedef struct _BURN_CONTAINER
     DWORD cbHash;
     DWORD64 qwAttachedOffset;
     BOOL fActuallyAttached;     // indicates whether an attached container is attached or missing.
+    BOOL fAcquiredThroughSourceEngine;
 
     //LPWSTR* rgsczPayloads;
     //DWORD cPayloads;

--- a/src/burn/engine/core.h
+++ b/src/burn/engine/core.h
@@ -139,6 +139,8 @@ typedef struct _BURN_ENGINE_STATE
     BOOL fDisableUnelevate;
 
     LPWSTR sczIgnoreDependencies;
+
+    HANDLE hSourceEngineFile;
 } BURN_ENGINE_STATE;
 
 

--- a/src/burn/engine/detect.cpp
+++ b/src/burn/engine/detect.cpp
@@ -46,7 +46,7 @@ static HRESULT DownloadUpdateFeed(
 extern "C" void DetectReset(
     __in BURN_REGISTRATION* pRegistration,
     __in BURN_PACKAGES* pPackages,
-    __in BURN_UPDATE* /*pUpdate*/
+    __in BURN_CONTAINERS* pContainers
     )
 {
     RelatedBundlesUninitialize(&pRegistration->relatedBundles);
@@ -88,6 +88,12 @@ extern "C" void DetectReset(
         MSIPATCHSEQUENCEINFOW* pPatchInfo = pPackages->rgPatchInfo + iPatchInfo;
         pPatchInfo->dwOrder = 0;
         pPatchInfo->uStatus = 0;
+    }
+
+    for (DWORD iContainer = 0; iContainer < pContainers->cContainers; ++iContainer)
+    {
+        BURN_CONTAINER* pContainer = pContainers->rgContainers + iContainer;
+        pContainer->fAcquiredThroughSourceEngine = FALSE;
     }
 }
 

--- a/src/burn/engine/detect.h
+++ b/src/burn/engine/detect.h
@@ -30,7 +30,7 @@ extern "C" {
 void DetectReset(
     __in BURN_REGISTRATION* pRegistration,
     __in BURN_PACKAGES* pPackages,
-    __in BURN_UPDATE* pUpdate
+    __in BURN_CONTAINERS* pContainers
     );
 
 HRESULT DetectForwardCompatibleBundle(

--- a/src/burn/engine/engine.cpp
+++ b/src/burn/engine/engine.cpp
@@ -287,6 +287,8 @@ static void UninitializeEngineState(
     __in BURN_ENGINE_STATE* pEngineState
     )
 {
+    ReleaseFileHandle(pEngineState->hSourceEngineFile);
+
     ReleaseStr(pEngineState->sczIgnoreDependencies);
 
     PipeConnectionUninitialize(&pEngineState->embeddedConnection);


### PR DESCRIPTION
Addresses wixtoolset/issues#5234.

Make Burn grab a file handle to the original bundle so it can still access compressed payloads even if the original bundle was deleted after initialization (e.g. when a bundle uses Burn's built-in update mechanism).

It's a little more complicated than I like, since Burn has to acquire attached containers that aren't actually attached and it only supported acquiring by copying or downloading a file.