### PR TITLE
Fix null-check to check the right null.

### DIFF
--- a/history/5318.md
+++ b/history/5318.md
@@ -1,0 +1,1 @@
+* Barnson: Fix null-check to check the right null. Fixes wixtoolset/issues/issues#5318.

--- a/src/burn/engine/package.cpp
+++ b/src/burn/engine/package.cpp
@@ -253,7 +253,7 @@ extern "C" HRESULT PackagesParseFromXml(
         ExitOnNull(pPackages->rgPatchInfo, hr, E_OUTOFMEMORY, "Failed to allocate memory for MSP patch sequence information.");
 
         pPackages->rgPatchInfoToPackage = static_cast<BURN_PACKAGE**>(MemAlloc(sizeof(BURN_PACKAGE*) * cMspPackages, TRUE));
-        ExitOnNull(pPackages->rgPatchInfo, hr, E_OUTOFMEMORY, "Failed to allocate memory for patch sequence information to package lookup.");
+        ExitOnNull(pPackages->rgPatchInfoToPackage, hr, E_OUTOFMEMORY, "Failed to allocate memory for patch sequence information to package lookup.");
 
         for (DWORD i = 0; i < pPackages->cPackages; ++i)
         {


### PR DESCRIPTION
Fixes wixtoolset/issues/issues#5318.