### PR TITLE
Move MsiProperty check from ChainPackageInfo.

### DIFF
--- a/history/5294.md
+++ b/history/5294.md
@@ -1,0 +1,3 @@
+* @barnson: Fix WIXBUG:5294 - Move MsiProperty check from ChainPackageInfo,
+  where it was verifying MSI property names too early, to the compiler for the
+  earliest feedback.

--- a/src/tools/wix/ChainPackageInfo.cs
+++ b/src/tools/wix/ChainPackageInfo.cs
@@ -636,8 +636,6 @@ namespace Microsoft.Tools.WindowsInstallerXml
 
                     this.Manufacturer = ChainPackageInfo.GetProperty(db, "Manufacturer");
 
-                    this.VerifyMsiProperties();
-
                     if (YesNoType.Yes == forcePerMachine)
                     {
                         if (YesNoDefaultType.No == this.PerMachine)
@@ -1171,23 +1169,6 @@ namespace Microsoft.Tools.WindowsInstallerXml
                 }
 
                 this.PatchXml = writer.ToString();
-            }
-        }
-
-        /// <summary>
-        /// Verifies that only allowed properties are passed to the MSI.
-        /// </summary>
-        private void VerifyMsiProperties()
-        {
-            foreach (string disallowed in new string[] { "ACTION", "ALLUSERS", "REBOOT", "REINSTALL", "REINSTALLMODE" })
-            {
-                foreach (MsiPropertyInfo propertyInfo in this.MsiProperties)
-                {
-                    if (disallowed.Equals(propertyInfo.Name, StringComparison.Ordinal))
-                    {
-                        this.core.OnMessage(WixErrors.DisallowedMsiProperty(this.PackagePayload.SourceLineNumbers, disallowed));
-                    }
-                }
             }
         }
 

--- a/src/tools/wix/Compiler.cs
+++ b/src/tools/wix/Compiler.cs
@@ -22228,7 +22228,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
                     switch (attrib.LocalName)
                     {
                         case "Name":
-                            name = this.core.GetAttributeValue(sourceLineNumbers, attrib);
+                            name = this.core.GetAttributeMsiPropertyNameValue(sourceLineNumbers, attrib);
                             break;
                         case "Value":
                             value = this.core.GetAttributeValue(sourceLineNumbers, attrib);

--- a/src/tools/wix/CompilerCore.cs
+++ b/src/tools/wix/CompilerCore.cs
@@ -154,6 +154,9 @@ namespace Microsoft.Tools.WindowsInstallerXml
 
         private static readonly Regex PutGuidHere = new Regex(@"PUT\-GUID\-(?:\d+\-)?HERE", RegexOptions.Singleline);
 
+        private static readonly List<string> DisallowedMsiProperties = new List<string>(
+            new string[] { "ACTION", "ADDLOCAL", "ADDSOURCE", "ADDDEFAULT", "ADVERTISE", "ALLUSERS", "REBOOT", "REINSTALL", "REINSTALLMODE", "REMOVE" });
+
         // Built-in variables (from burn\engine\variable.cpp, "vrgBuiltInVariables", around line 113)
         private static readonly List<String> BuiltinBundleVariables = new List<string>(
             new string[] {
@@ -1648,6 +1651,29 @@ namespace Microsoft.Tools.WindowsInstallerXml
             }
 
             return exitValue;
+        }
+
+        /// <summary>
+        /// Gets an MsiProperty name value and displays an error for an illegal value.
+        /// </summary>
+        /// <param name="sourceLineNumbers">Source line information about the owner element.</param>
+        /// <param name="attribute">The attribute containing the value to get.</param>
+        /// <returns>The attribute's value.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1059:MembersShouldNotExposeCertainConcreteTypes")]
+        public string GetAttributeMsiPropertyNameValue(SourceLineNumberCollection sourceLineNumbers, XmlAttribute attribute)
+        {
+            string value = this.GetAttributeValue(sourceLineNumbers, attribute);
+
+            if (0 < value.Length)
+            {
+                if (CompilerCore.DisallowedMsiProperties.Contains(value))
+                {
+                    string illegalValues = CompilerCore.CreateValueList(ValueListKind.Or, CompilerCore.DisallowedMsiProperties);
+                    this.OnMessage(WixWarnings.DisallowedMsiProperty(sourceLineNumbers, value, illegalValues));
+                }
+            }
+
+            return value;
         }
 
         /// <summary>

--- a/src/tools/wix/Data/messages.xml
+++ b/src/tools/wix/Data/messages.xml
@@ -2795,12 +2795,6 @@
           <Parameter Type="System.String" Name="value" />
         </Instance>
       </Message>
-      <Message Id="DisallowedMsiProperty" Number="365">
-        <Instance>
-          The '{0}' MsiProperty is controlled by the bootstrapper and cannot be authored. Remove the MsiProperty element.
-          <Parameter Type="System.String" Name="property" />
-        </Instance>
-      </Message>
       <Message Id="MissingOrInvalidModuleInstallerVersion" Number="366">
         <Instance>
           The merge module '{0}' from file '{1}' is either missing or has an invalid installer version. The value read from the installer version in module's summary information was '{2}'. This should be a numeric value representing a valid installer version such as 200 or 301.
@@ -3799,6 +3793,13 @@
                 <Parameter Type="System.String" Name="truncatedVersion" />
             </Instance>
         </Message>
+      <Message Id="DisallowedMsiProperty" Number="1149">
+        <Instance>
+          The '{0}' MsiProperty is controlled by the bootstrapper and cannot be authored. (Illegal properties are: {1}.) Remove the MsiProperty element. This restriction will be enforced as an error in WiX v4.0.
+          <Parameter Type="System.String" Name="property" />
+          <Parameter Type="System.String" Name="illegalValueList" />
+        </Instance>
+      </Message>
     </Class>
 
     <Class Name="WixVerboses" ContainerName="WixVerboseEventArgs" BaseContainerName="MessageEventArgs" Level="Information">


### PR DESCRIPTION
Fixes wixtoolset/issues #5294.