### PR TITLE
Introduce wix.nativeca.targets

### DIFF
--- a/src/Setup/CoreMsi/MSBuild.wxs
+++ b/src/Setup/CoreMsi/MSBuild.wxs
@@ -26,6 +26,10 @@
             <Component>
                 <File Source="wix.ca.targets" />
             </Component>
+
+            <Component>
+                <File Source="wix.nativeca.targets" />
+            </Component>
         </ComponentGroup>
     </Fragment>
 </Wix>

--- a/src/Setup/Zip/binaries.zipproj
+++ b/src/Setup/Zip/binaries.zipproj
@@ -223,6 +223,12 @@
     </Stage>
   </ItemGroup>
 
+  <ItemGroup>
+    <Stage Include="$(OutputPath)wix.nativeca.targets">
+      <StageSubDirectory>sdk</StageSubDirectory>
+    </Stage>
+  </ItemGroup>
+
   <!-- Headers -->
   <ItemGroup>
     <Stage Include="$(WixRoot)src\burn\inc\*.h">

--- a/src/tools/WixTasks/WixTasks.csproj
+++ b/src/tools/WixTasks/WixTasks.csproj
@@ -62,6 +62,9 @@
     <Content Include="wix.ca.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="wix.nativeca.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tools/WixTasks/wix.nativeca.targets
+++ b/src/tools/WixTasks/wix.nativeca.targets
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Import Project="$(CustomBeforeWixNativeCATargets)" Condition=" '$(CustomBeforeWixNativeCATargets)' != '' and Exists('$(CustomBeforeWixNativeCATargets)')" />
+
+  <PropertyGroup>
+    <WixNativeCATargetsImported>true</WixNativeCATargetsImported>
+
+    <WixPlatformToolset Condition=" '$(PlatformToolset)'=='v100' ">VS2010</WixPlatformToolset>
+    <WixPlatformToolset Condition=" '$(PlatformToolset)'=='v110' ">VS2012</WixPlatformToolset>
+    <WixPlatformToolset Condition=" '$(PlatformToolset)'=='v110_xp' ">VS2012</WixPlatformToolset>
+    <WixPlatformToolset Condition=" '$(PlatformToolset)'=='v120' ">VS2013</WixPlatformToolset>
+    <WixPlatformToolset Condition=" '$(PlatformToolset)'=='v120_xp' ">VS2013</WixPlatformToolset>
+    <WixPlatformToolset Condition=" '$(PlatformToolset)'=='v140' ">VS2015</WixPlatformToolset>
+    <WixPlatformToolset Condition=" '$(PlatformToolset)'=='v140_xp' ">VS2015</WixPlatformToolset>
+    <WixPlatformToolset Condition=" '$(PlatformToolset)'=='v141' ">VS2017</WixPlatformToolset>
+    <WixPlatformToolset Condition=" '$(PlatformToolset)'=='v141_xp' ">VS2017</WixPlatformToolset>
+
+    <WixPlatformToolset Condition=" '$(WixPlatformToolset)'=='' ">VS2015</WixPlatformToolset>
+  </PropertyGroup>
+
+  <Import Project="$(CustomAfterWixNativeCATargets)" Condition=" '$(CustomAfterWixNativeCATargets)' != '' and Exists('$(CustomAfterWixNativeCATargets)')" />
+
+</Project>


### PR DESCRIPTION
These targets are used to simplify CPP CA projects. In particular, the
targets select the correct WiX SDK folder.

Partial fix for wixtoolset/issues#5536