### PR TITLE
Add LICENSE.TXT to binaries .zip.

### DIFF
--- a/history/5474.md
+++ b/history/5474.md
@@ -1,0 +1,1 @@
+* Barnson: Add LICENSE.TXT to binaries .zip. Fixes wixtoolset/issues/issues#5474.

--- a/src/Setup/Zip/binaries.zipproj
+++ b/src/Setup/Zip/binaries.zipproj
@@ -106,6 +106,9 @@
 
   <!-- Doc -->
   <ItemGroup>
+    <Stage Include="$(WixRoot)LICENSE.TXT">
+      <Hardlink>false</Hardlink>
+    </Stage>
     <Stage Include="$(OutputPath)WiX.chm">
       <StageSubDirectory>doc</StageSubDirectory>
     </Stage>


### PR DESCRIPTION
Fixes wixtoolset/issues/issues#5474.