### PR TITLE
Change a button label in Estonian to match description

### DIFF
--- a/src/ext/UIExtension/wixlib/WixUI_et-EE.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_et-EE.wxl
@@ -11,7 +11,7 @@
     <String Id="WixUIBack" Overridable="yes">&amp;Tagasi</String>
     <String Id="WixUINext" Overridable="yes">&amp;Edasi</String>
     <String Id="WixUICancel" Overridable="yes">Loobu</String>
-    <String Id="WixUIFinish" Overridable="yes">&amp;Valmis</String>
+    <String Id="WixUIFinish" Overridable="yes">&amp;Lõpeta</String>
     <String Id="WixUIRetry" Overridable="yes">&amp;Proovi uuesti</String>
     <String Id="WixUIIgnore" Overridable="yes">&amp;Ignoreeri</String>
     <String Id="WixUIYes" Overridable="yes">&amp;Jah</String>


### PR DESCRIPTION
The Estonian text used in exit and error descriptions was not the same as the actual text used on the finish button (The description said to push the "Lõpeta" button while the button was actually labeled "Valmis")
Translated to English it would be like "Done" vs "Finish"