### PR TITLE
Fix 5265 and 5307

### DIFF
--- a/History.md
+++ b/History.md
@@ -42,7 +42,7 @@
 
 * @barnson: Fix WIXBUG:5293 - Document illegal MsiProperty names.
 
-RobMen: WIXBUG:5282 - reduce clean room security to successfully load BA's dependent on GDI+ (including WinForms).
+* RobMen: WIXBUG:5282 - reduce clean room security to successfully load BA's dependent on GDI+ (including WinForms).
 
 * FabienL: WIXBUG:4976 - Add support for .net framework 4.6.1 in netfxExtension
 
@@ -111,11 +111,11 @@ RobMen: WIXBUG:5282 - reduce clean room security to successfully load BA's depen
 
 * SeanHall: WIXBUG:4857 - Fix DTF custom actions in Win10 Apps and Features.
 
-jmcooper8654: WIXFEAT:4437 - Modify Wix.CA.targets to add PDB files to CA Package when /p:Configuration=Debug.
+* jmcooper8654: WIXFEAT:4437 - Modify Wix.CA.targets to add PDB files to CA Package when /p:Configuration=Debug.
 
 * DavidFlamme: WIXBUG:4785 - Fixing memory leak in InstallPackage.cs
 
-MikeGC: WIXBUG:4878 - fix iniutil memory leak
+* MikeGC: WIXBUG:4878 - fix iniutil memory leak
 
 * Himem: WIXBUG:4737 - fixed condition of showing InvalidDirDlg from BrowseDlg
 

--- a/history/4812.md
+++ b/history/4812.md
@@ -1,0 +1,1 @@
+* RobMen: WIXBUG:4812 - Properly modularize IIsAppPool Name column.

--- a/history/4813.md
+++ b/history/4813.md
@@ -1,0 +1,1 @@
+* RobMen: WIXBUG:4813 - Properly modularize IIsWebApplication Name column.

--- a/history/5265.md
+++ b/history/5265.md
@@ -1,0 +1,1 @@
+* RobMen: WIXBUG:5265 - Prevent bad use of ".." in payload names.

--- a/history/5270.md
+++ b/history/5270.md
@@ -1,0 +1,1 @@
+* RobMen: WIXBUG:5270 - Properly set WixMerge columns nullable.

--- a/history/5307.md
+++ b/history/5307.md
@@ -1,0 +1,1 @@
+* RobMen: WIXBUG:5307 - Correctly set and document SystemFolder and System64Folder in Burn.

--- a/history/5438.md
+++ b/history/5438.md
@@ -1,0 +1,1 @@
+* RobMen: WIXBUG:5438 - Fix typo in candle deprecation message.

--- a/src/chm/documents/bundle/bundle_built_in_variables.html.md
+++ b/src/chm/documents/bundle/bundle_built_in_variables.html.md
@@ -44,7 +44,8 @@ The Burn engine offers a set of commonly-used variables so you can use them with
 * ServicePackLevel - numeric value representing the installed OS service pack.
 * StartMenuFolder - gets the well-known folder for CSIDL\_STARTMENU.
 * StartupFolder - gets the well-known folder for CSIDL\_STARTUP.
-* SystemFolder - gets the well-known folder for CSIDL\_SYSTEMX86.
+* SystemFolder - gets the well-known folder for CSIDL\_SYSTEMX86 on 64-bit Windows and CSIDL\_SYSTEM on 32-bit Windows.
+* System64Folder - gets the well-known folder for CSIDL\_SYSTEM on 64-bit Windows and undefined on 32-bit Windows.
 * SystemLanguageID - gets the language ID for the system locale.
 * TempFolder - gets the well-known folder for temp location.
 * TemplateFolder - gets the well-known folder for CSIDL\_TEMPLATES.

--- a/src/tools/wix/Binder.cs
+++ b/src/tools/wix/Binder.cs
@@ -2058,13 +2058,13 @@ namespace Microsoft.Tools.WindowsInstallerXml
             if (null != this.validator)
             {
                 Stopwatch stopwatch = Stopwatch.StartNew();
-              
+
                 // set the output file for source line information
                 this.validator.Output = output;
 
                 this.core.OnMessage(WixVerboses.ValidatingDatabase());
                 this.core.EncounteredError = !this.validator.Validate(tempDatabaseFile);
-              
+
                 stopwatch.Stop();
                 this.core.OnMessage(WixVerboses.ValidatedDatabase(stopwatch.ElapsedMilliseconds));
 
@@ -3372,6 +3372,12 @@ namespace Microsoft.Tools.WindowsInstallerXml
                 {
                     payloadInfo.Packaging = bundleInfo.DefaultPackagingType;
                 }
+
+                string normalizedPath = payloadInfo.Name.Replace('\\', '/');
+                if (normalizedPath.StartsWith("../", StringComparison.Ordinal) || normalizedPath.Contains("/../"))
+                {
+                    this.core.OnMessage(WixWarnings.PayloadMustBeRelativeToCache(payloadInfo.SourceLineNumbers, "Payload", "Name", payloadInfo.Name));
+                }
             }
 
             Dictionary<string, ContainerInfo> containers = new Dictionary<string, ContainerInfo>();
@@ -3781,7 +3787,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
                     ApprovedExeForElevation approvedExeForElevation = new ApprovedExeForElevation(wixApprovedExeForElevationRow);
                     approvedExesForElevation.Add(approvedExeForElevation);
                 }
-            }            
+            }
 
             // Set the overridable bundle provider key.
             this.SetBundleProviderKey(bundle, bundleInfo);
@@ -7876,7 +7882,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
                 }
 
                 // The new Row has to be inserted just after the last cab in this cabinet split chain according to DiskID Sort
-                // This is because the FDI Extract requires DiskID of Split Cabinets to be continuous. It Fails otherwise with 
+                // This is because the FDI Extract requires DiskID of Split Cabinets to be continuous. It Fails otherwise with
                 // Error 2350 (FDI Server Error) as next DiskID did not have the right split cabinet during extraction
                 MediaRow newMediaRow = (MediaRow)mediaTable.CreateRow(null);
                 newMediaRow.Cabinet = newCabinetName;

--- a/src/tools/wix/CompilerCore.cs
+++ b/src/tools/wix/CompilerCore.cs
@@ -1460,6 +1460,14 @@ namespace Microsoft.Tools.WindowsInstallerXml
                         this.OnMessage(WixErrors.IllegalLongFilename(sourceLineNumbers, attribute.OwnerElement.Name, attribute.Name, value));
                     }
                 }
+                else if (allowRelative)
+                {
+                    string normalizedPath = value.Replace('\\', '/');
+                    if (normalizedPath.StartsWith("../", StringComparison.Ordinal) || normalizedPath.Contains("/../"))
+                    {
+                        this.OnMessage(WixWarnings.PayloadMustBeRelativeToCache(sourceLineNumbers, attribute.OwnerElement.Name, attribute.Name, value));
+                    }
+                }
                 else if (CompilerCore.IsAmbiguousFilename(value))
                 {
                     this.OnMessage(WixWarnings.AmbiguousFileOrDirectoryName(sourceLineNumbers, attribute.OwnerElement.Name, attribute.Name, value));

--- a/src/tools/wix/Data/messages.xml
+++ b/src/tools/wix/Data/messages.xml
@@ -2571,7 +2571,7 @@
         </Message>
         <Message Id="CannotDefaultComponentId" Number="330">
             <Instance>
-                The Component/@Id attribute was not found; it is required when there is no valid keypath to use as the default id value. 
+                The Component/@Id attribute was not found; it is required when there is no valid keypath to use as the default id value.
             </Instance>
         </Message>
         <Message Id="ParentElementAttributeRequired" Number="331">
@@ -2731,7 +2731,7 @@
         <Instance>
           Unable to read bundle executable '{0}', because this bundle was created with a newer version of WiX (bundle version '{1}'). You must use a newer version of Windows Installer XML in order to read this bundle.
           <Parameter Type="System.String" Name="bundleExecutable" />
-          <!-- we use a 64-bit field here because the field is really a 32-bit UInt, 
+          <!-- we use a 64-bit field here because the field is really a 32-bit UInt,
               but UInt gives a non-CLS-compliant warning.
               So 64-bit makes sure we don't drop the last bit -->
           <Parameter Type="System.Int64" Name="bundleVersion" />
@@ -3631,7 +3631,7 @@
         </Message>
         <Message Id="StandardDirectoryConflictInMergeModule" Number="1124">
             <Instance>
-                The Directory '{0}' starts with the same Id as the standard folder in Windows Installer '{1}'. A directory Id that begins with the same Id as a standard folder that is in an MSM may encounter a conflict when merging the MSM into an MSI. This may result in the contents of this merge module being installed to an unexpected location. To eliminate this warning, change your directory Id to not start with the same Id as any standard folders. 
+                The Directory '{0}' starts with the same Id as the standard folder in Windows Installer '{1}'. A directory Id that begins with the same Id as a standard folder that is in an MSM may encounter a conflict when merging the MSM into an MSI. This may result in the contents of this merge module being installed to an unexpected location. To eliminate this warning, change your directory Id to not start with the same Id as any standard folders.
                 <Parameter Type="System.String" Name="directory" />
                 <Parameter Type="System.String" Name="standardDirectory" />
             </Instance>
@@ -3806,6 +3806,14 @@
                 <Parameter Type="System.String" Name="elementName" />
             </Instance>
         </Message>
+      <Message Id="PayloadMustBeRelativeToCache" Number="1151">
+        <Instance>
+          The {0}/@{1} attribute's value, '{2}', is not a legal path name: Payload names must be relative to their cache directory and cannot contain '..'.
+          <Parameter Type="System.String" Name="elementName" />
+          <Parameter Type="System.String" Name="attributeName" />
+          <Parameter Type="System.String" Name="attributeValue" />
+        </Instance>
+      </Message>
     </Class>
 
     <Class Name="WixVerboses" ContainerName="WixVerboseEventArgs" BaseContainerName="MessageEventArgs" Level="Information">

--- a/src/tools/wix/Xsd/wix.xsd
+++ b/src/tools/wix/Xsd/wix.xsd
@@ -384,7 +384,7 @@
       </xs:attribute>
       <xs:attribute name="Name" type="xs:string">
         <xs:annotation>
-          <xs:documentation>The relative destination path and file name for the bootstrapper application DLL. The default is the source file name. Use this attribute to rename the bootstrapper application DLL or extract it into a subfolder.</xs:documentation>
+          <xs:documentation>The relative destination path and file name for the bootstrapper application DLL. The default is the source file name. Use this attribute to rename the bootstrapper application DLL or extract it into a subfolder. The use of '..' directories is not allowed.</xs:documentation>
         </xs:annotation>
       </xs:attribute>
     </xs:complexType>
@@ -867,6 +867,7 @@
             The destination path and file name for this chain payload. Use this attribute to rename the
             chain entry point or extract it into a subfolder. The default value is the file name from the
             SourceFile attribute, if provided. At a minimum, the Name or SourceFile attribute must be specified.
+            The use of '..' directories is not allowed.
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
@@ -1293,7 +1294,7 @@
       </xs:attribute>
       <xs:attribute name="Name" type="xs:string">
         <xs:annotation>
-          <xs:documentation>The destination path and file name for this payload. The default is the source file name.</xs:documentation>
+          <xs:documentation>The destination path and file name for this payload. The default is the source file name. The use of '..' directories is not allowed.</xs:documentation>
         </xs:annotation>
       </xs:attribute>
       <xs:attribute name="DownloadUrl" type="xs:string">


### PR DESCRIPTION
Prevent bad use of ".." in payload names in the Compiler and Binder.
Fixes wixtoolset/issues#5265

Correctly set and document SystemFolder and System64Folder in Burn
Fixes wixtoolset/issues#5307