### PR TITLE
Adding attribute LoggingBaseFolder to Bundle's Log element

### DIFF
--- a/src/burn/engine/engine.cpp
+++ b/src/burn/engine/engine.cpp
@@ -369,6 +369,7 @@ static void UninitializeEngineState(
 
     ReleaseStr(pEngineState->log.sczExtension);
     ReleaseStr(pEngineState->log.sczPrefix);
+    ReleaseStr(pEngineState->log.sczLoggingBaseFolder);
     ReleaseStr(pEngineState->log.sczPath);
     ReleaseStr(pEngineState->log.sczPathVariable);
 

--- a/src/burn/engine/logging.cpp
+++ b/src/burn/engine/logging.cpp
@@ -165,7 +165,7 @@ extern "C" HRESULT LoggingOpen(
     }
 
 LExit:
-	ReleaseStr(sczLoggingBaseFolder);
+    ReleaseStr(sczLoggingBaseFolder);
 
     return hr;
 }

--- a/src/burn/engine/logging.h
+++ b/src/burn/engine/logging.h
@@ -33,6 +33,7 @@ typedef struct _BURN_LOGGING
 
     DWORD dwAttributes;
     LPWSTR sczPath;
+    LPWSTR sczLoggingBaseFolder;
     LPWSTR sczPrefix;
     LPWSTR sczExtension;
 } BURN_LOGGING;

--- a/src/burn/engine/manifest.cpp
+++ b/src/burn/engine/manifest.cpp
@@ -40,7 +40,7 @@ extern "C" HRESULT ManifestLoadXmlFromBuffer(
         hr = XmlGetAttributeEx(pixnLog, L"LoggingBaseFolder", &pEngineState->log.sczLoggingBaseFolder);
         if (E_NOTFOUND != hr)
         {
-          ExitOnFailure(hr, "Failed to get Log/@BaseFolderPath.");
+            ExitOnFailure(hr, "Failed to get Log/@BaseFolderPath.");
         }
 
         hr = XmlGetAttributeEx(pixnLog, L"Prefix", &pEngineState->log.sczPrefix);

--- a/src/burn/engine/manifest.cpp
+++ b/src/burn/engine/manifest.cpp
@@ -37,6 +37,12 @@ extern "C" HRESULT ManifestLoadXmlFromBuffer(
             ExitOnFailure(hr, "Failed to get Log/@PathVariable.");
         }
 
+        hr = XmlGetAttributeEx(pixnLog, L"LoggingBaseFolder", &pEngineState->log.sczLoggingBaseFolder);
+        if (E_NOTFOUND != hr)
+        {
+          ExitOnFailure(hr, "Failed to get Log/@BaseFolderPath.");
+        }
+
         hr = XmlGetAttributeEx(pixnLog, L"Prefix", &pEngineState->log.sczPrefix);
         ExitOnFailure(hr, "Failed to get Log/@Prefix attribute.");
 

--- a/src/tools/wix/Binder.cs
+++ b/src/tools/wix/Binder.cs
@@ -4299,6 +4299,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
                     {
                         writer.WriteAttributeString("PathVariable", bundleInfo.LogPathVariable);
                     }
+                    writer.WriteAttributeString("LoggingBaseFolder", bundleInfo.LoggingBaseFolder);
                     writer.WriteAttributeString("Prefix", bundleInfo.LogPrefix);
                     writer.WriteAttributeString("Extension", bundleInfo.LogExtension);
                     writer.WriteEndElement();

--- a/src/tools/wix/Compiler.cs
+++ b/src/tools/wix/Compiler.cs
@@ -20178,6 +20178,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
             YesNoType disableLog = YesNoType.NotSet;
             string variable = "WixBundleLog";
             string logPrefix = fileSystemSafeBundleName ?? "Setup";
+            string loggingBaseFolder = null;
             string logExtension = ".log";
 
             foreach (XmlAttribute attrib in node.Attributes)
@@ -20191,6 +20192,9 @@ namespace Microsoft.Tools.WindowsInstallerXml
                             break;
                         case "PathVariable":
                             variable = this.core.GetAttributeValue(sourceLineNumbers, attrib, true);
+                            break;
+                        case "LoggingBaseFolder":
+                            loggingBaseFolder = this.core.GetAttributeValue(sourceLineNumbers, attrib, true);
                             break;
                         case "Prefix":
                             logPrefix = this.core.GetAttributeValue(sourceLineNumbers, attrib, false);
@@ -20229,7 +20233,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
                 }
             }
 
-            return YesNoType.Yes == disableLog ? null : String.Concat(variable, ":", logPrefix, logExtension);
+            return YesNoType.Yes == disableLog ? null : String.Concat(variable, "|", loggingBaseFolder, "|", logPrefix, logExtension);
         }
 
         /// <summary>

--- a/src/tools/wix/WixBundleRow.cs
+++ b/src/tools/wix/WixBundleRow.cs
@@ -112,8 +112,17 @@ namespace Microsoft.Tools.WindowsInstallerXml
         {
             get
             {
-                string[] logVariableAndPrefixExtension = this.LogPathPrefixExtension.Split(':');
+                string[] logVariableAndPrefixExtension = this.LogPathPrefixExtension.Split('|');
                 return logVariableAndPrefixExtension[0];
+            }
+        }
+
+        public string LoggingBaseFolder
+        {
+            get
+            {
+                string[] logVariableAndPrefixExtension = this.LogPathPrefixExtension.Split('|');
+                return logVariableAndPrefixExtension[1];
             }
         }
 
@@ -121,12 +130,12 @@ namespace Microsoft.Tools.WindowsInstallerXml
         {
             get
             {
-                string[] logVariableAndPrefixExtension = this.LogPathPrefixExtension.Split(':');
-                if (2 > logVariableAndPrefixExtension.Length)
+                string[] logVariableAndPrefixExtension = this.LogPathPrefixExtension.Split('|');
+                if (3 > logVariableAndPrefixExtension.Length)
                 {
                     return String.Empty;
                 }
-                string logPrefixAndExtension = logVariableAndPrefixExtension[1];
+                string logPrefixAndExtension = logVariableAndPrefixExtension[2];
                 int extensionIndex = logPrefixAndExtension.LastIndexOf('.');
                 return logPrefixAndExtension.Substring(0, extensionIndex);
             }
@@ -136,12 +145,12 @@ namespace Microsoft.Tools.WindowsInstallerXml
         {
             get
             {
-                string[] logVariableAndPrefixExtension = this.LogPathPrefixExtension.Split(':');
-                if (2 > logVariableAndPrefixExtension.Length)
+                string[] logVariableAndPrefixExtension = this.LogPathPrefixExtension.Split('|');
+                if (3 > logVariableAndPrefixExtension.Length)
                 {
                     return String.Empty;
                 }
-                string logPrefixAndExtension = logVariableAndPrefixExtension[1];
+                string logPrefixAndExtension = logVariableAndPrefixExtension[2];
                 int extensionIndex = logPrefixAndExtension.LastIndexOf('.');
                 return logPrefixAndExtension.Substring(extensionIndex + 1);
             }

--- a/src/tools/wix/Xsd/wix.xsd
+++ b/src/tools/wix/Xsd/wix.xsd
@@ -315,6 +315,11 @@
                     </xs:documentation>
         </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="LoggingBaseFolder" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Overrides the default log folder location. Defaults to %TEMP%.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
       <xs:attribute name="Prefix" type="xs:string">
         <xs:annotation>
           <xs:documentation>


### PR DESCRIPTION
This will allow placing the logs created by the burn bundle in a different folder other than %TEMP%.
If omitted it's backward compatible with existing functionality.

#### Sample xml

```
<Wix ...
    <Bundle ....
        <Log LoggingBaseFolder="[CommonAppDataFolder]\Acme" Prefix="InstallLogs\AwesomeInstaller" />
        <!-- ... -->
```
