### PR TITLE
WIXFEAT:5435 - Include the BA's directory in the DLL search path

### DIFF
--- a/history/5435.md
+++ b/history/5435.md
@@ -1,0 +1,1 @@
+* SeanHall: WIXFEAT:5435 - When loading the BA, include the BA's directory in the DLL search path.

--- a/src/burn/engine/userexperience.cpp
+++ b/src/burn/engine/userexperience.cpp
@@ -85,7 +85,7 @@ extern "C" HRESULT UserExperienceLoad(
     HRESULT hr = S_OK;
 
     // load UX DLL
-    pUserExperience->hUXModule = ::LoadLibraryW(pUserExperience->payloads.rgPayloads[0].sczLocalFilePath);
+    pUserExperience->hUXModule = ::LoadLibraryExW(pUserExperience->payloads.rgPayloads[0].sczLocalFilePath, NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
     ExitOnNullWithLastError(pUserExperience->hUXModule, hr, "Failed to load UX DLL.");
 
     // get BoostrapperApplicationCreate entry-point

--- a/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
+++ b/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
@@ -3300,7 +3300,7 @@ private: // privates
         BalLog(BOOTSTRAPPER_LOG_LEVEL_STANDARD, "WIXSTDBA: LoadBootstrapperBAFunctions() - BA function DLL %ls", sczBafPath);
 #endif
 
-        m_hBAFModule = ::LoadLibraryW(sczBafPath);
+        m_hBAFModule = ::LoadLibraryExW(sczBafPath, NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
         if (m_hBAFModule)
         {
             PFN_BOOTSTRAPPER_BA_FUNCTION_CREATE pfnBAFunctionCreate = reinterpret_cast<PFN_BOOTSTRAPPER_BA_FUNCTION_CREATE>(::GetProcAddress(m_hBAFModule, "CreateBootstrapperBAFunction"));


### PR DESCRIPTION
[`LoadLibraryEx`](https://msdn.microsoft.com/en-us/library/windows/desktop/ms684179(v=vs.85).aspx) with `LOAD_WITH_ALTERED_SEARCH_PATH` uses the target DLLs directory while loading it instead of the running application's directory, and is available on all platforms that we support.

Fixes wixtoolset/issues#5435.