### PR TITLE
Make themes DPI aware

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* JozefIzso: WIXBUG:3920 - Make themes DPI aware
+
 * HeathS: WIXBUG:4541 - Add support for high DPI to the Burn engine
 
 ## WixBuild: Version 3.11.0.705

--- a/History.md
+++ b/History.md
@@ -1,3 +1,5 @@
+* HeathS: WIXBUG:4541 - Add support for high DPI to the Burn engine
+
 ## WixBuild: Version 3.11.0.705
 
 * @barnson: WIXBUG:5306 - Warn against ServiceConfig and ServiceConfigFailureActions.

--- a/src/burn/engine/precomp.h
+++ b/src/burn/engine/precomp.h
@@ -12,6 +12,7 @@
 #include <windows.h>
 #include <aclapi.h>
 #include <Bits.h>
+#include <gdiplus.h>
 #include <math.h>
 #include <msiquery.h>
 #include <sddl.h>
@@ -33,6 +34,7 @@
 #include <cryputil.h>
 #include <dirutil.h>
 #include <fileutil.h>
+#include <gdiputil.h>
 #include <logutil.h>
 #include <memutil.h>
 #include <osutil.h>

--- a/src/burn/stub/Stub.vcxproj
+++ b/src/burn/stub/Stub.vcxproj
@@ -34,7 +34,7 @@
 
   <PropertyGroup>
     <ProjectAdditionalIncludeDirectories>$(WixRoot)src\libs\dutil\inc;$(ProjectDir)..\inc;$(ProjectDir)..\engine\inc</ProjectAdditionalIncludeDirectories>
-    <ProjectAdditionalLinkLibraries>cabinet.lib;crypt32.lib;msi.lib;rpcrt4.lib;shlwapi.lib;wininet.lib;wintrust.lib;wuguid.lib;dutil.lib;deputil.lib;engine.lib;engine.res</ProjectAdditionalLinkLibraries>
+    <ProjectAdditionalLinkLibraries>cabinet.lib;crypt32.lib;msi.lib;rpcrt4.lib;shlwapi.lib;wininet.lib;wintrust.lib;wuguid.lib;dutil.lib;deputil.lib;engine.lib;engine.res;gdiplus.lib</ProjectAdditionalLinkLibraries>
   </PropertyGroup>
 
   <ItemDefinitionGroup>

--- a/src/burn/stub/stub.manifest
+++ b/src/burn/stub/stub.manifest
@@ -2,9 +2,10 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
 
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" manifestVersion="1.0">
  <assemblyIdentity name="setup.exe" version="1.0.0.0" processorArchitecture="x86" type="win32"/>
  <description>WiX Toolset Bootstrapper</description>
+ <asmv3:application><asmv3:windowsSettings><ws:dpiAware xmlns:ws="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</ws:dpiAware></asmv3:windowsSettings></asmv3:application>
  <dependency><dependentAssembly><assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="X86" publicKeyToken="6595b64144ccf1df" language="*" /></dependentAssembly></dependency>
  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1"><application>
   <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>

--- a/src/burn/stub/stub_arm.manifest
+++ b/src/burn/stub/stub_arm.manifest
@@ -2,9 +2,10 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
 
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" manifestVersion="1.0">
  <assemblyIdentity name="setup.exe" version="1.0.0.0" processorArchitecture="arm" type="win32"/>
  <description>WiX Toolset Bootstrapper</description>
+ <asmv3:application><asmv3:windowsSettings><ws:dpiAware xmlns:ws="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</ws:dpiAware></asmv3:windowsSettings></asmv3:application>
  <dependency><dependentAssembly><assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="arm" publicKeyToken="6595b64144ccf1df" language="*" /></dependentAssembly></dependency>
  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1"><application><supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/><supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/></application></compatibility>
  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3"><security><requestedPrivileges><requestedExecutionLevel level="asInvoker" uiAccess="false"/></requestedPrivileges></security></trustInfo>

--- a/src/libs/dutil/gdiputil.cpp
+++ b/src/libs/dutil/gdiputil.cpp
@@ -210,3 +210,55 @@ HRESULT DAPI GdipHresultFromStatus(
 
     return E_UNEXPECTED;
 }
+
+/********************************************************************
+GetDpiForMonitor - returns the X and Y DPI values for specified monitor.
+
+********************************************************************/
+BOOL DAPI GetDpiForMonitor(
+    __in_opt HWND hWnd,
+    __out UINT* nDpiX,
+    __out UINT* nDpiY
+    )
+{
+    HMONITOR hMonitor = NULL;
+    MONITORINFOEXW mi;
+    HDC hdc = NULL;
+
+    hMonitor = ::MonitorFromWindow(hWnd, MONITOR_DEFAULTTOPRIMARY);
+    if (hMonitor)
+    {
+        SecureZeroMemory(&mi, sizeof(mi));
+        mi.cbSize = sizeof(mi);
+
+        if (::GetMonitorInfoW(hMonitor, &mi))
+        {
+            hdc = ::CreateDCW(L"DISPLAY", mi.szDevice, NULL, NULL);
+            if (hdc)
+            {
+                *nDpiX = ::GetDeviceCaps(hdc, LOGPIXELSX);
+                *nDpiY = ::GetDeviceCaps(hdc, LOGPIXELSY);
+
+                ::ReleaseDC(NULL, hdc);
+
+                return TRUE;
+            }
+        }
+    }
+
+    *nDpiX = 96;
+    *nDpiY = 96;
+
+    return FALSE;
+}
+
+/********************************************************************
+GetScaleFactorForDpi - returns the scale factor for given DPI resolution.
+
+********************************************************************/
+FLOAT DAPI GetScaleFactorForDpi(
+    UINT nDpi
+    )
+{
+    return nDpi / 96.0f;
+}

--- a/src/libs/dutil/gdiputil.cpp
+++ b/src/libs/dutil/gdiputil.cpp
@@ -5,6 +5,41 @@
 using namespace Gdiplus;
 
 /********************************************************************
+ GdipInitialize - initializes GDI+.
+
+ Note: pOutput must be non-NULL if pInput->SuppressBackgroundThread
+       is TRUE. See GdiplusStartup() for more information.
+********************************************************************/
+extern "C" HRESULT DAPI GdipInitialize(
+    __in const Gdiplus::GdiplusStartupInput* pInput,
+    __out ULONG_PTR* pToken,
+    __out_opt Gdiplus::GdiplusStartupOutput *pOutput
+    )
+{
+    AssertSz(!pInput->SuppressBackgroundThread || pOutput, "pOutput required if background thread suppressed.");
+
+    HRESULT hr = S_OK;
+    Status status = Ok;
+
+    status = GdiplusStartup(pToken, pInput, pOutput);
+    ExitOnGdipFailure(status, hr, "Failed to initialize GDI+.");
+
+LExit:
+    return hr;
+}
+
+/********************************************************************
+ GdipUninitialize - uninitializes GDI+.
+
+********************************************************************/
+extern "C" void DAPI GdipUninitialize(
+    __in ULONG_PTR token
+    )
+{
+    GdiplusShutdown(token);
+}
+
+/********************************************************************
  GdipBitmapFromResource - read a GDI+ image out of a resource stream
 
 ********************************************************************/

--- a/src/libs/dutil/inc/gdiputil.h
+++ b/src/libs/dutil/inc/gdiputil.h
@@ -35,6 +35,16 @@ HRESULT DAPI GdipHresultFromStatus(
     __in Gdiplus::Status gs
     );
 
+BOOL DAPI GetDpiForMonitor(
+    __in_opt HWND hWnd,
+    __out UINT* nDpiX,
+    __out UINT* nDpiY
+    );
+
+FLOAT DAPI GetScaleFactorForDpi(
+    UINT nDpi
+    );
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libs/dutil/inc/gdiputil.h
+++ b/src/libs/dutil/inc/gdiputil.h
@@ -10,6 +10,16 @@
 extern "C" {
 #endif
 
+HRESULT DAPI GdipInitialize(
+    __in const Gdiplus::GdiplusStartupInput* pInput,
+    __out ULONG_PTR* pToken,
+    __out_opt Gdiplus::GdiplusStartupOutput *pOutput
+    );
+
+void DAPI GdipUninitialize(
+    __in ULONG_PTR token
+    );
+
 HRESULT DAPI GdipBitmapFromResource(
     __in_opt HINSTANCE hinst,
     __in_z LPCSTR szId,

--- a/src/libs/dutil/inc/thmutil.h
+++ b/src/libs/dutil/inc/thmutil.h
@@ -179,6 +179,10 @@ struct THEME
     // state variables that should be ignored
     HWND hwndParent; // parent for loaded controls
     HWND hwndHover; // current hwnd hovered over
+
+    // DPI scaling
+    FLOAT fScaleFactorX;
+    FLOAT fScaleFactorY;
 };
 
 
@@ -549,6 +553,11 @@ DAPI_(void) ThemeSetFocus(
     __in THEME* pTheme,
     __in DWORD dwControl
     );
+
+DAPI_(int) ScaleByFactor(
+    int pixels,
+    FLOAT fScaleFactor
+);
 
 #ifdef __cplusplus
 }

--- a/src/libs/dutil/thmutil.cpp
+++ b/src/libs/dutil/thmutil.cpp
@@ -243,8 +243,8 @@ DAPI_(HRESULT) ThemeInitialize(
     // Initialize GDI+ and common controls.
     vgsi.SuppressBackgroundThread = TRUE;
 
-    Gdiplus::Status gdiStatus = Gdiplus::GdiplusStartup(&vgdiToken, &vgsi, &vgso);
-    ExitOnGdipFailure(gdiStatus, hr, "Failed to initialize GDI+.");
+    hr = GdipInitialize(&vgsi, &vgdiToken, &vgso);
+    ExitOnFailure(hr, "Failed to initialize GDI+.");
 
     icex.dwSize = sizeof(INITCOMMONCONTROLSEX);
     icex.dwICC = ICC_STANDARD_CLASSES | ICC_PROGRESS_CLASS | ICC_LISTVIEW_CLASSES | ICC_TREEVIEW_CLASSES | ICC_TAB_CLASSES | ICC_LINK_CLASS;
@@ -273,7 +273,7 @@ DAPI_(void) ThemeUninitialize()
 
     if (vgdiToken)
     {
-        Gdiplus::GdiplusShutdown(vgdiToken);
+        GdipUninitialize(vgdiToken);
         vgdiToken = 0;
     }
 

--- a/src/tools/thmviewer/display.cpp
+++ b/src/tools/thmviewer/display.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
 
 #include "precomp.h"
+#include "gdiputil.h"
 
 static const LPCWSTR THMVWR_WINDOW_CLASS_DISPLAY = L"ThmViewerDisplay";
 
@@ -106,8 +107,8 @@ static DWORD WINAPI DisplayThreadProc(
 
             if (CW_USEDEFAULT == x && CW_USEDEFAULT == y && ::GetWindowRect(hwndParent, &rc))
             {
-                x = rc.left;
-                y = rc.bottom + 20;
+                x = rc.right + ScaleByFactor(10, pTheme->fScaleFactorX);
+                y = rc.top;
             }
 
             hWnd = ::CreateWindowExW(0, wc.lpszClassName, pTheme->sczCaption, pTheme->dwStyle, x, y, pTheme->nWidth, pTheme->nHeight, hwndParent, NULL, hInstance, pCurrentHandle);

--- a/src/tools/thmviewer/thmviewer.manifest
+++ b/src/tools/thmviewer/thmviewer.manifest
@@ -2,10 +2,38 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
 
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
- <assemblyIdentity name="thmviewer.exe" version="1.0.0.0" processorArchitecture="x86" type="win32"/>
- <description>WiX Toolset Theme Viewer</description>
- <dependency><dependentAssembly><assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="X86" publicKeyToken="6595b64144ccf1df" language="*" /></dependentAssembly></dependency>
- <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1"><application><supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/><supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/></application></compatibility>
- <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3"><security><requestedPrivileges><requestedExecutionLevel level="asInvoker" uiAccess="false"/></requestedPrivileges></security></trustInfo>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" manifestVersion="1.0">
+  <assemblyIdentity name="thmviewer.exe" version="1.0.0.0" processorArchitecture="x86" type="win32"/>
+  <description>WiX Toolset Theme Viewer</description>
+  <asmv3:application>
+    <asmv3:windowsSettings>
+      <ws:dpiAware xmlns:ws="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</ws:dpiAware>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="X86" publicKeyToken="6595b64144ccf1df" language="*" />
+    </dependentAssembly>
+  </dependency>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <!-- Windows Vista -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+    </application>
+  </compatibility>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
 </assembly>

--- a/test/src/UnitTests/Burn/BurnUnitTest.vcxproj
+++ b/test/src/UnitTests/Burn/BurnUnitTest.vcxproj
@@ -25,7 +25,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), wix.proj))\tools\WixBuild.props" />
   <PropertyGroup>
     <ProjectAdditionalIncludeDirectories>$(WixRoot)src\libs\dutil\inc;$(WixRoot)src\burn\inc;$(WixRoot)src\burn\engine;$(WixRoot)src\libs\deputil\inc</ProjectAdditionalIncludeDirectories>
-    <ProjectAdditionalLinkLibraries>cabinet.lib;crypt32.lib;msi.lib;rpcrt4.lib;shlwapi.lib;wininet.lib;wintrust.lib;dutil.lib;deputil.lib;engine.lib</ProjectAdditionalLinkLibraries>
+    <ProjectAdditionalLinkLibraries>cabinet.lib;crypt32.lib;msi.lib;rpcrt4.lib;shlwapi.lib;wininet.lib;wintrust.lib;dutil.lib;deputil.lib;engine.lib;gdiplus.lib</ProjectAdditionalLinkLibraries>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="AssemblyInfo.cpp" />


### PR DESCRIPTION
I've updated theme loader to scale UI elements at load time to the DPI level of primary monitor.
I've ported the splashcreen code from https://github.com/wixtoolset/wix4/pull/46

The burn.exe is marked as DPI aware. Loading the DPI of primary monitor should be sufficient for general use. I could not make the rescaling based on current monitor. I tested the built-in themes and they worked correctly.

I also updated thmviewer.exe to support high DPI monitors.

There may be some quirks in the implementation. This fixes the https://github.com/wixtoolset/issues/issues/3920
