### PR TITLE
Fix for Multi-instance performance counters #5457

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ ipch/
 *.cachefile
 *.VC.db
 *.VC.VC.opendb
+/src/ext/UtilExtension/wixext/UpgradeLog.htm
+/src/ext/UtilExtension/wixext/WixUtilExtension.sln

--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,3 @@ ipch/
 *.cachefile
 *.VC.db
 *.VC.VC.opendb
-/src/ext/UtilExtension/wixext/UpgradeLog.htm
-/src/ext/UtilExtension/wixext/WixUtilExtension.sln

--- a/src/ext/UtilExtension/wixext/PerformanceCategoryHarvester.cs
+++ b/src/ext/UtilExtension/wixext/PerformanceCategoryHarvester.cs
@@ -1,5 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
 
+using System.Linq;
+
 namespace Microsoft.Tools.WindowsInstallerXml.Extensions
 {
     using System;
@@ -62,7 +64,7 @@ namespace Microsoft.Tools.WindowsInstallerXml.Extensions
                 Util.PerformanceCategory perfCategory = new Util.PerformanceCategory();
 
                 // Get the performance counter category and set the appropriate WiX attributes
-                PerformanceCounterCategory pcc = new PerformanceCounterCategory(category);
+                PerformanceCounterCategory pcc = PerformanceCounterCategory.GetCategories().Single(c => string.Equals(c.CategoryName, category));
                 perfCategory.Id = CompilerCore.GetIdentifierFromName(pcc.CategoryName);
                 perfCategory.Name = pcc.CategoryName;
                 perfCategory.Help = pcc.CategoryHelp;
@@ -71,15 +73,14 @@ namespace Microsoft.Tools.WindowsInstallerXml.Extensions
                     perfCategory.MultiInstance = Util.YesNoType.yes;
                 }
                 
-                foreach (InstanceDataCollection counter in pcc.ReadCategory().Values)
+                foreach (PerformanceCounter counter in pcc.GetCounters())
                 {
                     Util.PerformanceCounter perfCounter = new Util.PerformanceCounter();
 
                     // Get the performance counter and set the appropriate WiX attributes
-                    PerformanceCounter pc = new PerformanceCounter(pcc.CategoryName, counter.CounterName);
-                    perfCounter.Name = pc.CounterName;
-                    perfCounter.Type = CounterTypeToWix(pc.CounterType);
-                    perfCounter.Help = pc.CounterHelp;
+                    perfCounter.Name = counter.CounterName;
+                    perfCounter.Type = CounterTypeToWix(counter.CounterType);
+                    perfCounter.Help = counter.CounterHelp;
 
                     perfCategory.AddChild(perfCounter);
                 }

--- a/src/ext/UtilExtension/wixext/PerformanceCategoryHarvester.cs
+++ b/src/ext/UtilExtension/wixext/PerformanceCategoryHarvester.cs
@@ -73,7 +73,17 @@ namespace Microsoft.Tools.WindowsInstallerXml.Extensions
                     perfCategory.MultiInstance = Util.YesNoType.yes;
                 }
                 
-                foreach (PerformanceCounter counter in pcc.GetCounters())
+                // If it's multi-instance, check if there are any instances and get counters from there; else we get 
+                // the counters straight up. For multi-instance, GetCounters() fails if there are any instances. If there
+                // are no instances, then GetCounters(instance) can't be called since there is no instance. Instances
+                // will exist for each counter even if only one of the counters was "intialized."
+                string[] instances = pcc.GetInstanceNames();
+                bool hasInstances = instances.Length > 0;
+                PerformanceCounter[] counters = hasInstances
+                    ? pcc.GetCounters(instances.First())
+                    : pcc.GetCounters();
+                    
+                foreach (PerformanceCounter counter in counters)
                 {
                     Util.PerformanceCounter perfCounter = new Util.PerformanceCounter();
 


### PR DESCRIPTION
Fixes https://github.com/wixtoolset/issues/issues/5457

- When creating counters relying on a base counter, creates the base counter as well. (AverageTimer32+AverageBase)

- Does not fail when trying to create a multi-instance counters...

- Creates multi-instance counters whether or not there are any active instances.

