### PR TITLE
Update FileVersionFromStringEx to handle "vVersion" syntax like FileV…

### DIFF
--- a/history/5236.md
+++ b/history/5236.md
@@ -1,0 +1,1 @@
+* @barnson for @firegiantco: Update FileVersionFromStringEx to handle "vVersion" syntax like FileVersionFromString.

--- a/src/libs/dutil/fileutil.cpp
+++ b/src/libs/dutil/fileutil.cpp
@@ -420,6 +420,14 @@ extern "C" HRESULT DAPI FileVersionFromStringEx(
         }
     }
 
+    if ((L'v' == *wzVersion) || (L'V' == *wzVersion))
+    {
+        ++wzVersion;
+        --cchVersion;
+        wzPartBegin = wzVersion;
+        wzPartEnd = wzVersion;
+    }
+
     // save end pointer
     wzEnd = wzVersion + cchVersion;
 


### PR DESCRIPTION
…ersionFromString. Fixes wixtoolset/issues#5221.