### PR TITLE
burn engine: Always use the bundle source path for all purposes.

### DIFF
--- a/history/5277.md
+++ b/history/5277.md
@@ -1,0 +1,1 @@
+* FRichter: WIXBUG:5277 - burn engine: Always use the bundle source path for all purposes. The original source path is needed in all cases: for copying the bundle to the layout directory as well as for checking whether we're layouting to the bundle location.

--- a/src/burn/engine/apply.cpp
+++ b/src/burn/engine/apply.cpp
@@ -954,14 +954,22 @@ static HRESULT LayoutBundle(
 {
     HRESULT hr = S_OK;
     LPWSTR sczBundlePath = NULL;
-    LPWSTR sczBundleSourcePath = NULL;
     LPWSTR sczDestinationPath = NULL;
     int nEquivalentPaths = 0;
     BURN_CACHE_ACQUIRE_PROGRESS_CONTEXT progress = { };
     BOOL fRetry = FALSE;
 
-    hr = PathForCurrentProcess(&sczBundlePath, NULL);
-    ExitOnFailure(hr, "Failed to get path to bundle to layout.");
+    hr = VariableGetString(pVariables, BURN_BUNDLE_SOURCE_PROCESS_PATH, &sczBundlePath);
+    if (FAILED(hr))
+    {
+        if  (E_NOTFOUND != hr)
+        {
+            ExitOnFailure(hr, "Failed to get path to bundle source process path to layout.");
+        }
+
+        hr = PathForCurrentProcess(&sczBundlePath, NULL);
+        ExitOnFailure(hr, "Failed to get path to bundle to layout.");
+    }
 
     hr = PathConcat(wzLayoutDirectory, wzExecutableName, &sczDestinationPath);
     ExitOnFailure(hr, "Failed to concat layout path for bundle.");
@@ -973,21 +981,6 @@ static HRESULT LayoutBundle(
     if (CSTR_EQUAL == nEquivalentPaths)
     {
         ExitFunction1(hr = S_OK);
-    }
-
-    hr = VariableGetString(pVariables, BURN_BUNDLE_SOURCE_PROCESS_PATH, &sczBundleSourcePath);
-    if (E_NOTFOUND != hr)
-    {
-        ExitOnFailure(hr, "Failed to get path to bundle source process path to layout.");
-
-        // If the destination path is the currently running bundles source process, bail.
-        hr = PathCompare(sczBundleSourcePath, sczDestinationPath, &nEquivalentPaths);
-        ExitOnFailure(hr, "Failed to determine if layout bundle path was equivalent with source process path.");
-
-        if (CSTR_EQUAL == nEquivalentPaths)
-        {
-            ExitFunction1(hr = S_OK);
-        }
     }
 
     progress.pUX = pUX;
@@ -1057,7 +1050,6 @@ static HRESULT LayoutBundle(
     LogExitOnFailure2(hr, MSG_FAILED_LAYOUT_BUNDLE, "Failed to layout bundle: %ls to layout directory: %ls", sczBundlePath, wzLayoutDirectory);
 
 LExit:
-    ReleaseStr(sczBundleSourcePath);
     ReleaseStr(sczDestinationPath);
     ReleaseStr(sczBundlePath);
 


### PR DESCRIPTION
When layouting we need the original source path in all cases: for
copying the bundle to the layout directory as well as for checking
whether we're layouting to the bundle location.

This fixes issue #5277.