### PR TITLE
WIXBUG:4180 - Make WixMbaPrereqLicenseUrl variable Overridable.  

### DIFF
--- a/src/ext/NetFxExtension/wixlib/NetFx4.5.wxs
+++ b/src/ext/NetFxExtension/wixlib/NetFx4.5.wxs
@@ -44,7 +44,7 @@
     <util:RegistrySearchRef Id="NETFRAMEWORK45"/>
 
     <WixVariable Id="WixMbaPrereqPackageId" Value="NetFx45Web" />
-    <WixVariable Id="WixMbaPrereqLicenseUrl" Value="$(var.NetFx45EulaLink)" />
+    <WixVariable Id="WixMbaPrereqLicenseUrl" Value="$(var.NetFx45EulaLink)" Overridable="yes" />
     <WixVariable Id="NetFx45WebDetectCondition" Value="NETFRAMEWORK45 &gt;= $(var.NetFx45MinRelease)" Overridable="yes" />
     <WixVariable Id="NetFx45WebInstallCondition" Value="" Overridable="yes" />
     <WixVariable Id="NetFx45WebPackageDirectory" Value="redist\" Overridable="yes" />

--- a/src/ext/NetFxExtension/wixlib/NetFx4.wxs
+++ b/src/ext/NetFxExtension/wixlib/NetFx4.wxs
@@ -45,7 +45,7 @@
     <util:RegistrySearchRef Id="NETFRAMEWORK40"/>
 
     <WixVariable Id="WixMbaPrereqPackageId" Value="NetFx40Web" />
-    <WixVariable Id="WixMbaPrereqLicenseUrl" Value="$(var.NetFx40EulaLink)" />
+    <WixVariable Id="WixMbaPrereqLicenseUrl" Value="$(var.NetFx40EulaLink)" Overridable="yes" />
 
     <PackageGroup Id="NetFx40Web">
       <ExePackage

--- a/src/ext/NetFxExtension/wixlib/NetFx451.wxs
+++ b/src/ext/NetFxExtension/wixlib/NetFx451.wxs
@@ -34,7 +34,7 @@
     <util:RegistrySearchRef Id="NETFRAMEWORK45"/>
 
     <WixVariable Id="WixMbaPrereqPackageId" Value="NetFx451Web" />
-    <WixVariable Id="WixMbaPrereqLicenseUrl" Value="$(var.NetFx451EulaLink)" />
+    <WixVariable Id="WixMbaPrereqLicenseUrl" Value="$(var.NetFx451EulaLink)" Overridable="yes" />
     <WixVariable Id="NetFx451WebDetectCondition" Value="NETFRAMEWORK45 &gt;= $(var.NetFx451MinRelease)" Overridable="yes" />
     <WixVariable Id="NetFx451WebInstallCondition" Value="" Overridable="yes" />
     <WixVariable Id="NetFx451WebPackageDirectory" Value="redist\" Overridable="yes" />

--- a/src/ext/NetFxExtension/wixlib/NetFx452.wxs
+++ b/src/ext/NetFxExtension/wixlib/NetFx452.wxs
@@ -34,7 +34,7 @@
     <util:RegistrySearchRef Id="NETFRAMEWORK45"/>
 
     <WixVariable Id="WixMbaPrereqPackageId" Value="NetFx452Web" />
-    <WixVariable Id="WixMbaPrereqLicenseUrl" Value="$(var.NetFx452EulaLink)" />
+    <WixVariable Id="WixMbaPrereqLicenseUrl" Value="$(var.NetFx452EulaLink)" Overridable="yes" />
     <WixVariable Id="NetFx452WebDetectCondition" Value="NETFRAMEWORK45 &gt;= $(var.NetFx452MinRelease)" Overridable="yes" />
     <WixVariable Id="NetFx452WebInstallCondition" Value="" Overridable="yes" />
     <WixVariable Id="NetFx452WebPackageDirectory" Value="redist\" Overridable="yes" />

--- a/src/ext/NetFxExtension/wixlib/NetFx46.wxs
+++ b/src/ext/NetFxExtension/wixlib/NetFx46.wxs
@@ -34,7 +34,7 @@
     <util:RegistrySearchRef Id="NETFRAMEWORK45"/>
 
     <WixVariable Id="WixMbaPrereqPackageId" Value="NetFx46Web" />
-    <WixVariable Id="WixMbaPrereqLicenseUrl" Value="$(var.NetFx46EulaLink)" />
+    <WixVariable Id="WixMbaPrereqLicenseUrl" Value="$(var.NetFx46EulaLink)" Overridable="yes" />
     <WixVariable Id="NetFx46WebDetectCondition" Value="NETFRAMEWORK45 &gt;= $(var.NetFx46MinRelease)" Overridable="yes" />
     <WixVariable Id="NetFx46WebInstallCondition" Value="" Overridable="yes" />
     <WixVariable Id="NetFx46WebPackageDirectory" Value="redist\" Overridable="yes" />


### PR DESCRIPTION
Current links are invalid for .NET 4.5.1, 4.5.2 as they point to http://wixtoolset.org/licenses/netfx451, http://wixtoolset.org/licenses/netfx452 which do not exist.  Making the variables overridable allows specifying an alternate EULA link.