### PR TITLE
Fix #4932 - Adding german localization for SqlExtension

### DIFF
--- a/history/4932.md
+++ b/history/4932.md
@@ -1,0 +1,1 @@
+* MarcSch WIXBUG:4932 - Adding german localization for SqlExtension

--- a/src/ext/SqlExtension/wixlib/SqlExtension.wixproj
+++ b/src/ext/SqlExtension/wixlib/SqlExtension.wixproj
@@ -24,12 +24,12 @@
 
   <ItemGroup>
     <Compile Include="SqlExtension.wxs" />
+    <EmbeddedResource Include="de-de.wxl" />
     <EmbeddedResource Include="en-us.wxl" />
     <EmbeddedResource Include="es-es.wxl" />
     <EmbeddedResource Include="ja-jp.wxl" />
     <EmbeddedResource Include="pt-pt.wxl" />
     <EmbeddedResource Include="pt-br.wxl" />
-    <EmbeddedResource Include="de-de.wxl" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ext/SqlExtension/wixlib/SqlExtension.wixproj
+++ b/src/ext/SqlExtension/wixlib/SqlExtension.wixproj
@@ -29,6 +29,7 @@
     <EmbeddedResource Include="ja-jp.wxl" />
     <EmbeddedResource Include="pt-pt.wxl" />
     <EmbeddedResource Include="pt-br.wxl" />
+    <EmbeddedResource Include="de-de.wxl" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ext/SqlExtension/wixlib/de-de.wxl
+++ b/src/ext/SqlExtension/wixlib/de-de.wxl
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WixLocalization Culture="de-de" xmlns="http://schemas.microsoft.com/wix/2006/localization">
+    <String Id="msierrSQLFailedCreateDatabase" Overridable="yes">Fehler [2]: Erstellen der SQL-Datenbank fehlgeschlagen: [3], Fehlerbeschreibung: [4].</String>
+    <String Id="msierrSQLFailedDropDatabase" Overridable="yes">Fehler [2]: Löschen der SQL-Datenbank fehlgeschlagen: [3], Fehlerbeschreibung: [4].</String>
+    <String Id="msierrSQLFailedConnectDatabase" Overridable="yes">Verbinden mit der SQL-Datenbank fehlgeschlagen.  ([2]   [3]   [4]   [5])</String>
+    <String Id="msierrSQLFailedExecString" Overridable="yes">Fehler [2]: Das Ausführen der SQL Zeichenfolge ist fehlgeschlagen, Fehlerbeschreibung: [3], SQL-Schlüssel: [4] SQL-Zeichenfolge: [5]</String>
+    <String Id="msierrSQLDatabaseAlreadyExists" Overridable="yes">Die Datenbank [3] existiert bereits. Wollen Sie fortfahren?</String>
+
+    <String Id="ConfigureSql" Overridable="yes">Konfiguriere SQL Server</String>
+    <String Id="CreateDatabase" Overridable="yes">Erstelle Datenbanken</String>
+    <String Id="DropDatabase" Overridable="yes">Lösche Datenbanken</String>
+    <String Id="ExecuteSqlStrings" Overridable="yes">SQL-Zeichenfolgen werden ausgeführt</String>
+    <String Id="RollbackExecuteSqlStrings" Overridable="yes">SQL Zeichenfolgen werden zurück gesetzt</String>
+</WixLocalization>

--- a/src/ext/SqlExtension/wixlib/de-de.wxl
+++ b/src/ext/SqlExtension/wixlib/de-de.wxl
@@ -3,12 +3,12 @@
     <String Id="msierrSQLFailedCreateDatabase" Overridable="yes">Fehler [2]: Erstellen der SQL-Datenbank fehlgeschlagen: [3], Fehlerbeschreibung: [4].</String>
     <String Id="msierrSQLFailedDropDatabase" Overridable="yes">Fehler [2]: Löschen der SQL-Datenbank fehlgeschlagen: [3], Fehlerbeschreibung: [4].</String>
     <String Id="msierrSQLFailedConnectDatabase" Overridable="yes">Verbinden mit der SQL-Datenbank fehlgeschlagen.  ([2]   [3]   [4]   [5])</String>
-    <String Id="msierrSQLFailedExecString" Overridable="yes">Fehler [2]: Das Ausführen der SQL Zeichenfolge ist fehlgeschlagen, Fehlerbeschreibung: [3], SQL-Schlüssel: [4] SQL-Zeichenfolge: [5]</String>
+    <String Id="msierrSQLFailedExecString" Overridable="yes">Fehler [2]: Das Erstellen der SQL Zeichenfolge ist fehlgeschlagen, Fehlerbeschreibung: [3], SQL-Schlüssel: [4] SQL-Zeichenfolge: [5]</String>
     <String Id="msierrSQLDatabaseAlreadyExists" Overridable="yes">Die Datenbank [3] existiert bereits. Wollen Sie fortfahren?</String>
 
     <String Id="ConfigureSql" Overridable="yes">Konfiguriere SQL Server</String>
     <String Id="CreateDatabase" Overridable="yes">Erstelle Datenbanken</String>
     <String Id="DropDatabase" Overridable="yes">Lösche Datenbanken</String>
-    <String Id="ExecuteSqlStrings" Overridable="yes">SQL-Zeichenfolgen werden ausgeführt</String>
-    <String Id="RollbackExecuteSqlStrings" Overridable="yes">SQL Zeichenfolgen werden zurück gesetzt</String>
+    <String Id="ExecuteSqlStrings" Overridable="yes">SQL-Zeichenfolgen werden erstellt</String>
+    <String Id="RollbackExecuteSqlStrings" Overridable="yes">SQL-Zeichenfolgen werden zurückgesetzt</String>
 </WixLocalization>


### PR DESCRIPTION
Fix for Issue #4932 "WixSqlExtension de localized strings are in the WixUIExtension, not accessible so far as I could tell."

This could also be merged to wix4. Please notify me if I should also create pull request for it.