### PR TITLE
Use correct NuGet API endpoint

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -6,4 +6,8 @@
   <config>
     <add key="repositoryPath" value="packages" />
   </config>
+  <packageSources>
+    <clear />
+    <add key="NuGet v2" value="https://nuget.org/api/v2" />
+  </packageSources>
 </configuration>


### PR DESCRIPTION
First time project initialization may fail on `nuget.exe install` when user has the NuGet 3 installed and the global config file uses v3 API endpoint because the WiX project bundle NuGet 2 in tools.

This adds the v2 API endpoint to NuGet configuration file.