### PR TITLE
Some LEADTools dlls create bad default values for some keys that incl…

### DIFF
--- a/src/ext/UtilExtension/wixext/RegistryHarvester.cs
+++ b/src/ext/UtilExtension/wixext/RegistryHarvester.cs
@@ -314,7 +314,17 @@ namespace Microsoft.Tools.WindowsInstallerXml.Extensions
                 else if (value is string) // string, expandable (there is no way to differentiate a string and expandable value in .NET 1.1)
                 {
                     registryValue.Type = Wix.RegistryValue.TypeType.@string;
-                    registryValue.Value = (string)value;
+
+                    string valueStr = (string)value;
+                    int nullPos = valueStr.IndexOf('\0');
+                    if (-1 == nullPos)
+                    {
+                        registryValue.Value = valueStr;
+                    }
+                    else
+                    {
+                        registryValue.Value = valueStr.Substring(0, nullPos);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
…ude null characters and other garbage.  Truncate REG_SZ values at the first null character.