### PR TITLE
WIXBUG:4929 - Fix infinite loop in PathCreateTimeBasedTempFile

### DIFF
--- a/history/4929.md
+++ b/history/4929.md
@@ -1,0 +1,1 @@
+* SeanHall: WIXBUG:4929 - Fix infinite loop in PathCreateTimeBasedTempFile that caused Burn to hang if it didn't have rights to create the log file.

--- a/history/4929.md
+++ b/history/4929.md
@@ -1,1 +1,1 @@
-* SeanHall: WIXBUG:4929 - Fix infinite loop in PathCreateTimeBasedTempFile that caused Burn to hang if it didn't have rights to create the log file.
+* SeanHall: WIXBUG:4929 - Fix infinite loop in PathCreateTimeBasedTempFile that caused Burn to hang if it didn't have rights to create the log file. Also, write entry in Application event log when Burn is unable to create the Failed log.

--- a/src/burn/engine/engine.cpp
+++ b/src/burn/engine/engine.cpp
@@ -205,7 +205,7 @@ LExit:
     // and that will dump anything captured in the log memory buffer to the log.
     if (FAILED(hr) && BURN_LOGGING_STATE_CLOSED == engineState.log.state)
     {
-        LogOpen(NULL, L"Setup", L"_Failed", L"txt", FALSE, FALSE, NULL);
+        LoggingOpenFailed();
     }
 
     UserExperienceRemove(&engineState.userExperience);

--- a/src/burn/engine/logging.h
+++ b/src/burn/engine/logging.h
@@ -48,6 +48,8 @@ HRESULT LoggingOpen(
     __in_z LPCWSTR wzBundleName
     );
 
+void LoggingOpenFailed();
+
 void LoggingIncrementPackageSequence();
 
 HRESULT LoggingSetPackageVariable(

--- a/src/libs/dutil/pathutil.cpp
+++ b/src/libs/dutil/pathutil.cpp
@@ -630,6 +630,7 @@ DAPI_(HRESULT) PathCreateTimeBasedTempFile(
 
     LPWSTR sczTempPath = NULL;
     HANDLE hTempFile = INVALID_HANDLE_VALUE;
+    DWORD dwAttempts = 0;
 
     if (wzDirectory && *wzDirectory)
     {
@@ -662,6 +663,7 @@ DAPI_(HRESULT) PathCreateTimeBasedTempFile(
     do
     {
         fRetry = FALSE;
+        ++dwAttempts;
 
         ::GetLocalTime(&time);
 
@@ -678,8 +680,11 @@ DAPI_(HRESULT) PathCreateTimeBasedTempFile(
             {
                 ::Sleep(100);
 
-                er = ERROR_SUCCESS;
-                fRetry = TRUE;
+                if (10 > dwAttempts)
+                {
+                    er = ERROR_SUCCESS;
+                    fRetry = TRUE;
+                }
             }
 
             hr = HRESULT_FROM_WIN32(er);


### PR DESCRIPTION
I also included writing an error entry to the Application event log if unable to create the Failed log. Feel free to skip that commit if it's not right for v3.

Fixes wixtoolset/issues#4929