### PR TITLE
Add internal WixBundleUILevel variable

### DIFF
--- a/src/burn/engine/core.cpp
+++ b/src/burn/engine/core.cpp
@@ -117,6 +117,9 @@ extern "C" HRESULT CoreInitialize(
     hr = VariableSetNumeric(&pEngineState->variables, BURN_BUNDLE_ELEVATED, fElevated, TRUE);
     ExitOnFailure(hr, "Failed to overwrite the %ls built-in variable.", BURN_BUNDLE_ELEVATED);
 
+    hr = VariableSetNumeric(&pEngineState->variables, BURN_BUNDLE_UILEVEL, pEngineState->command.display, TRUE);
+    ExitOnFailure(hr, "Failed to overwrite the %ls built-in variable.", BURN_BUNDLE_UILEVEL);
+
     if (sczSourceProcessPath)
     {
         hr = VariableSetLiteralString(&pEngineState->variables, BURN_BUNDLE_SOURCE_PROCESS_PATH, sczSourceProcessPath, TRUE);

--- a/src/burn/engine/core.h
+++ b/src/burn/engine/core.h
@@ -58,6 +58,7 @@ const LPCWSTR BURN_BUNDLE_MANUFACTURER = L"WixBundleManufacturer";
 const LPCWSTR BURN_BUNDLE_SOURCE_PROCESS_PATH = L"WixBundleSourceProcessPath";
 const LPCWSTR BURN_BUNDLE_SOURCE_PROCESS_FOLDER = L"WixBundleSourceProcessFolder";
 const LPCWSTR BURN_BUNDLE_TAG = L"WixBundleTag";
+const LPCWSTR BURN_BUNDLE_UILEVEL = L"WixBundleUILevel";
 const LPCWSTR BURN_BUNDLE_VERSION = L"WixBundleVersion";
 
 // The following constants must stay in sync with src\wix\Binder.cs

--- a/src/burn/engine/variable.cpp
+++ b/src/burn/engine/variable.cpp
@@ -274,6 +274,7 @@ extern "C" HRESULT VariableInitialize(
         {BURN_BUNDLE_SOURCE_PROCESS_PATH, InitializeVariableString, NULL, FALSE, TRUE},
         {BURN_BUNDLE_SOURCE_PROCESS_FOLDER, InitializeVariableString, NULL, FALSE, TRUE},
         {BURN_BUNDLE_TAG, InitializeVariableString, (DWORD_PTR)L"", FALSE, TRUE},
+        {BURN_BUNDLE_UILEVEL, InitializeVariableNumeric, 0, FALSE, TRUE},
         {BURN_BUNDLE_VERSION, InitializeVariableVersion, 0, FALSE, TRUE},
     };
 

--- a/src/chm/documents/bundle/bundle_built_in_variables.html.md
+++ b/src/chm/documents/bundle/bundle_built_in_variables.html.md
@@ -70,4 +70,5 @@ The Burn engine offers a set of commonly-used variables so you can use them with
 * WixBundleSourceProcessFolder - gets the source folder of the bundle where originally executed. Will only be set when bundle is executing in the clean room.
 * WixBundleProviderKey - gets the bundle dependency provider key.
 * WixBundleTag - gets the developer-defined tag string for this bundle (from Bundle/@Tag).
+* WixBundleUILevel - gets the level of the user interface (the value BOOTSTRAPPER\_DISPLAY enum).
 * WixBundleVersion - gets the version for this bundle (from Bundle/@Version).


### PR DESCRIPTION
Internal `WixBundleUILevel` variable is set to the value of `BOOTSTRAPPER_DISPLAY` enum.

Burn engine will set `WixBundleUILevel` value based on `pEngineState->command.display` field after parsing command line options. Parameters `/quiet` and `/passive` can change UI level value.

Fixes https://github.com/wixtoolset/issues/issues/3789