### PR TITLE
Allow custom ProjectDefineConstants defined in properties

### DIFF
--- a/src/tools/WixTasks/wix2010.targets
+++ b/src/tools/WixTasks/wix2010.targets
@@ -447,6 +447,7 @@
       TargetFileName=$(TargetFileName);
       TargetName=$(TargetName);
       TargetPath=$(TargetPath);
+      $(ProjectDefineConstants)
     </ProjectDefineConstants>
   </PropertyGroup>
   <!--


### PR DESCRIPTION
Fixes issue https://github.com/wixtoolset/issues/issues/5313