### PR TITLE
Remove copyleft header from templates

### DIFF
--- a/src/Votive/votive2010/Templates/Projects/CustomActionCPP/CustomAction.cpp
+++ b/src/Votive/votive2010/Templates/Projects/CustomActionCPP/CustomAction.cpp
@@ -1,5 +1,3 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
-
 #include "stdafx.h"
 
 

--- a/src/Votive/votive2010/Templates/Projects/CustomActionCPP/CustomAction.def
+++ b/src/Votive/votive2010/Templates/Projects/CustomActionCPP/CustomAction.def
@@ -1,6 +1,3 @@
-; Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
-
-
 LIBRARY "$projectname$"
 
 EXPORTS

--- a/src/Votive/votive2010/Templates/Projects/CustomActionCPP/stdafx.cpp
+++ b/src/Votive/votive2010/Templates/Projects/CustomActionCPP/stdafx.cpp
@@ -1,5 +1,3 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
-
 #include "stdafx.h"
 
 // TODO: reference any additional headers you need in STDAFX.H

--- a/src/Votive/votive2010/Templates/Projects/CustomActionCPP/stdafx.h
+++ b/src/Votive/votive2010/Templates/Projects/CustomActionCPP/stdafx.h
@@ -1,6 +1,4 @@
 #pragma once
-// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
-
 
 #include "targetver.h"
 

--- a/src/Votive/votive2010/Templates/Projects/CustomActionCPP/targetver.h
+++ b/src/Votive/votive2010/Templates/Projects/CustomActionCPP/targetver.h
@@ -1,6 +1,4 @@
 #pragma once
-// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
-
 
 #ifndef WINVER                  // Specifies that the minimum required platform is Windows 2000.
 #define WINVER 0x0500           // Change this to the appropriate value to target other versions of Windows.

--- a/src/Votive/votive2010/src/Templates/ProjectItems/BlankFile/BlankFile.wxs
+++ b/src/Votive/votive2010/src/Templates/ProjectItems/BlankFile/BlankFile.wxs
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-
-
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
 	<Fragment>
 		<!-- $loc_TODO$ -->

--- a/src/Votive/votive2010/src/Templates/ProjectItems/IncludeFile/IncludeFile.wxi
+++ b/src/Votive/votive2010/src/Templates/ProjectItems/IncludeFile/IncludeFile.wxi
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-
-
 <Include>
 	<!-- $loc_TODO$ -->
 </Include>

--- a/src/Votive/votive2010/src/Templates/ProjectItems/LocalizationFile/LocalizationFile.wxl
+++ b/src/Votive/votive2010/src/Templates/ProjectItems/LocalizationFile/LocalizationFile.wxl
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-
-
 <WixLocalization Culture="en-us" xmlns="http://schemas.microsoft.com/wix/2006/localization">
 	<String Id="YOURLOCID">$loc_YOURLOCSTRING$</String>
 </WixLocalization>

--- a/src/Votive/votive2010/src/Templates/Projects/CustomActionCS/AssemblyInfo.cs
+++ b/src/Votive/votive2010/src/Templates/Projects/CustomActionCS/AssemblyInfo.cs
@@ -1,10 +1,8 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
-
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("$projectname$")]
@@ -15,8 +13,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -26,11 +24,11 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]

--- a/src/Votive/votive2010/src/Templates/Projects/CustomActionCS/CustomAction.config
+++ b/src/Votive/votive2010/src/Templates/Projects/CustomActionCS/CustomAction.config
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-
-
 <configuration>
     <startup useLegacyV2RuntimeActivationPolicy="true">
 
@@ -16,7 +13,7 @@
 
           Note for .NET Framework v3.0 and v3.5, the runtime version is still v2.0.
 
-          In order to enable .NET Framework version 2.0 runtime activation policy, which is to load all assemblies 
+          In order to enable .NET Framework version 2.0 runtime activation policy, which is to load all assemblies
           by using the latest supported runtime, @useLegacyV2RuntimeActivationPolicy="true".
 
           For more information, see http://msdn.microsoft.com/en-us/library/bbx34a2h.aspx

--- a/src/Votive/votive2010/src/Templates/Projects/CustomActionCS/CustomAction.cs
+++ b/src/Votive/votive2010/src/Templates/Projects/CustomActionCS/CustomAction.cs
@@ -1,5 +1,3 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
-
 using System;
 using System.Collections.Generic;
 $if$ ($targetframeworkversion$ == 3.5)using System.Linq;

--- a/src/Votive/votive2010/src/Templates/Projects/CustomActionCS/CustomAction.csproj
+++ b/src/Votive/votive2010/src/Templates/Projects/CustomActionCS/CustomAction.csproj
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-
-
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -10,7 +7,7 @@
 		<SchemaVersion>2.0</SchemaVersion>
 		<ProjectGuid>$guid1$</ProjectGuid>
 		<OutputType>Library</OutputType>
-		<AppDesignerFolder>Properties</AppDesignerFolder>	
+		<AppDesignerFolder>Properties</AppDesignerFolder>
 		<RootNamespace>$safeprojectname$</RootNamespace>
 		<AssemblyName>$safeprojectname$</AssemblyName>
 		<TargetFrameworkVersion>v$targetframeworkversion$</TargetFrameworkVersion>

--- a/src/Votive/votive2010/src/Templates/Projects/CustomActionVB/CustomAction.config
+++ b/src/Votive/votive2010/src/Templates/Projects/CustomActionVB/CustomAction.config
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-
-
 <configuration>
     <startup useLegacyV2RuntimeActivationPolicy="true">
 
@@ -16,7 +13,7 @@
 
           Note for .NET Framework v3.0 and v3.5, the runtime version is still v2.0.
 
-          In order to enable .NET Framework version 2.0 runtime activation policy, which is to load all assemblies 
+          In order to enable .NET Framework version 2.0 runtime activation policy, which is to load all assemblies
           by using the latest supported runtime, @useLegacyV2RuntimeActivationPolicy="true".
 
           For more information, see http://msdn.microsoft.com/en-us/library/bbx34a2h.aspx

--- a/src/Votive/votive2010/src/Templates/Projects/WixBundleProject/Bundle.Generated.wxs
+++ b/src/Votive/votive2010/src/Templates/Projects/WixBundleProject/Bundle.Generated.wxs
@@ -1,7 +1,4 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-
-
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <Fragment>
     <PayloadGroup Id="Bundle.Generated.Payloads" />

--- a/src/Votive/votive2010/src/Templates/Projects/WixBundleProject/Bundle.wxs
+++ b/src/Votive/votive2010/src/Templates/Projects/WixBundleProject/Bundle.wxs
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-
-
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
 	<Bundle Name="$wixsafeprojectname$" Version="1.0.0.0" Manufacturer="$registeredorganization$" UpgradeCode="$guid1$">
 		<BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.RtfLicense" />

--- a/src/Votive/votive2010/src/Templates/Projects/WixBundleProject/BundleProject.wixproj
+++ b/src/Votive/votive2010/src/Templates/Projects/WixBundleProject/BundleProject.wixproj
@@ -1,7 +1,3 @@
-
-<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-
-
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/src/Votive/votive2010/src/Templates/Projects/WixLibrary/Library.wxs
+++ b/src/Votive/votive2010/src/Templates/Projects/WixLibrary/Library.wxs
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-
-
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
 	<Fragment>
 		<!-- $loc_WXS_TODO$ -->

--- a/src/Votive/votive2010/src/Templates/Projects/WixLibrary/setuplibrary.wixproj
+++ b/src/Votive/votive2010/src/Templates/Projects/WixLibrary/setuplibrary.wixproj
@@ -1,7 +1,3 @@
-
-<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-
-
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/src/Votive/votive2010/src/Templates/Projects/WixMergeModule/MergeModule.wixproj
+++ b/src/Votive/votive2010/src/Templates/Projects/WixMergeModule/MergeModule.wixproj
@@ -1,7 +1,3 @@
-
-<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-
-
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/src/Votive/votive2010/src/Templates/Projects/WixMergeModule/MergeModule.wxs
+++ b/src/Votive/votive2010/src/Templates/Projects/WixMergeModule/MergeModule.wxs
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-
-
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
 	<Module Id="$wixsafeprojectname$" Language="1033" Version="1.0.0.0">
 		<Package Id="$guid2$" Manufacturer="$registeredorganization$" InstallerVersion="200" />

--- a/src/Votive/votive2010/src/Templates/Projects/WixProject/Product.wxs
+++ b/src/Votive/votive2010/src/Templates/Projects/WixProject/Product.wxs
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-
-
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
 	<Product Id="*" Name="$wixsafeprojectname$" Language="1033" Version="1.0.0.0" Manufacturer="$registeredorganization$" UpgradeCode="$guid3$">
 		<Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" />

--- a/src/Votive/votive2010/src/Templates/Projects/WixProject/SetupProject.wixproj
+++ b/src/Votive/votive2010/src/Templates/Projects/WixProject/SetupProject.wixproj
@@ -1,7 +1,3 @@
-
-<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-
-
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/src/Votive/votive2010/src/Templates/Projects/customaction.config
+++ b/src/Votive/votive2010/src/Templates/Projects/customaction.config
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
-
-
 <configuration>
     <startup useLegacyV2RuntimeActivationPolicy="true">
 
@@ -16,7 +13,7 @@
 
           Note for .NET Framework v3.0 and v3.5, the runtime version is still v2.0.
 
-          In order to enable .NET Framework version 2.0 runtime activation policy, which is to load all assemblies 
+          In order to enable .NET Framework version 2.0 runtime activation policy, which is to load all assemblies
           by using the latest supported runtime, @useLegacyV2RuntimeActivationPolicy="true".
 
           For more information, see http://msdn.microsoft.com/en-us/library/bbx34a2h.aspx

--- a/src/Votive/votive2012/Templates/Projects/CustomActionCPP/CustomAction.cpp
+++ b/src/Votive/votive2012/Templates/Projects/CustomActionCPP/CustomAction.cpp
@@ -1,5 +1,3 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
-
 #include "stdafx.h"
 
 

--- a/src/Votive/votive2012/Templates/Projects/CustomActionCPP/CustomAction.def
+++ b/src/Votive/votive2012/Templates/Projects/CustomActionCPP/CustomAction.def
@@ -1,6 +1,3 @@
-; Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
-
-
 LIBRARY "$projectname$"
 
 EXPORTS

--- a/src/Votive/votive2012/Templates/Projects/CustomActionCPP/stdafx.cpp
+++ b/src/Votive/votive2012/Templates/Projects/CustomActionCPP/stdafx.cpp
@@ -1,5 +1,3 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
-
 #include "stdafx.h"
 
 // TODO: reference any additional headers you need in STDAFX.H

--- a/src/Votive/votive2012/Templates/Projects/CustomActionCPP/stdafx.h
+++ b/src/Votive/votive2012/Templates/Projects/CustomActionCPP/stdafx.h
@@ -1,6 +1,4 @@
 #pragma once
-// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
-
 
 #include "targetver.h"
 

--- a/src/Votive/votive2012/Templates/Projects/CustomActionCPP/targetver.h
+++ b/src/Votive/votive2012/Templates/Projects/CustomActionCPP/targetver.h
@@ -1,6 +1,4 @@
 #pragma once
-// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
-
 
 #ifndef WINVER                  // Specifies that the minimum required platform is Windows 2000.
 #define WINVER 0x0500           // Change this to the appropriate value to target other versions of Windows.

--- a/src/Votive/votive2013/Templates/Projects/CustomActionCPP/CustomAction.cpp
+++ b/src/Votive/votive2013/Templates/Projects/CustomActionCPP/CustomAction.cpp
@@ -1,5 +1,3 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
-
 #include "stdafx.h"
 
 

--- a/src/Votive/votive2013/Templates/Projects/CustomActionCPP/CustomAction.def
+++ b/src/Votive/votive2013/Templates/Projects/CustomActionCPP/CustomAction.def
@@ -1,6 +1,3 @@
-; Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
-
-
 LIBRARY "$projectname$"
 
 EXPORTS

--- a/src/Votive/votive2013/Templates/Projects/CustomActionCPP/stdafx.cpp
+++ b/src/Votive/votive2013/Templates/Projects/CustomActionCPP/stdafx.cpp
@@ -1,5 +1,3 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
-
 #include "stdafx.h"
 
 // TODO: reference any additional headers you need in STDAFX.H

--- a/src/Votive/votive2013/Templates/Projects/CustomActionCPP/stdafx.h
+++ b/src/Votive/votive2013/Templates/Projects/CustomActionCPP/stdafx.h
@@ -1,6 +1,4 @@
 #pragma once
-// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
-
 
 #include "targetver.h"
 

--- a/src/Votive/votive2013/Templates/Projects/CustomActionCPP/targetver.h
+++ b/src/Votive/votive2013/Templates/Projects/CustomActionCPP/targetver.h
@@ -1,6 +1,4 @@
 #pragma once
-// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
-
 
 #ifndef WINVER                  // Specifies that the minimum required platform is Windows 2000.
 #define WINVER 0x0500           // Change this to the appropriate value to target other versions of Windows.

--- a/src/Votive/votive2015/Templates/Projects/CustomActionCPP/CustomAction.cpp
+++ b/src/Votive/votive2015/Templates/Projects/CustomActionCPP/CustomAction.cpp
@@ -1,5 +1,3 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
-
 #include "stdafx.h"
 
 

--- a/src/Votive/votive2015/Templates/Projects/CustomActionCPP/CustomAction.def
+++ b/src/Votive/votive2015/Templates/Projects/CustomActionCPP/CustomAction.def
@@ -1,6 +1,3 @@
-; Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
-
-
 LIBRARY "$projectname$"
 
 EXPORTS

--- a/src/Votive/votive2015/Templates/Projects/CustomActionCPP/stdafx.cpp
+++ b/src/Votive/votive2015/Templates/Projects/CustomActionCPP/stdafx.cpp
@@ -1,5 +1,3 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
-
 #include "stdafx.h"
 
 // TODO: reference any additional headers you need in STDAFX.H

--- a/src/Votive/votive2015/Templates/Projects/CustomActionCPP/stdafx.h
+++ b/src/Votive/votive2015/Templates/Projects/CustomActionCPP/stdafx.h
@@ -1,6 +1,4 @@
 #pragma once
-// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
-
 
 #include "targetver.h"
 

--- a/src/Votive/votive2015/Templates/Projects/CustomActionCPP/targetver.h
+++ b/src/Votive/votive2015/Templates/Projects/CustomActionCPP/targetver.h
@@ -1,6 +1,4 @@
 #pragma once
-// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
-
 
 #ifndef WINVER                  // Specifies that the minimum required platform is Windows 2000.
 #define WINVER 0x0500           // Change this to the appropriate value to target other versions of Windows.


### PR DESCRIPTION
Templates are meant to be starting points for developers to build on.
They should not be copyleft or that would force any project using our
templates to release their source code.