### PR TITLE
Issue #5601: Support RemotePayload for and Payload (not just ExePackage)

### DIFF
--- a/src/ext/UtilExtension/wixext/DirPayloadsHarvester.cs
+++ b/src/ext/UtilExtension/wixext/DirPayloadsHarvester.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Tools.WindowsInstallerXml.Extensions
             payload.Name = path.Substring(baseDir.Length + 1);
             payload.Id = this.Core.GenerateIdentifier(PayloadPrefix, BaseDownloadUrl, payload.Name);
             payload.DownloadUrl = BaseDownloadUrl + "/" + payload.Name.Replace("\\", "/");
+            payload.Compressed = Microsoft.Tools.WindowsInstallerXml.Serialize.YesNoDefaultType.no;
 
             // Harvest remote payload
             Wix.RemotePayload remotePayload = this.HarvestRemotePayload(path);

--- a/src/ext/UtilExtension/wixext/DirPayloadsHarvester.cs
+++ b/src/ext/UtilExtension/wixext/DirPayloadsHarvester.cs
@@ -1,0 +1,75 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace Microsoft.Tools.WindowsInstallerXml.Extensions
+{
+    using System;
+    using System.IO;
+
+    using Wix = Microsoft.Tools.WindowsInstallerXml.Serialize;
+
+    /// <summary>
+    /// Harvest WiX authoring for a payload from the file system.
+    /// </summary>
+    public sealed class DirPayloadsHarvester : PayloadHarvester
+    {
+        private static readonly string PayloadPrefix = "pld";
+
+        /// <summary>
+        /// Instantiate a new DirPayloadsHarvester.
+        /// </summary>
+        public DirPayloadsHarvester()
+        {
+        }
+
+        public string BaseDownloadUrl { get; internal set; }
+
+        /// <summary>
+        /// Harvest a folder hierarchy as payloads with RemotePayload information.
+        /// </summary>
+        /// <param name="argument">The path of the payload.</param>
+        /// <returns>A harvested payload.</returns>
+        public override Wix.Fragment[] Harvest(string argument)
+        {
+            if (null == argument)
+            {
+                throw new ArgumentNullException("argument");
+            }
+            if (string.IsNullOrEmpty(BaseDownloadUrl))
+            {
+                throw new ArgumentNullException("url");
+            }
+
+            string dir = Path.GetFullPath(argument);
+            string[] files = Directory.GetFiles(dir, "*", SearchOption.AllDirectories);
+            Wix.Fragment fragment = new Wix.Fragment();
+            foreach (string f in files)
+            {
+                if (!File.Exists(f))
+                {
+                    continue;
+                }
+
+                Wix.Payload payload = this.HarvestPayload(dir, f);
+                fragment.AddChild(payload);
+            }
+
+            return new Wix.Fragment[] { fragment };
+        }
+
+        private Wix.Payload HarvestPayload(string baseDir, string path)
+        {
+            Wix.Payload payload = new Wix.Payload();
+
+            // baseDir is absolute so we can simplify sub-name retrieval
+            payload.Name = path.Substring(baseDir.Length + 1);
+            payload.Id = this.Core.GenerateIdentifier(PayloadPrefix, BaseDownloadUrl, payload.Name);
+            payload.DownloadUrl = BaseDownloadUrl + "/" + payload.Name.Replace("\\", "/");
+
+            // Harvest remote payload
+            Wix.RemotePayload remotePayload = this.HarvestRemotePayload(path);
+            payload.AddChild(remotePayload);
+
+            return payload;
+        }
+    }
+}

--- a/src/ext/UtilExtension/wixext/PayloadHarvester.cs
+++ b/src/ext/UtilExtension/wixext/PayloadHarvester.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Tools.WindowsInstallerXml.Extensions
     /// <summary>
     /// Harvest WiX authoring for a payload from the file system.
     /// </summary>
-    public sealed class PayloadHarvester : HarvesterExtension
+    public class PayloadHarvester : HarvesterExtension
     {
         private bool setUniqueIdentifiers;
 

--- a/src/ext/UtilExtension/wixext/UtilHeatExtension.cs
+++ b/src/ext/UtilExtension/wixext/UtilHeatExtension.cs
@@ -29,11 +29,13 @@ namespace Microsoft.Tools.WindowsInstallerXml.Extensions
                     new HeatCommandLineOption("dir", "harvest a directory"),
                     new HeatCommandLineOption("file", "harvest a file"),
                     new HeatCommandLineOption("payload", "harvest a bundle payload as RemotePayload"),
+                    new HeatCommandLineOption("payload_dir", "harvest bundle payloads as RemotePayload"),
                     new HeatCommandLineOption("perf", "harvest performance counters"),
                     new HeatCommandLineOption("reg", "harvest a .reg file"),
                     new HeatCommandLineOption("-ag", "autogenerate component guids at compile time"),
                     new HeatCommandLineOption("-cg <ComponentGroupName>", "component group name (cannot contain spaces e.g -cg MyComponentGroup)"),
                     new HeatCommandLineOption("-dr <DirectoryName>", "directory reference to root directories (cannot contain spaces e.g. -dr MyAppDirRef)"),
+                    new HeatCommandLineOption("-url <DownloadUrl>", "when harvesting payload_dir, used as base download URL. Each payload DownloadUrl will be set to this field + payload name"),
                     new HeatCommandLineOption("-var <VariableName>", "substitute File/@Source=\"SourceDir\" with a preprocessor or a wix variable" + Environment.NewLine +
                                                       "(e.g. -var var.MySource will become File/@Source=\"$(var.MySource)\\myfile.txt\" and " + Environment.NewLine + 
                                                       "-var wix.MySource will become File/@Source=\"!(wix.MySource)\\myfile.txt\""),
@@ -79,6 +81,10 @@ namespace Microsoft.Tools.WindowsInstallerXml.Extensions
                     break;
                 case "payload":
                     harvesterExtension = new PayloadHarvester();
+                    active = true;
+                    break;
+                case "payload_dir":
+                    harvesterExtension = new DirPayloadsHarvester();
                     active = true;
                     break;
                 case "perf":
@@ -138,6 +144,20 @@ namespace Microsoft.Tools.WindowsInstallerXml.Extensions
                         else if (harvesterExtension is FileHarvester)
                         {
                             ((FileHarvester)harvesterExtension).RootedDirectoryRef = dr;
+                        }
+                    }
+                    else if ("url" == truncatedCommandSwitch)
+                    {
+                        string url = this.GetArgumentParameter(args, i);
+
+                        if (this.Core.EncounteredError)
+                        {
+                            return;
+                        }
+
+                        if (harvesterExtension is DirPayloadsHarvester)
+                        {
+                            ((DirPayloadsHarvester)harvesterExtension).BaseDownloadUrl = url;
                         }
                     }
                     else if ("gg" == truncatedCommandSwitch)

--- a/src/ext/UtilExtension/wixext/WixUtilExtension.csproj
+++ b/src/ext/UtilExtension/wixext/WixUtilExtension.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
 
@@ -16,6 +16,7 @@
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="FeedBuilder.cs" />
     <Compile Include="NativeMethods.cs" />
+    <Compile Include="DirPayloadsHarvester.cs" />
     <Compile Include="PayloadHarvester.cs" />
     <Compile Include="PerformanceCategoryHarvester.cs" />
     <Compile Include="RegFileHarvester.cs" />

--- a/src/tools/wix/Compiler.cs
+++ b/src/tools/wix/Compiler.cs
@@ -20684,6 +20684,9 @@ namespace Microsoft.Tools.WindowsInstallerXml
                     {
                         switch (child.LocalName)
                         {
+                            case "RemotePayload":
+                                break;
+
                             default:
                                 this.core.UnexpectedElement(node, child);
                                 break;
@@ -20766,7 +20769,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
                 {
                     SourceLineNumberCollection childSourceLineNumbers = Preprocessor.GetSourceLineNumbers(child);
 
-                    if (node.NamespaceURI == this.schema.TargetNamespace && node.LocalName != "ExePackage")
+                    if (node.NamespaceURI == this.schema.TargetNamespace && node.LocalName != "ExePackage" && node.LocalName != "Payload")
                     {
                         this.core.OnMessage(WixErrors.RemotePayloadUnsupported(childSourceLineNumbers));
                         continue;
@@ -20867,25 +20870,13 @@ namespace Microsoft.Tools.WindowsInstallerXml
                 }
             }
 
-            if (String.IsNullOrEmpty(remotePayload.Description))
-            {
-                this.core.OnMessage(WixErrors.ExpectedAttribute(sourceLineNumbers, node.Name, "Description"));
-            }
             if (String.IsNullOrEmpty(remotePayload.Hash))
             {
                 this.core.OnMessage(WixErrors.ExpectedAttribute(sourceLineNumbers, node.Name, "Hash"));
             }
-            if (String.IsNullOrEmpty(remotePayload.ProductName))
-            {
-                this.core.OnMessage(WixErrors.ExpectedAttribute(sourceLineNumbers, node.Name, "ProductName"));
-            }
             if (0 == remotePayload.FileSize)
             {
                 this.core.OnMessage(WixErrors.ExpectedAttribute(sourceLineNumbers, node.Name, "Size"));
-            }
-            if (String.IsNullOrEmpty(remotePayload.Version))
-            {
-                this.core.OnMessage(WixErrors.ExpectedAttribute(sourceLineNumbers, node.Name, "Version"));
             }
 
             return remotePayload;

--- a/src/tools/wix/PayloadInfoRow.cs
+++ b/src/tools/wix/PayloadInfoRow.cs
@@ -317,8 +317,14 @@ namespace Microsoft.Tools.WindowsInstallerXml
                     payloadInfo.Version = version.ToString();
                 }
 
-                payloadInfo.ProductName = versionInfo.ProductName;
-                payloadInfo.Description = versionInfo.FileDescription;
+                if (!string.IsNullOrEmpty(versionInfo.ProductName))
+                {
+                    payloadInfo.ProductName = versionInfo.ProductName;
+                }
+                if (!string.IsNullOrEmpty(versionInfo.FileDescription))
+                {
+                    payloadInfo.Description = versionInfo.FileDescription;
+                }
             }
         }
     }

--- a/src/tools/wix/PayloadInfoRow.cs
+++ b/src/tools/wix/PayloadInfoRow.cs
@@ -278,9 +278,16 @@ namespace Microsoft.Tools.WindowsInstallerXml
                 X509Certificate2 certificate = null;
                 try
                 {
+                    string ext = Path.GetExtension(payloadInfo.SourceFile);
                     if (!payloadInfo.SuppressSignatureValidation)
                     {
-                        certificate = new X509Certificate2(fileInfo.FullName);
+                        if (ext.Equals(".exe", StringComparison.OrdinalIgnoreCase)
+                            || ext.Equals(".dll", StringComparison.OrdinalIgnoreCase)
+                            || ext.Equals(".ocx", StringComparison.OrdinalIgnoreCase)
+                            || ext.Equals(".cab", StringComparison.OrdinalIgnoreCase))
+                        {
+                            certificate = new X509Certificate2(fileInfo.FullName);
+                        }
                     }
                 }
                 catch (CryptographicException) // we don't care about non-signed files.

--- a/src/tools/wix/Xsd/wix.xsd
+++ b/src/tools/wix/Xsd/wix.xsd
@@ -1285,6 +1285,20 @@
       </xs:appinfo>
     </xs:annotation>
     <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="RemotePayload" />
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+                Extensibility point in the WiX XML Schema.  Schema extensions can register additional
+                elements at this point in the schema.  The extension's
+                <html:code><html:nobr>CompilerExtension.ParseElement()</html:nobr></html:code>
+                method will be called with the package identifier as the first value in
+                <html:code>contextValues</html:code>.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
       <xs:attribute name="Id" type="xs:string">
         <xs:annotation>
           <xs:documentation>The identifier of Payload element.</xs:documentation>
@@ -1295,7 +1309,7 @@
           <xs:documentation>Whether the payload should be embedded in a container or left as an external payload.</xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="SourceFile" type="xs:string" use="required">
+      <xs:attribute name="SourceFile" type="xs:string">
         <xs:annotation>
           <xs:documentation>Location of the source file.</xs:documentation>
         </xs:annotation>
@@ -1388,7 +1402,7 @@
           <xs:documentation>Thumbprint of the authenticode certificate used to sign the RemotePayload.  Include this attribute if the remote file is signed.</xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="Description" type="xs:string" use="required">
+      <xs:attribute name="Description" type="xs:string">
         <xs:annotation>
           <xs:documentation>Description of the file from version resources.</xs:documentation>
         </xs:annotation>
@@ -1398,7 +1412,7 @@
           <xs:documentation>SHA-1 hash of the RemotePayload.  Include this attribute if the remote file is unsigned or SuppressSignatureVerification is set to Yes.</xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="ProductName" type="xs:string" use="required">
+      <xs:attribute name="ProductName" type="xs:string">
         <xs:annotation>
         <xs:documentation>Product name of the file from version resouces.</xs:documentation>
         </xs:annotation>
@@ -1408,7 +1422,7 @@
           <xs:documentation>Size of the remote file in bytes.</xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="Version" type="VersionType" use="required">
+      <xs:attribute name="Version" type="VersionType">
         <xs:annotation>
           <xs:documentation>Version of the remote file</xs:documentation>
         </xs:annotation>


### PR DESCRIPTION
Done to reduce bind time of multitude unchanging payloads (e.g. SQL server). 
Without this, each build computes hashes for them all which consumes a lot of time.
Runtime behavior is unchanged.