### PR TITLE
Fix #4831 - Check if current package shows internal UI before display the FilesInUse page.

### DIFF
--- a/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
+++ b/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
@@ -972,7 +972,7 @@ public: // IBootstrapperApplication
         __in_ecount_z(cFiles) LPCWSTR* rgwzFiles
         )
     {
-        if (m_fShowFilesInUse && !m_fPrereq && wzPackageId && *wzPackageId)
+        if (m_fShowFilesInUse && !m_fShowingInternalUiThisPackage && !m_fPrereq && wzPackageId && *wzPackageId)
         {
             //If this is an MSI package, display the files in use page.
             BAL_INFO_PACKAGE* pPackage = NULL;


### PR DESCRIPTION
Fix [wixtoolset/issues#4831](https://github.com/wixtoolset/issues/issues/4831).
Adds condition to check if current package shows internal UI before display the FilesInUse page.