### PR TITLE
Workaround GDI+ security vulnerability

### DIFF
--- a/history/5282-unsafe-cleanroom.md
+++ b/history/5282-unsafe-cleanroom.md
@@ -1,0 +1,1 @@
+RobMen: WIXBUG:5282 - reduce clean room security to successfully load BA's dependent on GDI+ (including WinForms).

--- a/src/burn/engine/core.cpp
+++ b/src/burn/engine/core.cpp
@@ -128,13 +128,6 @@ extern "C" HRESULT CoreInitialize(
     {
         hr = CacheInitialize(&pEngineState->registration, &pEngineState->variables, sczSourceProcessPath);
         ExitOnFailure(hr, "Failed to initialize internal cache functionality.");
-
-        BOOL fRunningFromCache = CacheBundleRunningFromCache();
-
-        if (BURN_MODE_UNTRUSTED == pEngineState->mode && fRunningFromCache)
-        {
-            pEngineState->mode = BURN_MODE_NORMAL;
-        }
     }
 
     // If we're not elevated then we'll be loading the bootstrapper application, so extract
@@ -1397,7 +1390,7 @@ static HRESULT ParseCommandLine(
                 CSTR_EQUAL == ::CompareStringW(LOCALE_INVARIANT, NORM_IGNORECASE, &argv[i][1], lstrlenW(BURN_COMMANDLINE_SWITCH_PREFIX), BURN_COMMANDLINE_SWITCH_PREFIX, lstrlenW(BURN_COMMANDLINE_SWITCH_PREFIX)))
             {
                 // Skip (but log) any other private burn switches we don't recognize, so that
-                // adding future private variables doesn't break old bundles 
+                // adding future private variables doesn't break old bundles
                 LogId(REPORT_STANDARD, MSG_BURN_UNKNOWN_PRIVATE_SWITCH, &argv[i][1]);
             }
             else

--- a/src/burn/engine/inc/engine.h
+++ b/src/burn/engine/inc/engine.h
@@ -9,6 +9,10 @@ extern "C" {
 
 // function declarations
 
+BOOL EngineInCleanRoom(
+    __in_z_opt LPCWSTR wzCommandLine
+    );
+
 HRESULT EngineRun(
     __in HINSTANCE hInstance,
     __in HANDLE hEngineFile,

--- a/src/libs/dutil/apputil.cpp
+++ b/src/libs/dutil/apputil.cpp
@@ -70,6 +70,11 @@ extern "C" void DAPI AppInitialize(
     }
 }
 
+extern "C" void DAPI AppInitializeUnsafe()
+{
+    ::HeapSetInformation(NULL, HeapEnableTerminationOnCorruption, NULL, 0);
+}
+
 extern "C" DAPI_(HRESULT) AppParseCommandLine(
     __in LPCWSTR wzCommandLine,
     __in int* pArgc,

--- a/src/libs/dutil/inc/apputil.h
+++ b/src/libs/dutil/inc/apputil.h
@@ -22,6 +22,13 @@ void DAPI AppInitialize(
     );
 
 /********************************************************************
+AppInitializeUnsafe - initializes without the full standard safety
+                      precautions for an application.
+
+********************************************************************/
+void DAPI AppInitializeUnsafe();
+
+/********************************************************************
 AppParseCommandLine - parses the command line using CommandLineToArgvW.
                       The caller must free the value of pArgv on success
                       by calling AppFreeCommandLineArgs.


### PR DESCRIPTION
GDI+ fails in some scenarios when ::SetDefaultDllDirectories() is used
to protect a process from DLL hijacking. All WinForms based BAs hit this
problem. To workaround the failure, all Burn processes that load BAs
will no longer protect themselves from DLL hijacking. In particular, the
clean room and package cache processes will be unsecure. Fortunately,
the design of those processes should be safe without the extra
protection.

Fixes wixtoolset/issues#5282