### PR TITLE
Add .NET 4.7 to NetFxExtension

### DIFF
--- a/src/ext/NetFxExtension/wixlib/NetFx47.wxs
+++ b/src/ext/NetFxExtension/wixlib/NetFx47.wxs
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+
+  <!--
+        .NET Framework installation state properties
+
+        Official documentation can be found at the following location:
+
+        .NET Framework 4.5/4.5.1/4.5.2/4.6/4.6.1/4.6.2/4.7 - http://msdn.microsoft.com/en-us/library/w0x726c2(v=vs.110).aspx
+    -->
+
+  <?define NetFx47MinRelease = 460798 ?>
+  <?define NetFx47WebLink = http://go.microsoft.com/fwlink/?LinkId=825298 ?>
+  <?define NetFx47RedistLink = http://go.microsoft.com/fwlink/?LinkId=825302 ?>
+  <?define NetFx47EulaLink = http://referencesource.microsoft.com/license.html ?>
+
+  <Fragment>
+    <PropertyRef Id="WIXNETFX4RELEASEINSTALLED" />
+    <Property Id="WIX_IS_NETFRAMEWORK_462_OR_LATER_INSTALLED" Secure="yes" />
+    <SetProperty Id="WIX_IS_NETFRAMEWORK_462_OR_LATER_INSTALLED" Value="1" After="AppSearch">
+      WIXNETFX4RELEASEINSTALLED >= "#$(var.NetFx462MinRelease)"
+    </SetProperty>
+  </Fragment>
+
+  <Fragment>
+    <util:RegistrySearchRef Id="NETFRAMEWORK45"/>
+    <util:FileSearch
+      Id='SearchForD3DCompiler'
+      Variable="D3DCompilerExists"
+      Result="exists"
+      Path="%windir%\system32\D3DCompiler_47.dll"
+    />
+
+    <WixVariable Id="WixMbaPrereqPackageId" Value="NetFx47Web" />
+    <WixVariable Id="WixMbaPrereqLicenseUrl" Value="$(var.NetFx47EulaLink)" Overridable="yes" />
+    <WixVariable Id="NetFx47WebDetectCondition" Value="NETFRAMEWORK45 &gt;= $(var.NetFx47MinRelease)" Overridable="yes" />
+    <WixVariable Id="NetFx47WebInstallCondition" Value="" Overridable="yes" />
+    <WixVariable Id="NetFx47WebPackageDirectory" Value="redist\" Overridable="yes" />
+
+    <PackageGroup Id="NetFx47Web">
+      <!-- Update for Windows 7 x64 -->
+      <MsuPackage
+        Id="d3dcompiler64"
+        Compressed="no"
+        Permanent="yes"
+        DetectCondition="((NOT VersionNT64) OR (VersionNT &gt; v6.1) OR (D3DCompilerExists))"
+        DownloadUrl="http://go.microsoft.com/fwlink/?LinkId=848158"
+        KB="KB4019990"
+        Name="redist\Windows6.1-KB4019990-x64.msu">
+        <RemotePayload CertificatePublicKey="371DD003A37769487A2A89A5A9DDB3026451B906" CertificateThumbprint="98ED99A67886D020C564923B7DF25E9AC019DF26" Description="Microsoft .NET Framework 4.7 prerequisite setup" Hash="35CC310E81EF23439BA0EC1F11D7B71DD34ADFE5" ProductName="Microsoft .NET Framework 4.7 prerequisite" Size="2873529" Version="1.0.0.0" />
+      </MsuPackage>
+
+      <!-- Update for Windows 7 x86 -->
+      <MsuPackage
+        Id="d3dcompiler86"
+        Compressed="no"
+        Permanent="yes"
+        DetectCondition="((VersionNT64) OR (VersionNT &gt; v6.1) OR (D3DCompilerExists))"
+        DownloadUrl="http://go.microsoft.com/fwlink/?LinkId=848159"
+        KB="KB4019990"
+        Name="redist\Windows6.1-KB4019990-x86.msu">
+        <RemotePayload CertificatePublicKey="371DD003A37769487A2A89A5A9DDB3026451B906" CertificateThumbprint="98ED99A67886D020C564923B7DF25E9AC019DF26" Description="Microsoft .NET Framework 4.7 prerequisite setup" Hash="1365FB557D5E5917CBF59B507EAC066AD89EA3F7" ProductName="Microsoft .NET Framework 4.7 prerequisite" Size="1424481" Version="1.0.0.0" />
+      </MsuPackage>
+
+      <ExePackage
+          InstallCommand="/q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx47FullLog].html&quot;"
+          RepairCommand="/q /norestart /repair /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx47FullLog].html&quot;"
+          UninstallCommand="/uninstall /q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx47FullLog].html&quot;"
+          PerMachine="yes"
+          DetectCondition="!(wix.NetFx47WebDetectCondition)"
+          InstallCondition="!(wix.NetFx47WebInstallCondition)"
+          Id="NetFx47Web"
+          Vital="yes"
+          Permanent="yes"
+          Protocol="netfx4"
+          DownloadUrl="$(var.NetFx47WebLink)"
+          LogPathVariable="NetFx47FullLog"
+          Compressed="no"
+          Name="!(wix.NetFx47WebPackageDirectory)NDP47-KB3186500-Web.exe">
+        <RemotePayload
+          CertificatePublicKey="371DD003A37769487A2A89A5A9DDB3026451B906"
+          CertificateThumbprint="98ED99A67886D020C564923B7DF25E9AC019DF26"
+          Description="Microsoft .NET Framework 4.7 Setup"
+          Hash="B3A24DEB7A8D937FC0B5591CDCC2725BF4E1BDEA"
+          ProductName="Microsoft .NET Framework 4.7"
+          Size="1426720"
+          Version="4.7.2053.0" />
+      </ExePackage>
+    </PackageGroup>
+  </Fragment>
+
+  <Fragment>
+    <util:RegistrySearchRef Id="NETFRAMEWORK45"/>
+    <util:FileSearch
+      Id='SearchForD3DCompiler'
+      Variable="D3DCompilerExists"
+      Result="exists"
+      Path="%windir%\system32\D3DCompiler_47.dll"
+    />
+
+    <WixVariable Id="WixMbaPrereqPackageId" Value="NetFx47Redist" />
+    <WixVariable Id="WixMbaPrereqLicenseUrl" Value="$(var.NetFx47EulaLink)" Overridable="yes" />
+    <WixVariable Id="NetFx47RedistDetectCondition" Value="NETFRAMEWORK45 &gt;= $(var.NetFx47MinRelease)" Overridable="yes" />
+    <WixVariable Id="NetFx47RedistInstallCondition" Value="" Overridable="yes" />
+    <WixVariable Id="NetFx47RedistPackageDirectory" Value="redist\" Overridable="yes" />
+
+    <PackageGroup Id="NetFx47Redist">
+      <!-- Preferred web installer even for redist version because this is such a corner case dependency. -->
+      
+      <!-- Update for Windows 7 x64 -->
+      <MsuPackage
+        Id="d3dcompiler64"
+        Compressed="no"
+        Permanent="yes"
+        DetectCondition="((NOT VersionNT64) OR (VersionNT &gt; v6.1) OR (D3DCompilerExists))"
+        DownloadUrl="http://go.microsoft.com/fwlink/?LinkId=848158"
+        KB="KB4019990"
+        Name="redist\Windows6.1-KB4019990-x64.msu">
+        <RemotePayload CertificatePublicKey="371DD003A37769487A2A89A5A9DDB3026451B906" CertificateThumbprint="98ED99A67886D020C564923B7DF25E9AC019DF26" Description="Microsoft .NET Framework 4.7 prerequisite setup" Hash="35CC310E81EF23439BA0EC1F11D7B71DD34ADFE5" ProductName="Microsoft .NET Framework 4.7 prerequisite" Size="2873529" Version="1.0.0.0" />
+      </MsuPackage>
+
+      <!-- Update for Windows 7 x86 -->
+      <MsuPackage
+        Id="d3dcompiler86"
+        Compressed="no"
+        Permanent="yes"
+        DetectCondition="((VersionNT64) OR (VersionNT &gt; v6.1) OR (D3DCompilerExists))"
+        DownloadUrl="http://go.microsoft.com/fwlink/?LinkId=848159"
+        KB="KB4019990"
+        Name="redist\Windows6.1-KB4019990-x86.msu">
+        <RemotePayload CertificatePublicKey="371DD003A37769487A2A89A5A9DDB3026451B906" CertificateThumbprint="98ED99A67886D020C564923B7DF25E9AC019DF26" Description="Microsoft .NET Framework 4.7 prerequisite setup" Hash="1365FB557D5E5917CBF59B507EAC066AD89EA3F7" ProductName="Microsoft .NET Framework 4.7 prerequisite" Size="1424481" Version="1.0.0.0" />
+      </MsuPackage>
+
+      <ExePackage
+          InstallCommand="/q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx47FullLog].html&quot;"
+          RepairCommand="/q /norestart /repair /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx47FullLog].html&quot;"
+          UninstallCommand="/uninstall /q /norestart /ChainingPackage &quot;[WixBundleName]&quot; /log &quot;[NetFx47FullLog].html&quot;"
+          PerMachine="yes"
+          DetectCondition="!(wix.NetFx47RedistDetectCondition)"
+          InstallCondition="!(wix.NetFx47RedistInstallCondition)"
+          Id="NetFx47Redist"
+          Vital="yes"
+          Permanent="yes"
+          Protocol="netfx4"
+          DownloadUrl="$(var.NetFx47RedistLink)"
+          LogPathVariable="NetFx47FullLog"
+          Compressed="no"
+          Name="!(wix.NetFx47RedistPackageDirectory)NDP47-KB3186497-x86-x64-AllOS-ENU.exe">
+        <RemotePayload
+          CertificatePublicKey="371DD003A37769487A2A89A5A9DDB3026451B906"
+          CertificateThumbprint="98ED99A67886D020C564923B7DF25E9AC019DF26"
+          Description="Microsoft .NET Framework 4.7 Setup"
+          Hash="76054141A492BA307595250BDA05AD4E0694CDC3"
+          ProductName="Microsoft .NET Framework 4.7"
+          Size="61586744"
+          Version="4.7.2053.0" />
+      </ExePackage>
+    </PackageGroup>
+  </Fragment>
+</Wix>

--- a/src/ext/NetFxExtension/wixlib/NetFxExtension.wixproj
+++ b/src/ext/NetFxExtension/wixlib/NetFxExtension.wixproj
@@ -25,6 +25,7 @@
     <Compile Include="NetFx46.wxs" />
     <Compile Include="NetFx461.wxs" />
     <Compile Include="NetFx462.wxs" />
+    <Compile Include="NetFx47.wxs" />
     <Compile Include="NetFxExtension_x86.wxs" />
   </ItemGroup>
 


### PR DESCRIPTION
Add .NET 4.7 installer for NetFxExtension.
Includes windows update for .NET 4.7 to work on windows 7.
Chose to use the web version of the windows update even for NetFx47Redist; This will cause the installer to fail if there is no internet connection.

I'm not sure if you guys will accept this since development moved to wix4 but our team is still using wix3, so here it is.
Based on the code from this issue: https://github.com/wixtoolset/issues/issues/5575