### PR TITLE
WIXBUG:5331 is resolved by changing the declaration of wzDescription …

### DIFF
--- a/history/5331.md
+++ b/history/5331.md
@@ -1,0 +1,1 @@
+    * PhillHgl: WIXBUG:5331 - fix ConfigureSmbUninstall CA failures (on install) when util:FileShare/@Description was longer than 73 chars.  Increased to 255 chars, matching table definition.

--- a/src/ext/ca/serverca/scasched/scasmb.h
+++ b/src/ext/ca/serverca/scasched/scasmb.h
@@ -18,7 +18,7 @@ struct SCA_SMB  // hungarian ss
 {
 	WCHAR wzId[MAX_DARWIN_KEY + 1];
 	WCHAR wzShareName[MAX_DARWIN_KEY + 1];
-	WCHAR wzDescription[MAX_DARWIN_KEY + 1];
+	WCHAR wzDescription[MAX_DARWIN_COLUMN + 1];
 	WCHAR wzComponent[MAX_DARWIN_KEY + 1];
 	WCHAR wzDirectory[MAX_PATH + 1];
 


### PR DESCRIPTION
…in SCA_SMB struct from MAX_DARWIN_KEY (73) to MAX_DARWIN_COLUMN (255)