### PR TITLE
WIXBUG:5512 - Fix declaration of OnDetectCompatiblePackage

### DIFF
--- a/history/5512.md
+++ b/history/5512.md
@@ -1,0 +1,1 @@
+* SeanHall: WIXBUG:5512 - Fix declaration of OnDetectCompatiblePackage in managed IBootstrapperApplication.

--- a/src/ext/BalExtension/mba/core/IBootstrapperApplication.cs
+++ b/src/ext/BalExtension/mba/core/IBootstrapperApplication.cs
@@ -88,6 +88,7 @@ namespace Microsoft.Tools.WindowsInstallerXml.Bootstrapper
             [MarshalAs(UnmanagedType.LPWStr)] string wzPackageId
             );
 
+        [PreserveSig]
         [return: MarshalAs(UnmanagedType.I4)]
         Result OnDetectCompatiblePackage(
             [MarshalAs(UnmanagedType.LPWStr)] string wzPackageId,


### PR DESCRIPTION
in managed IBootstrapperApplication.

Addresses wixtoolset/issues#5512