### PR TITLE
Protect against use of reserved file names

### DIFF
--- a/src/tools/wix/Common.cs
+++ b/src/tools/wix/Common.cs
@@ -88,6 +88,8 @@ namespace Microsoft.Tools.WindowsInstallerXml
         // FILE_ALL_ACCESS           (STANDARD_RIGHTS_REQUIRED | SYNCHRONIZE | 0x1FF)
         internal static readonly string[] FilePermissions = { "Read", "Write", "Append", "ReadExtendedAttributes", "WriteExtendedAttributes", "Execute", "FileAllRights", "ReadAttributes", "WriteAttributes" };
 
+        internal static readonly string[] ReservedFileNames = { "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9" };
+
         internal static readonly Regex WixVariableRegex = new Regex(@"(\!|\$)\((?<namespace>loc|wix|bind|bindpath)\.(?<fullname>(?<name>[_A-Za-z][0-9A-Za-z_]+)(\.(?<scope>[_A-Za-z][0-9A-Za-z_\.]*))?)(\=(?<value>.+?))?\)", RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.ExplicitCapture);
 
         internal const char CustomRowFieldSeparator = '\x85';


### PR DESCRIPTION
Windows has a set of reserved file names such as `CON`, `NUL`, `COM1`,
`LPT2`. Creating files with those names will result in all sorts of
undesirable behavior, the most common is that that the build hangs.
Now we'll catch use of reserved names and print out a helpful error
message.

Fixes wixtoolset/issues#4797