### PR TITLE
Fix for pathLengths, Issue 5314

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,1 +1,5 @@
+## WixBuild: Version 3.14.0.712
+
+* HeathS: WIXBUG:5597 - Check VS2017 product IDs against supported SKUs
+
 ## WixBuild: Version 3.14.0

--- a/history/5597.md
+++ b/history/5597.md
@@ -1,1 +1,0 @@
-* HeathS: WIXBUG:5597 - Check VS2017 product IDs against supported SKUs

--- a/src/Setup/Zip/binaries.zipproj
+++ b/src/Setup/Zip/binaries.zipproj
@@ -96,7 +96,6 @@
     <Stage Include="$(OutputPath)lux.exe" />
     <Stage Include="$(OutputPath)lux.exe.config" />
     <Stage Include="$(OutputPath)nit.exe" />
-    <Stage Include="$(OutputPath)nit.exe.config" />
     <Stage Include="$(OutputPath)WixLuxExtension.dll" />
     <Stage Include="$(OutputPath)lux.targets" />
     <Stage Include="$(OutputPath)LuxTasks.dll" />


### PR DESCRIPTION
This is a fix for issue #5314.  It allows users to bypass the issue when calling the utils directly via command line.  When called from wix.dll, however users will have to set  RunWixToolsOutOfProc to true in their .wixproj files, at least for now.  
error LGHT0103 : The system cannot find the file #5314