### PR TITLE
WIXBUG:5301/5302 - Fix command line parameter issues

### DIFF
--- a/history/5301.md
+++ b/history/5301.md
@@ -1,0 +1,1 @@
+* SeanHall: WIXBUG:5301 - Fix bug where file handles weren't being passed to the clean room process.

--- a/history/5302.md
+++ b/history/5302.md
@@ -1,0 +1,1 @@
+* SeanHall: WIXBUG:5302 - Fix bug where the command line for burn exe packages had the executable path in the middle.

--- a/src/burn/engine/core.cpp
+++ b/src/burn/engine/core.cpp
@@ -981,7 +981,6 @@ extern "C" HRESULT CoreAppendFileHandleAttachedToCommandLine(
 {
     HRESULT hr = S_OK;
     HANDLE hExecutableFile = INVALID_HANDLE_VALUE;
-    LPWSTR sczCommandLine = NULL;
 
     *phExecutableFile = INVALID_HANDLE_VALUE;
 
@@ -990,18 +989,13 @@ extern "C" HRESULT CoreAppendFileHandleAttachedToCommandLine(
         ExitWithLastError(hr, "Failed to duplicate file handle for attached container.");
     }
 
-    hr = StrAllocFormattedSecure(&sczCommandLine, L"-%ls=%u %ls", BURN_COMMANDLINE_SWITCH_FILEHANDLE_ATTACHED, hExecutableFile, *psczCommandLine);
+    hr = StrAllocFormattedSecure(psczCommandLine, L"%ls -%ls=%u", *psczCommandLine, BURN_COMMANDLINE_SWITCH_FILEHANDLE_ATTACHED, hExecutableFile);
     ExitOnFailure(hr, "Failed to append the file handle to the command line.");
-
-    StrSecureZeroFreeString(*psczCommandLine);
-    *psczCommandLine = sczCommandLine;
-    sczCommandLine = NULL;
 
     *phExecutableFile = hExecutableFile;
     hExecutableFile = INVALID_HANDLE_VALUE;
 
 LExit:
-    StrSecureZeroFreeString(sczCommandLine);
     ReleaseFileHandle(hExecutableFile);
 
     return hr;
@@ -1016,8 +1010,6 @@ extern "C" HRESULT CoreAppendFileHandleSelfToCommandLine(
 {
     HRESULT hr = S_OK;
     HANDLE hExecutableFile = INVALID_HANDLE_VALUE;
-    LPWSTR sczCommandLine = NULL;
-    LPWSTR sczObfuscatedCommandLine = NULL;
     SECURITY_ATTRIBUTES securityAttributes = { };
     securityAttributes.bInheritHandle = TRUE;
     *phExecutableFile = INVALID_HANDLE_VALUE;
@@ -1025,21 +1017,13 @@ extern "C" HRESULT CoreAppendFileHandleSelfToCommandLine(
     hExecutableFile = ::CreateFileW(wzExecutablePath, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_DELETE, &securityAttributes, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
     if (INVALID_HANDLE_VALUE != hExecutableFile)
     {
-        hr = StrAllocFormattedSecure(&sczCommandLine, L"-%ls=%u %ls", BURN_COMMANDLINE_SWITCH_FILEHANDLE_SELF, hExecutableFile, *psczCommandLine);
+        hr = StrAllocFormattedSecure(psczCommandLine, L"%ls -%ls=%u", *psczCommandLine, BURN_COMMANDLINE_SWITCH_FILEHANDLE_SELF, hExecutableFile);
         ExitOnFailure(hr, "Failed to append the file handle to the command line.");
-
-        StrSecureZeroFreeString(*psczCommandLine);
-        *psczCommandLine = sczCommandLine;
-        sczCommandLine = NULL;
 
         if (psczObfuscatedCommandLine)
         {
-            hr = StrAllocFormatted(&sczObfuscatedCommandLine, L"-%ls=%u %ls", BURN_COMMANDLINE_SWITCH_FILEHANDLE_SELF, hExecutableFile, *psczObfuscatedCommandLine);
+            hr = StrAllocFormatted(psczObfuscatedCommandLine, L"%ls -%ls=%u", *psczObfuscatedCommandLine, BURN_COMMANDLINE_SWITCH_FILEHANDLE_SELF, hExecutableFile);
             ExitOnFailure(hr, "Failed to append the file handle to the obfuscated command line.");
-
-            StrSecureZeroFreeString(*psczObfuscatedCommandLine);
-            *psczObfuscatedCommandLine = sczObfuscatedCommandLine;
-            sczObfuscatedCommandLine = NULL;
         }
 
         *phExecutableFile = hExecutableFile;
@@ -1047,8 +1031,6 @@ extern "C" HRESULT CoreAppendFileHandleSelfToCommandLine(
     }
 
 LExit:
-    StrSecureZeroFreeString(sczObfuscatedCommandLine);
-    StrSecureZeroFreeString(sczCommandLine);
     ReleaseFileHandle(hExecutableFile);
 
     return hr;

--- a/src/burn/engine/engine.cpp
+++ b/src/burn/engine/engine.cpp
@@ -425,6 +425,11 @@ static HRESULT RunUntrusted(
         wzCleanRoomBundlePath = sczCachedCleanRoomBundlePath;
     }
 
+    // The clean room switch must always be at the front of the command line so
+    // the EngineInCleanRoom function will operate correctly.
+    hr = StrAllocFormatted(&sczParameters, L"-%ls=\"%ls\"", BURN_COMMANDLINE_SWITCH_CLEAN_ROOM, sczCurrentProcessPath);
+    ExitOnFailure(hr, "Failed to allocate parameters for unelevated process.");
+
     // Send a file handle for the child Burn process to access the attached container.
     hr = CoreAppendFileHandleAttachedToCommandLine(pEngineState->section.hEngineFile, &hFileAttached, &sczParameters);
     ExitOnFailure(hr, "Failed to append %ls", BURN_COMMANDLINE_SWITCH_FILEHANDLE_ATTACHED);
@@ -433,10 +438,8 @@ static HRESULT RunUntrusted(
     hr = CoreAppendFileHandleSelfToCommandLine(wzCleanRoomBundlePath, &hFileSelf, &sczParameters, NULL);
     ExitOnFailure(hr, "Failed to append %ls", BURN_COMMANDLINE_SWITCH_FILEHANDLE_SELF);
 
-    // The clean room switch must always end up at the front of the command line so
-    // the EngineInCleanRoom function will operate correctly.
-    hr = StrAllocFormattedSecure(&sczParameters, L"-%ls=\"%ls\" %ls", BURN_COMMANDLINE_SWITCH_CLEAN_ROOM, sczCurrentProcessPath, wzCommandLine);
-    ExitOnFailure(hr, "Failed to allocate parameters for unelevated process.");
+    hr = StrAllocFormattedSecure(&sczParameters, L"%ls %ls", sczParameters, wzCommandLine);
+    ExitOnFailure(hr, "Failed to append original command line.");
 
 #ifdef ENABLE_UNELEVATE
     // TODO: Pass file handle to unelevated process if this ever gets reenabled.


### PR DESCRIPTION
WIXBUG:5301 - Fix bug where file handles weren't being passed to the clean room process.
WIXBUG:5302 - Fix bug where the command line for burn exe packages had the executable path in the middle.

Fixes wixtoolset/issues#5301.
Fixes wixtoolset/issues#5302.