### PR TITLE
Support for the VS 2017 VSIX installer.

### DIFF
--- a/src/ext/VSExtension/wixlib/VsixPackage.wxs
+++ b/src/ext/VSExtension/wixlib/VsixPackage.wxs
@@ -22,11 +22,17 @@
             </RegistrySearch>
         </Property>
 
-        <!-- VS2015 is the latest VSIX at this point in time, so search for that by default. -->
         <Property Id="VS2015_VSIX_INSTALLER_PATH" Secure="yes">
             <RegistrySearch Id="WixVS2015EnvDir" Root="HKLM" Key="SOFTWARE\Microsoft\VisualStudio\14.0\Setup\VS" Name="EnvironmentDirectory" Type="directory">
                 <FileSearch Id="WixVS2015VsixInstaller" Name="VSIXInstaller.exe" />
             </RegistrySearch>
+        </Property>
+
+        <!-- Currently, VS2017 contains the latest VSIX installer, so search it by default. -->
+        <Property Id="VS2017_VSIX_INSTALLER_PATH" Secure="yes">
+            <DirectorySearchRef Id="VS2017EnvironmentDirectorySearch" Parent="VS2017DirectorySearch" Path="Common7\IDE">
+                <FileSearch Id="WixVS2017VsixInstallerPath" Name="VSIXInstaller.exe" />
+            </DirectorySearchRef>
         </Property>
 
         <Property Id="VS_VSIX_INSTALLER_PATH" Secure="yes" />
@@ -47,7 +53,9 @@
         </Property>
 
         <!-- Use the latest VS- or VWD-installed VSIXInstaller.exe. -->
-        <SetProperty Action="SetVS2015Vsix" Id="VS_VSIX_INSTALLER_PATH" Value="[VS2015_VSIX_INSTALLER_PATH]" Sequence="both" After="AppSearch">NOT VS_VSIX_INSTALLER_PATH AND VS2015_VSIX_INSTALLER_PATH</SetProperty>
+        <SetProperty Action="SetVS2017Vsix" Id="VS_VSIX_INSTALLER_PATH" Value="[VS2017_VSIX_INSTALLER_PATH]" Sequence="both" After="AppSearch">NOT VS_VSIX_INSTALLER_PATH AND VS2017_VSIX_INSTALLER_PATH</SetProperty>
+
+        <SetProperty Action="SetVS2015Vsix" Id="VS_VSIX_INSTALLER_PATH" Value="[VS2015_VSIX_INSTALLER_PATH]" Sequence="both" After="SetVS2017Vsix">NOT VS_VSIX_INSTALLER_PATH AND VS2015_VSIX_INSTALLER_PATH</SetProperty>
         <SetProperty Action="Vwd2015VsixWhenVSAbsent" Id="VS_VSIX_INSTALLER_PATH" Value="[VWD2015_VSIX_INSTALL_ROOT]\Common7\IDE\VSIXInstaller.exe" Sequence="both" After="SetVS2015Vsix">NOT VS_VSIX_INSTALLER_PATH AND VWD2015_VSIX_INSTALL_ROOT</SetProperty>
 
         <SetProperty Action="SetVS2013Vsix" Id="VS_VSIX_INSTALLER_PATH" Value="[VS2013_VSIX_INSTALLER_PATH]" Sequence="both" After="Vwd2015VsixWhenVSAbsent">NOT VS_VSIX_INSTALLER_PATH AND VS2013_VSIX_INSTALLER_PATH</SetProperty>


### PR DESCRIPTION
With this patch, one can use [VsixPackage ](http://wixtoolset.org/documentation/manual/v3/xsd/vs/vsixpackage.html) to install VSIX v3 package into all or SKU-specific VS 2017 instances.