### PR TITLE
Fix period conistency in dialog description strings by appending a period (issue 5317)

### DIFF
--- a/src/ext/UIExtension/wixlib/WixUI_ar-SA.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_ar-SA.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">إعداد [ProductName]</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">اختر نطاق التثبيت والمجلد</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">اختر نطاق التثبيت والمجلد.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}نطاق التثبيت</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}التثبيت لك &amp;فقط ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">سيتم تثبيت [ProductName] في مجلد لكل مستخدم ولن يكون متوفرًا سوى لحساب المستخدم الخاص بك. ولا تحتاج إلى امتيازات مسؤول محلي.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_ar-SA.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_ar-SA.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">إعداد [ProductName]</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">أوافق &amp;على الشروط الواردة في اتفاقية الترخيص</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">الرجاء قراءة اتفاقية الترخيص التالية بعناية</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">الرجاء قراءة اتفاقية الترخيص التالية بعناية.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}اتفاقية ترخيص المستخدم</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">إعداد [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_ar-SA.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_ar-SA.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">تثبيت كامل</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}اختيار نوع الإعداد</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">اختر نوع الإعداد الأكثر ملاءمة لاحتياجاتك</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">اختر نوع الإعداد الأكثر ملاءمة لاحتياجاتك.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">تثبيت ميزات البرنامج الأكثر شيوعًا. مستحسن لمعظم المستخدمين.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">السماح للمستخدمين باختيار ميزات البرنامج التي سيتم تثبيتها وموقع تثبيتها. مستحسن للمستخدمين المتقدمين.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">سيتم تثبيت جميع ميزات البرنامج. وهذا يتطلب معظم مساحة القرص.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_ar-SA.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_ar-SA.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">إنشاء مجلد جديد</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;اسم المجلد:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">استعراض للوصول إلى المجلد الوجهة</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">استعراض للوصول إلى المجلد الوجهة.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}تغيير المجلد الوجهة</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">إعداد [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_bg-BG.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_bg-BG.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Създаване на нова папка</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;Име на папката:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Отидете до папката местоназначение</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Отидете до папката местоназначение.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Промяна на папката местоназначение</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">Инсталиране на [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_bg-BG.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_bg-BG.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">Инсталиране на [ProductName]</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">&amp;Приемам условията в лицензионното споразумение</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Прочетете внимателно следното лицензионно споразумение</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Прочетете внимателно следното лицензионно споразумение.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Лицензионно споразумение с краен потребител</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">Инсталиране на [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_bg-BG.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_bg-BG.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">Инсталиране на [ProductName]</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">Избор на обхвата и папката на инсталиране</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">Избор на обхвата и папката на инсталиране.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Обхват на инсталиране</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}Инсталиране &amp;само за вас ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">[ProductName] ще се инсталира в отделна папка за всеки потребител и ще бъде достъпно само за вашия потребителски акаунт. Не се нуждаете от привилегии на локален администратор.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_bg-BG.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_bg-BG.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Пълна инсталация</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Избор на тип инсталация</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Избор на типа инсталация, който отговаря най-добре на вашите нужди</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Избор на типа инсталация, който отговаря най-добре на вашите нужди.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Инсталира най-често използваните програмни компоненти. Препоръчва се за повечето потребители.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Позволява на потребителите да изберат кои компоненти на програмата ще се инсталират и къде ще се инсталират. Препоръчва се за опитни потребители.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Всички програмни компоненти ще се инсталират. Изисква най-много дисково пространство.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_ca-ES.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_ca-ES.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Instal·lació completa</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Trieu un tipus de configuració</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Trieu el tipus de configuració que més bé s'adapti a les vostres necessitats</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Trieu el tipus de configuració que més bé s'adapti a les vostres necessitats.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Instal·la les característiques del programa més comunes. Recomanat per a la majoria dels usuaris.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Permet que els usuaris triïn quines característiques del programa s'instal·laran i on s'instal·laran. Recomanat per a usuaris avançats.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">S'instal·laran totes les característiques del programa. Requereix la major part de l'espai al disc.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_ca-ES.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_ca-ES.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">Instal·lació del producte [ProductName]</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">Trieu l'àmbit d'instal·lació i la carpeta</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">Trieu l'àmbit d'instal·lació i la carpeta.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Àmbit d'instal·lació</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}Instal·la &amp;només per al vostre usuari ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">El producte [ProductName] s'instal·larà en una carpeta per usuari i estarà disponible només per al compte del vostre usuari. No necessiteu privilegis locals d'administrador.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_ca-ES.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_ca-ES.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Crea una carpeta nova</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;Nom de la carpeta:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Navega a la carpeta de destinació</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Navega a la carpeta de destinació.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Canvia la carpeta de destinació</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">Instal·lació del producte [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_ca-ES.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_ca-ES.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">Instal·lació del producte [ProductName]</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">&amp;Accepto les condicions del contracte de llicència</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Llegiu el contracte de llicència següent atentament</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Llegiu el contracte de llicència següent atentament.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Contracte de llicència de l'usuari final</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">Instal·lació del producte [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_cs-CZ.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_cs-CZ.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Umožňuje vytvořit novou složku.</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;Název složky:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Umožňuje přejít do cílové složky.</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Umožňuje přejít do cílové složky..</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Změnit cílovou složku</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">Instalace produktu [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_cs-CZ.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_cs-CZ.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">Instalace produktu [ProductName]</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">&amp;S podmínkami licenční smlouvy souhlasím</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Přečtěte si pečlivě následující licenční smlouvu.</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Přečtěte si pečlivě následující licenční smlouvu..</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Licenční smlouva s koncovým uživatelem (EULA)</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">Instalace produktu [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_cs-CZ.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_cs-CZ.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Umožňuje vytvořit novou složku.</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;Název složky:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Umožňuje přejít do cílové složky..</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Umožňuje přejít do cílové složky.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Změnit cílovou složku</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">Instalace produktu [ProductName]</String>
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">Instalace produktu [ProductName]</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">Umožňuje zvolit obor instalace a instalační složku..</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">Umožňuje zvolit obor instalace a instalační složku.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Obor instalace</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}Nainstalovat &amp;pouze pro vás ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">Produkt [ProductName] bude nainstalován do složky konkrétního uživatele a bude k dispozici pouze pro váš uživatelský účet. Nepotřebujete oprávnění místního správce.</String>
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">Instalace produktu [ProductName]</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">&amp;S podmínkami licenční smlouvy souhlasím</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Přečtěte si pečlivě následující licenční smlouvu..</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Přečtěte si pečlivě následující licenční smlouvu.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Licenční smlouva s koncovým uživatelem (EULA)</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">Instalace produktu [ProductName]</String>
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Úplná instalace</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Zvolit typ instalace</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Zvolte typ instalace, který nejlépe vyhovuje vašim potřebám..</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Zvolte typ instalace, který nejlépe vyhovuje vašim potřebám.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Nainstaluje nejběžnější součásti programu. Doporučeno pro většinu uživatelů.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Umožňuje uživatelům zvolit, které součásti programu budou nainstalovány a kam. Doporučeno pro zkušené uživatele.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Budou nainstalovány všechny součásti programu. Požaduje nejvíce místa na pevném disku.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_cs-CZ.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_cs-CZ.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">Instalace produktu [ProductName]</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">Umožňuje zvolit obor instalace a instalační složku.</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">Umožňuje zvolit obor instalace a instalační složku..</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Obor instalace</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}Nainstalovat &amp;pouze pro vás ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">Produkt [ProductName] bude nainstalován do složky konkrétního uživatele a bude k dispozici pouze pro váš uživatelský účet. Nepotřebujete oprávnění místního správce.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_cs-CZ.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_cs-CZ.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Úplná instalace</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Zvolit typ instalace</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Zvolte typ instalace, který nejlépe vyhovuje vašim potřebám.</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Zvolte typ instalace, který nejlépe vyhovuje vašim potřebám..</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Nainstaluje nejběžnější součásti programu. Doporučeno pro většinu uživatelů.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Umožňuje uživatelům zvolit, které součásti programu budou nainstalovány a kam. Doporučeno pro zkušené uživatele.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Budou nainstalovány všechny součásti programu. Požaduje nejvíce místa na pevném disku.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_da-DK.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_da-DK.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">[ProductName] Installation</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">Jeg &amp;accepterer vilkårene i licensaftalen</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Læs følgende licensaftale grundigt</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Læs følgende licensaftale grundigt.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Slutbrugerlicensaftale</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">[ProductName] Installation</String>

--- a/src/ext/UIExtension/wixlib/WixUI_da-DK.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_da-DK.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">[ProductName] Installation</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">Vælg installationsområde og -mappe</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">Vælg installationsområde og -mappe.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Installationsområde</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}Installer &amp;kun for dig ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">[ProductName] installeres i en mappe pr. bruger og er kun tilgængelig for din brugerkonto. Du behøver ikke lokale administratorrettigheder.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_da-DK.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_da-DK.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Opret en ny mappe</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;Mappenavn:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Gå til destinationsmappen</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Gå til destinationsmappen.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Skift destinationsmappe</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">[ProductName] Installation</String>

--- a/src/ext/UIExtension/wixlib/WixUI_da-DK.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_da-DK.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Fuld installation</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Vælg installationstype</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Vælg den installationstype, som passer bedst til dine behov</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Vælg den installationstype, som passer bedst til dine behov.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Installerer de mest almindelige programfunktioner. Anbefales til de fleste brugere.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Giver brugerne mulighed for at vælge, hvilke programfunktioner der installeres, og hvor de installeres. Anbefales til avancerede brugere.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Alle programfunktioner installeres. Kræver mest diskplads.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_de-de.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_de-de.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">[ProductName]-Setup</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">Wählen Sie Installationsumfang und -ordner</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">Wählen Sie Installationsumfang und -ordner.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Installationsumfang</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}&amp;Nur für mich installieren ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">[ProductName] wird in einem Benutzerordner installiert und steht nur unter Ihrem Benutzerkonto zur Verfügung. Sie benötigen keine Administratorberechtigungen.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_de-de.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_de-de.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Neuen Ordner erstellen</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;Ordnername:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Zielordner suchen</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Zielordner suchen.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Zielordner ändern</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">[ProductName]-Setup</String>

--- a/src/ext/UIExtension/wixlib/WixUI_de-de.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_de-de.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Vollständige Installation</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Installationstyp wählen</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Wählen Sie die für Sie passende Installationsart aus</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Wählen Sie die für Sie passende Installationsart aus.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Standardprogrammfunktionen werden installiert. Empfohlen für die meisten Benutzer.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Installiert die vom Benutzer festgelegten Programmfunktionen am vom Benutzer angegebenen Speicherort. Empfohlen für fortgeschrittene Benutzer.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Alle Programmfunktionen werden installiert. Erfordert den meisten Speicherplatz.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_de-de.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_de-de.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">[ProductName]-Setup</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">Ich &amp;stimme den Bedingungen der Lizenzvereinbarung zu.</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Lesen Sie die nachfolgenden Lizenzbedingungen aufmerksam durch</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Lesen Sie die nachfolgenden Lizenzbedingungen aufmerksam durch.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Lizenzbedingungen</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">[ProductName]-Setup</String>

--- a/src/ext/UIExtension/wixlib/WixUI_el-GR.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_el-GR.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Δημιουργία νέου φακέλου</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">Ό&amp;νομα φακέλου:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Αναζήτηση του φακέλου προορισμού</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Αναζήτηση του φακέλου προορισμού.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Αλλαγή φακέλου προορισμού</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">Πρόγραμμα εγκατάστασης του [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_el-GR.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_el-GR.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">Πρόγραμμα εγκατάστασης του [ProductName]</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">Επιλέξτε την εμβέλεια και το φάκελο εγκατάστασης</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">Επιλέξτε την εμβέλεια και το φάκελο εγκατάστασης.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Εμβέλεια εγκατάστασης</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}Εγκατάσταση &amp;μόνο για εσάς, το χρήστη ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">Το [ProductName] θα εγκατασταθεί σε ένα φάκελο ανά χρήστη και θα είναι διαθέσιμο μόνο για τον δικό σας λογαριασμό χρήστη. Δεν χρειάζεστε δικαιώματα τοπικού διαχειριστή.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_el-GR.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_el-GR.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Πλήρης εγκατάσταση</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Επιλογή τύπου εγκατάστασης</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Επιλέξτε τον τύπο εγκατάστασης που ταιριάζει καλύτερα στις ανάγκες σας</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Επιλέξτε τον τύπο εγκατάστασης που ταιριάζει καλύτερα στις ανάγκες σας.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Εγκαθιστά τις συνηθέστερες δυνατότητες του προγράμματος. Συνιστάται για τους περισσότερους χρήστες.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Επιτρέπει στους χρήστες να επιλέξουν τις δυνατότητες του προγράμματος που θα εγκατασταθούν και τη θέση στην οποία θα εγκατασταθούν. Συνιστάται για προχωρημένους χρήστες.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Θα εγκατασταθούν όλες οι δυνατότητες του προγράμματος. Απαιτεί τον περισσότερο χώρο στο δίσκο.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_el-GR.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_el-GR.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">Πρόγραμμα εγκατάστασης του [ProductName]</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">&amp;Αποδέχομαι τους όρους της άδειας χρήσης</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Διαβάστε προσεκτικά την παρακάτω άδειας χρήσης</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Διαβάστε προσεκτικά την παρακάτω άδειας χρήσης.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Άδεια χρήσης τελικού χρήστη</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">Πρόγραμμα εγκατάστασης του [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_en-us.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_en-us.wxl
@@ -211,7 +211,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes"><!-- _locID_text="SetupTypeDlgCompleteButtonTooltip" _locComment="SetupTypeDlgCompleteButtonTooltip" -->Complete Installation</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes"><!-- _locID_text="SetupTypeDlgBannerBitmap" _locComment="SetupTypeDlgBannerBitmap" -->WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes"><!-- _locID_text="SetupTypeDlgTitle" _locComment="SetupTypeDlgTitle" -->{\WixUI_Font_Title}Choose Setup Type</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes"><!-- _locID_text="SetupTypeDlgDescription" _locComment="SetupTypeDlgDescription" -->Choose the setup type that best suits your needs</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes"><!-- _locID_text="SetupTypeDlgDescription" _locComment="SetupTypeDlgDescription" -->Choose the setup type that best suits your needs.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes"><!-- _locID_text="SetupTypeDlgTypicalText" _locComment="SetupTypeDlgTypicalText" -->Installs the most common program features. Recommended for most users.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes"><!-- _locID_text="SetupTypeDlgCustomText" _locComment="SetupTypeDlgCustomText" -->Allows users to choose which program features will be installed and where they will be installed. Recommended for advanced users.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes"><!-- _locID_text="SetupTypeDlgCompleteText" _locComment="SetupTypeDlgCompleteText" -->All program features will be installed. Requires the most disk space.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_en-us.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_en-us.wxl
@@ -39,7 +39,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes"><!-- _locID_text="BrowseDlgNewFolderTooltip" _locComment="BrowseDlgNewFolderTooltip" -->Create a new folder</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes"><!-- _locID_text="BrowseDlgPathLabel" _locComment="BrowseDlgPathLabel" -->&amp;Folder name:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes"><!-- _locID_text="BrowseDlgBannerBitmap" _locComment="BrowseDlgBannerBitmap" -->WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes"><!-- _locID_text="BrowseDlgDescription" _locComment="BrowseDlgDescription" -->Browse to the destination folder</String>
+    <String Id="BrowseDlgDescription" Overridable="yes"><!-- _locID_text="BrowseDlgDescription" _locComment="BrowseDlgDescription" -->Browse to the destination folder.</String>
     <String Id="BrowseDlgTitle" Overridable="yes"><!-- _locID_text="BrowseDlgTitle" _locComment="BrowseDlgTitle" -->{\WixUI_Font_Title}Change destination folder</String>
 
     <String Id="CancelDlg_Title" Overridable="yes"><!-- _locID_text="CancelDlg_Title" _locComment="CancelDlg_Title" -->[ProductName] Setup</String>

--- a/src/ext/UIExtension/wixlib/WixUI_en-us.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_en-us.wxl
@@ -110,7 +110,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes"><!-- _locID_text="InstallScopeDlg_Title" _locComment="InstallScopeDlg_Title" -->[ProductName] Setup</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes"><!-- _locID_text="InstallScopeDlgBannerBitmap" _locComment="InstallScopeDlgBannerBitmap" -->WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes"><!-- _locID_text="InstallScopeDlgDescription" _locComment="InstallScopeDlgDescription" -->Choose the installation scope and folder</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes"><!-- _locID_text="InstallScopeDlgDescription" _locComment="InstallScopeDlgDescription" -->Choose the installation scope and folder.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes"><!-- _locID_text="InstallScopeDlgTitle" _locComment="InstallScopeDlgTitle" -->{\WixUI_Font_Title}Installation Scope</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes"><!-- _locID_text="InstallScopeDlgPerUser" _locComment="InstallScopeDlgPerUser" -->{\WixUI_Font_Emphasized}Install &amp;just for you ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes"><!-- _locID_text="InstallScopeDlgPerUserDescription" _locComment="InstallScopeDlgPerUserDescription" -->[ProductName] will be installed in a per-user folder and be available just for your user account. You do not need local Administrator privileges.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_en-us.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_en-us.wxl
@@ -128,7 +128,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes"><!-- _locID_text="LicenseAgreementDlg_Title" _locComment="LicenseAgreementDlg_Title" -->[ProductName] Setup</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes"><!-- _locID_text="LicenseAgreementDlgLicenseAcceptedCheckBox" _locComment="LicenseAgreementDlgLicenseAcceptedCheckBox" -->I &amp;accept the terms in the License Agreement</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes"><!-- _locID_text="LicenseAgreementDlgBannerBitmap" _locComment="LicenseAgreementDlgBannerBitmap" -->WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes"><!-- _locID_text="LicenseAgreementDlgDescription" _locComment="LicenseAgreementDlgDescription" -->Please read the following license agreement carefully</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes"><!-- _locID_text="LicenseAgreementDlgDescription" _locComment="LicenseAgreementDlgDescription" -->Please read the following license agreement carefully.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes"><!-- _locID_text="LicenseAgreementDlgTitle" _locComment="LicenseAgreementDlgTitle" -->{\WixUI_Font_Title}End-User License Agreement</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes"><!-- _locID_text="MaintenanceTypeDlg_Title" _locComment="MaintenanceTypeDlg_Title" -->[ProductName] Setup</String>

--- a/src/ext/UIExtension/wixlib/WixUI_es-es.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_es-es.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Instalación completa</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Elija un tipo de instalación</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Elija el tipo de instalación que mejor se adapte a sus necesidades..</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Elija el tipo de instalación que mejor se adapte a sus necesidades.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Instala las características de programa más comunes. Recomendada para la mayoría de los usuarios.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">El usuario podrá elegir las características de programa que se instalarán y dónde se instalarán. Recomendada para usuarios avanzados.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Instalará todas las características del programa. Esta opción es la que más espacio en disco requiere.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_es-es.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_es-es.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Crea una nueva carpeta</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;Nombre de carpeta:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Buscar la carpeta de destino</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Buscar la carpeta de destino.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Cambiar carpeta de destino</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">Instalación de [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_es-es.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_es-es.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">Instalación de [ProductName]</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">Elija el ámbito y la carpeta de instalación</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">Elija el ámbito y la carpeta de instalación.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Ámbito de la instalación</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}Instalar &amp;solo para el usuario actual ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">[ProductName] se instalará en una carpeta por usuario y solo estará disponible para su cuenta de usuario. No se necesitan privilegios de administrador local.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_es-es.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_es-es.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">Instalación de [ProductName]</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">A&amp;cepto los términos del Contrato de licencia</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Lea detenidamente el siguiente Contrato de licencia</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Lea detenidamente el siguiente Contrato de licencia.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Contrato de licencia para el usuario final</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">Instalación de [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_es-es.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_es-es.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Instalación completa</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Elija un tipo de instalación</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Elija el tipo de instalación que mejor se adapte a sus necesidades.</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Elija el tipo de instalación que mejor se adapte a sus necesidades..</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Instala las características de programa más comunes. Recomendada para la mayoría de los usuarios.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">El usuario podrá elegir las características de programa que se instalarán y dónde se instalarán. Recomendada para usuarios avanzados.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Instalará todas las características del programa. Esta opción es la que más espacio en disco requiere.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_et-EE.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_et-EE.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Loo uus kaust</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;Kausta nimi:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Liikuge sirvides soovitud sihtkausta juurde</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Liikuge sirvides soovitud sihtkausta juurde.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Sihtkausta muutmine</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">Toote [ProductName] install</String>

--- a/src/ext/UIExtension/wixlib/WixUI_et-EE.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_et-EE.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">Toote [ProductName] install</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">&amp;Nõustun litsentsilepingu tingimustega</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Palun lugege alltoodud litsentsileping hoolikalt läbi</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Palun lugege alltoodud litsentsileping hoolikalt läbi.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Lõppkasutaja litsentsileping</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">Toote [ProductName] install</String>

--- a/src/ext/UIExtension/wixlib/WixUI_et-EE.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_et-EE.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Täielik install</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Installitüübi valimine</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Valige oma vajadustele vastav installitüüp</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Valige oma vajadustele vastav installitüüp.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Installitakse levinumad programmifunktsioonid. Soovitatav enamikule kasutajatele.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Võimaldab kasutajatel otsustada programmifunktsioonide installimise valiku ja koha üle. Soovitatav kogenud kasutajatele.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Installitakse kõik programmifunktsioonid. Nõuab kõige rohkem kettaruumi.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_et-EE.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_et-EE.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">Toote [ProductName] install</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">Valige installimise ulatus ja kaust</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">Valige installimise ulatus ja kaust.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Installimise ulatus</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}Installimine &amp;ainult teie jaoks ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">Toode [ProductName] installitakse kasutajapõhisesse kausta ja see on saadaval ainult teie kasutajakontole. Teil ei ole vaja kohaliku administraatori õigusi.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_fi-FI.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_fi-FI.wxl
@@ -130,7 +130,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">Tuotteen [ProductName] asennus</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">&amp;Hyväksyn käyttöoikeussopimuksen ehdot</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Lue seuraava käyttöoikeussopimus huolellisesti</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Lue seuraava käyttöoikeussopimus huolellisesti.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Käyttöoikeussopimus</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">Tuotteen [ProductName] asennus</String>

--- a/src/ext/UIExtension/wixlib/WixUI_fi-FI.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_fi-FI.wxl
@@ -213,7 +213,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Täydellinen asennus</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Valitse asennustyyppi</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Valitse tarpeitasi parhaiten vastaava asennustyyppi</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Valitse tarpeitasi parhaiten vastaava asennustyyppi.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Asentaa yleisimmät ohjelman ominaisuudet. Suositellaan useimmille käyttäjille.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Käyttäjä voi valita, mitkä ohjelman ominaisuudet asennetaan ja mihin ne asennetaan. Suositellaan kokeneille käyttäjille.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Kaikki ohjelman ominaisuudet asennetaan. Vaatii eniten levytilaa.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_fi-FI.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_fi-FI.wxl
@@ -112,7 +112,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">Tuotteen [ProductName] asennus</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">Valitse asennuksen laajuus ja kansio</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">Valitse asennuksen laajuus ja kansio.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Asennuksen laajuus</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}Asenna &amp;vain nykyiselle käyttäjälle ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">[ProductName] asennetaan käyttäjäkohtaiseen kansioon, ja se on vain nykyisen käyttäjätilin käytettävissä. Paikallisia järjestelmänvalvojaoikeuksia ei tarvita.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_fi-FI.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_fi-FI.wxl
@@ -41,7 +41,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Luo uusi kansio</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;Kansion nimi:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Selaa kohdekansioon</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Selaa kohdekansioon.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Vaihda kohdekansiota</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">Tuotteen [ProductName] asennus</String>

--- a/src/ext/UIExtension/wixlib/WixUI_fr-fr.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_fr-fr.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Créer un dossier</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;Nom du dossier :</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Sélectionner le dossier de destination</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Sélectionner le dossier de destination.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Modifier le dossier de destination</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">Installation de [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_fr-fr.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_fr-fr.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Installation complète</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Sélectionner le type d'installation</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Choisissez le type d'installation qui correspond le mieux à vos besoins..</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Choisissez le type d'installation qui correspond le mieux à vos besoins.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Installe les composants les plus courants du programme. Recommandé pour la plupart des utilisateurs.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Permet à l'utilisateur de sélectionner les composants du programme qui seront installés et l'emplacement d'installation. Ceci est recommandé pour les utilisateurs expérimentés.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Tous les composants du programme vont être installés. Nécessite une quantité d’espace disque maximale.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_fr-fr.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_fr-fr.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">Installation de [ProductName]</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">J'&amp;accepte les termes du contrat de licence</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Lisez attentivement le contrat de licence suivant</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Lisez attentivement le contrat de licence suivant.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Contrat de Licence Utilisateur Final</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">Installation de [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_fr-fr.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_fr-fr.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">Installation de [ProductName]</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">Choisir l'étendue et le dossier d'installation</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">Choisir l'étendue et le dossier d'installation.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Étendue d'installation</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}Installer &amp;uniquement pour vous ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">[ProductName] sera installé dans un dossier spécifique à chaque utilisateur et sera disponible uniquement pour votre compte d'utilisateur. Vous n'avez pas besoin de disposer de privilèges d'administrateur local.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_fr-fr.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_fr-fr.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Installation complète</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Sélectionner le type d'installation</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Choisissez le type d'installation qui correspond le mieux à vos besoins.</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Choisissez le type d'installation qui correspond le mieux à vos besoins..</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Installe les composants les plus courants du programme. Recommandé pour la plupart des utilisateurs.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Permet à l'utilisateur de sélectionner les composants du programme qui seront installés et l'emplacement d'installation. Ceci est recommandé pour les utilisateurs expérimentés.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Tous les composants du programme vont être installés. Nécessite une quantité d’espace disque maximale.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_he-IL.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_he-IL.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">התקנה מלאה</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}בחירת סוג התקנה</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">בחר בסוג ההתקנה שמתאים ביותר לצרכיך</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">בחר בסוג ההתקנה שמתאים ביותר לצרכיך.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">התקנת תכונות התוכנית הנפוצות ביותר. מומלץ עבור מרבית המשתמשים.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">מתן אפשרות למשתמשים לבחור אילו תכונות תוכנית יותקנו והיכן הן יותקנו. מומלץ עבור משתמשים מתקדמים.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">כל תכונות התוכנית יותקנו. האפשרות דורשת את שטח הדיסק הרב ביותר.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_he-IL.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_he-IL.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">תוכנית ההתקנה של [ProductName]</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">אני &amp;מקבל את תנאי הסכם הרשיון</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">קרא בעיון את הסכם הרשיון שלהלן</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">קרא בעיון את הסכם הרשיון שלהלן.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}הסכם רשיון למשתמש קצה</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">תוכנית ההתקנה של [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_he-IL.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_he-IL.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">צור תיקיה חדשה</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;שם תיקיה:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">עבור אל תיקיית היעד</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">עבור אל תיקיית היעד.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}שינוי תיקיית יעד</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">תוכנית ההתקנה של [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_he-IL.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_he-IL.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">תוכנית ההתקנה של [ProductName]</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">בחר את הטווח והתיקיה להתקנה</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">בחר את הטווח והתיקיה להתקנה.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}טווח התקנה</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}התקן &amp;רק עבורך ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">[ProductName] יותקן בתיקיה לפי משתמש ויהיה זמין רק עבור חשבון המשתמש שלך. אינך זקוק להרשאות מקומיות של מנהל מערכת.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_hi-IN.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_hi-IN.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">पूर्ण स्थापना</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}सेटअप प्रकार चुनें</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">वह सेटअप प्रकार चुनें को आपकी आवश्यकताओं के लिए श्रेष्ठ हो</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">वह सेटअप प्रकार चुनें को आपकी आवश्यकताओं के लिए श्रेष्ठ हो.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">सबसे सामान्य प्रोग्राम सुविधाएँ स्थापित करता है. अधिकांश उपयोगकर्ताओं के लिए अनुशंसित.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">उपयोगकर्ताओं को यह चुनने देता है कि कौन सा प्रोग्राम स्थापित होगा और वे कहाँ स्थापित होंगे. उन्नत उपयोगकर्ताओं के लिए अनुशंसित.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">सभी प्रोग्राम स्थापित किए जाएँगे. अधिक डिस्क स्थान की आवश्यकता होती है.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_hi-IN.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_hi-IN.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">नया फ़ोल्डर बनाएँ</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;फ़ोल्डर नाम:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">गंतव्य फ़ोल्डर ब्राउज़ करें</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">गंतव्य फ़ोल्डर ब्राउज़ करें.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}गंतव्य फ़ोल्डर बदलें</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">[ProductName] सेटअप</String>

--- a/src/ext/UIExtension/wixlib/WixUI_hi-IN.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_hi-IN.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">[ProductName] सेटअप</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">स्थापना क्षेत्र और फ़ोल्डर चुनें</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">स्थापना क्षेत्र और फ़ोल्डर चुनें.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}स्थापना क्षेत्र</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}Install &amp;केवल आपके लिए ([USERNAME])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">[ProductName] को प्रति उपयोगकर्ता फ़ोल्डर में स्थापित किया जाएगा और केवल आपके लिए उपलब्ध होगा. आपको स्थानीय व्यवस्थापक विशेषाधिकारों की आवश्यकता नहीं होगी.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_hi-IN.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_hi-IN.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">[ProductName] सेटअप</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">मुझे &amp;लायसेंस एग्रीमेंट की शर्तें स्वीकार हैं</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">कृपया निम्न लाइसेंस अनुबंध को ध्यानपूर्वक पढ़ें</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">कृपया निम्न लाइसेंस अनुबंध को ध्यानपूर्वक पढ़ें.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}एंड-यूज़र लाइसेंस एग्रीमेंट</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">[ProductName] सेटअप</String>

--- a/src/ext/UIExtension/wixlib/WixUI_hr-HR.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_hr-HR.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">Instalacija programa [ProductName]</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">Odaberite opseg i mapu instalacije</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">Odaberite opseg i mapu instalacije.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Opseg instalacije</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}Instalacija &amp;samo za vas ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">[ProductName] instalirat će se u korisničku mapu i bit će dostupan samo iz vašeg korisničkog računa. Nisu vam potrebne lokalne administratorske ovlasti.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_hr-HR.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_hr-HR.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Stvaranje nove mape</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;Naziv mape:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Pregledavanje odredišne mape</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Pregledavanje odredišne mape.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Promjena odredišne mape</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">Instalacija programa [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_hr-HR.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_hr-HR.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">Instalacija programa [ProductName]</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">&amp;Prihvaćam uvjete licencnog ugovora</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Pozorno pročitajte sljedeći licencni ugovor</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Pozorno pročitajte sljedeći licencni ugovor.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Licencni ugovor za krajnjeg korisnika</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">Instalacija programa [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_hr-HR.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_hr-HR.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Potpuna instalacija</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Odaberite vrstu instalacije</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Odaberite vrstu instalacije koja najbolje odgovara vašim potrebama</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Odaberite vrstu instalacije koja najbolje odgovara vašim potrebama.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Instalira najčešće značajke programa. Preporučuje se za većinu korisnika.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Korisniku omogućuje da odabere značajke programa koje želi instalirati te mjesto na koje će se instalirati. Preporučuje se za napredne korisnike.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Instaliraju se sve značajke programa. Potrebno je najviše prostora na disku.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_hu-HU.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_hu-HU.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">A(z) [ProductName] telepítése</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">&amp;Elfogadom a licencszerződés feltételeit.</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Figyelmesen olvassa el az alábbi licencszerződést.</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Figyelmesen olvassa el az alábbi licencszerződést..</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Végfelhasználói licencszerződés</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">A(z) [ProductName] telepítése</String>

--- a/src/ext/UIExtension/wixlib/WixUI_hu-HU.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_hu-HU.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Új mappa létrehozása</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;Mappa neve:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Tallózással keresse meg a célmappát.</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Tallózással keresse meg a célmappát..</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Célmappa módosítása</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">A(z) [ProductName] telepítése</String>

--- a/src/ext/UIExtension/wixlib/WixUI_hu-HU.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_hu-HU.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Teljes telepítés</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}A telepítéstípus kiválasztása</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Ezen a lapon választhatja ki a telepítés típusát.</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Ezen a lapon választhatja ki a telepítés típusát..</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">A leggyakrabban használt szolgáltatások telepítése (a legtöbb esetben ez a lehetőség ajánlott).</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">A telepítendő szolgáltatások és azok helyének kiválasztása (tapasztalt felhasználóknak ajánlott).</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">A program minden szolgáltatása települ. Ehhez szükséges a legtöbb lemezterület.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_hu-HU.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_hu-HU.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">A(z) [ProductName] telepítése</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">A telepítési hatókör és mappa kiválasztása</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">A telepítési hatókör és mappa kiválasztása.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Telepítési hatókör</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}Telepítés &amp;csak önmaga számára ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">A(z) [ProductName] egy felhasználói mappába települ, és csak az Ön felhasználói fiókjával lesz elérhető. Nem szükségesek rendszergazdai jogok.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_hu-HU.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_hu-HU.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Új mappa létrehozása</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;Mappa neve:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Tallózással keresse meg a célmappát..</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Tallózással keresse meg a célmappát.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Célmappa módosítása</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">A(z) [ProductName] telepítése</String>
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">A(z) [ProductName] telepítése</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">&amp;Elfogadom a licencszerződés feltételeit.</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Figyelmesen olvassa el az alábbi licencszerződést..</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Figyelmesen olvassa el az alábbi licencszerződést.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Végfelhasználói licencszerződés</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">A(z) [ProductName] telepítése</String>
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Teljes telepítés</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}A telepítéstípus kiválasztása</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Ezen a lapon választhatja ki a telepítés típusát..</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Ezen a lapon választhatja ki a telepítés típusát.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">A leggyakrabban használt szolgáltatások telepítése (a legtöbb esetben ez a lehetőség ajánlott).</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">A telepítendő szolgáltatások és azok helyének kiválasztása (tapasztalt felhasználóknak ajánlott).</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">A program minden szolgáltatása települ. Ehhez szükséges a legtöbb lemezterület.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_it-it.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_it-it.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Crea una nuova cartella</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;Nome cartella:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Scegliere la cartella di destinazione</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Scegliere la cartella di destinazione.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Modifica cartella di destinazione</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">Installazione di [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_it-it.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_it-it.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">Installazione di [ProductName]</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">&amp;Accetto i termini del Contratto di Licenza</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Leggere attentamente il Contratto di Licenza</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Leggere attentamente il Contratto di Licenza.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Contratto di Licenza con l'utente finale</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">Installazione di [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_it-it.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_it-it.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">Installazione di [ProductName]</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">Scegliere la cartella e l'ambito di installazione</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">Scegliere la cartella e l'ambito di installazione.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Ambito di installazione</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}Installa solo per l'&amp;utente corrente ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">[ProductName] verrà installato in una cartella per utente e sarà disponibile solo per l'account utente corrente. Non sono necessari privilegi di amministratore locale.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_it-it.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_it-it.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Installazione completa</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Scegliere il tipo di installazione</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Scegliere il tipo di installazione più adatto</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Scegliere il tipo di installazione più adatto.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Vengono installate le funzionalità del programma più comuni. Opzione consigliata per la maggior parte degli utenti.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Consente agli utenti di scegliere le funzionalità del programma da installare e la posizione in cui verranno installate. Opzione consigliata per utenti esperti.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Verranno installate tutte le funzionalità del programma. È necessaria la quantità massima di spazio su disco.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_ja-jp.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_ja-jp.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">完全インストール</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}セットアップの種類の選択</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">目的に合わせてセットアップの種類を選択してください。</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">目的に合わせてセットアップの種類を選択してください。.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">最も一般的に使われるプログラムの機能がインストールされます。通常は、こちらを選択してください。</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">ユーザーが、インストールするプログラムの機能やインストール先を選択することができます。詳しい知識のある方にお勧めします。</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">すべてのプログラム機能をインストールします。最も多くのディスク領域が必要です。</String>

--- a/src/ext/UIExtension/wixlib/WixUI_ja-jp.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_ja-jp.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">新しいフォルダーの作成</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">フォルダー名(&amp;F):</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">インストール先フォルダーを参照します。</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">インストール先フォルダーを参照します。.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}インストール先フォルダーの変更</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">[ProductName] セットアップ</String>

--- a/src/ext/UIExtension/wixlib/WixUI_ja-jp.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_ja-jp.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">[ProductName] セットアップ</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">インストール範囲とフォルダーの選択</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">インストール範囲とフォルダーの選択.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}インストール範囲</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}自分のみを対象にインストール ([LogonUser])(&amp;J)</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">[ProductName] はユーザーごとのフォルダーにインストールされ、そのユーザー アカウントでのみ使用できます。ローカル管理者の権限は必要ありません。</String>

--- a/src/ext/UIExtension/wixlib/WixUI_ja-jp.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_ja-jp.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">[ProductName] セットアップ</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">使用許諾契約書に同意します(&amp;A)</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">以下の使用許諾契約書をよくお読みください。</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">以下の使用許諾契約書をよくお読みください。.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}使用許諾契約書</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">[ProductName] セットアップ</String>

--- a/src/ext/UIExtension/wixlib/WixUI_kk-KZ.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_kk-KZ.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Орнатуды аяқтау</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Орнату түрін таңдау</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Қажеттіліктерге сәйкес келетін орнату түрін таңдау</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Қажеттіліктерге сәйкес келетін орнату түрін таңдау.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Көптеген жалпы бағдарлама мүмкіндіктерін орнатады. Көптеген пайдаланушыларға ұсынылады.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Пайдаланушыларға орнатылатын бағдарлама мүмкіндіктерін және олардың орнатылатын жерін таңдауға мүмкіндік береді. Тәжірибелі пайдаланушылар үшін ұсынылады.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Барлық бағдарлама мүмкіндіктері орнатылады. Дискіде қосымша бос орын қажет.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_kk-KZ.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_kk-KZ.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">[ProductName] бағдарламасын орнату</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">Мен лицензиялық келісімнің шарттарын &amp;қабылдаймын</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Төмендегі лицензиялық келісімнің шарттарын мұқият оқып шығыңыз</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Төмендегі лицензиялық келісімнің шарттарын мұқият оқып шығыңыз.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}соңғы тұтынушысына арналған лицензиялық келісім</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">[ProductName] бағдарламасын орнату</String>

--- a/src/ext/UIExtension/wixlib/WixUI_kk-KZ.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_kk-KZ.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">[ProductName] бағдарламасын орнату</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">Орнату ауқымын және қалтасын таңдау</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">Орнату ауқымын және қалтасын таңдау.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Орнату ауқымы</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}&amp;Тек өзіңіз үшін орнату ([USERNAME])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">[ProductName] бағдарламасы әрбір пайдаланушы қалтасына орнатылады және тек пайдаланушы тіркелгіңізге қол жетімді болады. Әкімші құқықтары қажет емес.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_kk-KZ.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_kk-KZ.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Жаңа қалта жасау</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;Қалта атауы:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Тағайындалған қалтаны шолу</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Тағайындалған қалтаны шолу.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Тағайындау қалтасын өзгерту</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">[ProductName] бағдарламасын орнату</String>

--- a/src/ext/UIExtension/wixlib/WixUI_ko-KR.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_ko-KR.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">[ProductName] 설치</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">동의함(&amp;A)</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">다음 사용 조건을 자세히 읽어 주십시오.</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">다음 사용 조건을 자세히 읽어 주십시오..</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}최종 사용자 사용권 계약</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">[ProductName] 설치</String>

--- a/src/ext/UIExtension/wixlib/WixUI_ko-KR.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_ko-KR.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">새 폴더 만들기</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">폴더 이름(&amp;F):</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">대상 폴더 찾아보기</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">대상 폴더 찾아보기.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}대상 폴더 변경</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">[ProductName] 설치</String>

--- a/src/ext/UIExtension/wixlib/WixUI_ko-KR.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_ko-KR.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">[ProductName] 설치</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">설치 범위 및 폴더 선택</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">설치 범위 및 폴더 선택.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}설치 범위</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}사용자([LogonUser])에 대해서만(&amp;J)</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">[ProductName]은(는) 사용자 단위 폴더에 설치되며 사용자 계정에 대해서만 사용 가능하게 됩니다. 이 설치에는 로컬 관리자 권한이 없어도 됩니다.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_ko-KR.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_ko-KR.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">[ProductName] 설치</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">동의함(&amp;A)</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">다음 사용 조건을 자세히 읽어 주십시오..</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">다음 사용 조건을 자세히 읽어 주십시오.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}최종 사용자 사용권 계약</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">[ProductName] 설치</String>
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">전체 설치</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}설치 유형 선택</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">사용자의 요구 사항에 가장 적합한 설치 유형을 선택하십시오..</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">사용자의 요구 사항에 가장 적합한 설치 유형을 선택하십시오.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">가장 일반적인 프로그램 기능을 설치합니다. 대부분의 사용자에게 권장합니다.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">설치할 프로그램 기능과 위치를 선택할 수 있습니다. 고급 사용자에게 권장합니다.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">모든 프로그램 기능을 설치합니다. 가장 많은 디스크 공간이 필요합니다.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_ko-KR.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_ko-KR.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">전체 설치</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}설치 유형 선택</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">사용자의 요구 사항에 가장 적합한 설치 유형을 선택하십시오.</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">사용자의 요구 사항에 가장 적합한 설치 유형을 선택하십시오..</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">가장 일반적인 프로그램 기능을 설치합니다. 대부분의 사용자에게 권장합니다.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">설치할 프로그램 기능과 위치를 선택할 수 있습니다. 고급 사용자에게 권장합니다.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">모든 프로그램 기능을 설치합니다. 가장 많은 디스크 공간이 필요합니다.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_lt-LT.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_lt-LT.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">[ProductName] sąranka</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">Pasirinkite diegimo aprėptį ir aplanką</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">Pasirinkite diegimo aprėptį ir aplanką.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Diegimo aprėptis</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}Diegti &amp;tik sau ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">[ProductName] bus įdiegta vartotojo aplanke ir bus pasiekiama tik jūsų vartotojo abonementui. Nereikia turėti vietinio administratoriaus teisių.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_lt-LT.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_lt-LT.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">[ProductName] sąranka</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">&amp;Sutinku su licencijos sutarties sąlygomis</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Atidžiai perskaitykite šią licencijos sutartį</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Atidžiai perskaitykite šią licencijos sutartį.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Galutinio vartotojo licencijos sutartis</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">[ProductName] sąranka</String>

--- a/src/ext/UIExtension/wixlib/WixUI_lt-LT.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_lt-LT.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Kurti naują aplanką</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;Aplanko pavadinimas:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Eiti į paskirties aplanką</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Eiti į paskirties aplanką.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Keisti paskirties aplanką</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">[ProductName] sąranka</String>

--- a/src/ext/UIExtension/wixlib/WixUI_lt-LT.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_lt-LT.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Visas diegimas</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Pasirinkite sąrankos tipą</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Pasirinkite sąrankos tipą, kuris geriausiai atitinka jūsų poreikius</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Pasirinkite sąrankos tipą, kuris geriausiai atitinka jūsų poreikius.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Diegia dažniausias programos priemones. Rekomenduojama daugumai vartotojų.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Leidžia vartotojams pasirinkti, kurias programos priemones diegti ir diegimo vietą. Rekomenduojama pažengusiems vartotojams.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Bus įdiegtos visos programos priemonės. Reikia daugiausia disko vietos.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_lv-LV.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_lv-LV.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">[ProductName] uzstādīšana</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">Izvēlieties instalēšanas tvērumu un mapi</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">Izvēlieties instalēšanas tvērumu un mapi.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Instalēšanas tvērums</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}Instalēt &amp;tikai sev ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">[ProductName] tiks instalēts lietotājam paredzētā mapē un būs pieejams tikai jūsu lietotāja kontam. Nav nepieciešamas lokālā administratora atļaujas.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_lv-LV.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_lv-LV.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Pilna instalācija</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Uzstādīšanas tipa izvēle</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Izvēlieties savām vajadzībām visatbilstošāko uzstādīšanas tipu</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Izvēlieties savām vajadzībām visatbilstošāko uzstādīšanas tipu.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Tiek instalēti visbiežāk lietotie programmas līdzekļi. Ieteicams lielākajai daļai lietotāju.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Lietotāji var izvēlēties instalēšanas vietu un instalējamos programmas līdzekļus. Ieteicams pieredzējušiem lietotājiem.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Tiks instalēti visi programmas līdzekļi. Aizņem visvairāk vietas diskā.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_lv-LV.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_lv-LV.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Izveidot jaunu mapi</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;Mapes nosaukums:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Meklēt mērķa mapi</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Meklēt mērķa mapi.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Mērķa mapes maiņa</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">[ProductName] uzstādīšana</String>

--- a/src/ext/UIExtension/wixlib/WixUI_lv-LV.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_lv-LV.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">[ProductName] uzstādīšana</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">Es &amp;piekrītu licences līguma nosacījumiem</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Lūdzu, uzmanīgi izlasiet šo licences līgumu</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Lūdzu, uzmanīgi izlasiet šo licences līgumu.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Lietotāja licences līgums</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">[ProductName] uzstādīšana</String>

--- a/src/ext/UIExtension/wixlib/WixUI_nb-NO.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_nb-NO.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">Installere [ProductName]</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">Jeg &amp;godtar vilkårene i lisensavtalen</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Les nøye gjennom lisensavtalen nedenfor</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Les nøye gjennom lisensavtalen nedenfor.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Lisensavtale for sluttbrukere</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">Installere [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_nb-NO.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_nb-NO.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Fullstendig installasjon</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Velg installasjonstype</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Velg installasjonstypen som passer best til dine behov</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Velg installasjonstypen som passer best til dine behov.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Installerer de vanligste programfunksjonene. Anbefales for de fleste brukere.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Gjør det mulig for brukere å velge hvilke programfunksjoner som installeres, og hvor de installeres. Anbefales for avanserte brukere.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Alle programfunksjoner blir installert. Krever mest diskplass.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_nb-NO.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_nb-NO.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Opprett en ny mappe</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;Mappenavn:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Søk etter målmappen</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Søk etter målmappen.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Endre målmappe</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">Installere [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_nb-NO.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_nb-NO.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">Installere [ProductName]</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">Velg installasjonsomfang og -mappe</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">Velg installasjonsomfang og -mappe.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Installasjonsomfang</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}Installer &amp;bare for deg ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">[ProductName] blir installert i en mappe per bruker og blir bare tilgjengelig for din brukerkonto. Du trenger ikke lokale administratorrettigheter.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_nl-NL.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_nl-NL.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Een nieuwe map maken</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;Mapnaam:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Naar de doelmap bladeren</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Naar de doelmap bladeren.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Doelmap wijzigen</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">[ProductName] Setup</String>

--- a/src/ext/UIExtension/wixlib/WixUI_nl-NL.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_nl-NL.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">[ProductName] Setup</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">Ik ga &amp;akkoord met de voorwaarden in de overeenkomst</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Lees de volgende gebruiksrechtovereenkomst aandachtig door</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Lees de volgende gebruiksrechtovereenkomst aandachtig door.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Gebruiksrechtovereenkomst</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">[ProductName] Setup</String>

--- a/src/ext/UIExtension/wixlib/WixUI_nl-NL.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_nl-NL.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Volledige installatie</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Installatietype kiezen</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Kies het meest geschikte installatietype</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Kies het meest geschikte installatietype.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">De meest gebruikte programmaonderdelen worden geïnstalleerd. Aanbevolen voor de meeste gebruikers.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Gebruikers kunnen kiezen welke programmaonderdelen worden geïnstalleerd en waar ze worden geïnstalleerd. Aanbevolen voor ervaren gebruikers.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Alle programmaonderdelen worden geïnstalleerd. Hiervoor is de meeste schijfruimte vereist.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_nl-NL.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_nl-NL.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">[ProductName] Setup</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">Kies het installatiebereik en de installatiemap</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">Kies het installatiebereik en de installatiemap.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Installatiebereik</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}Alleen voor &amp;uzelf installeren ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">[ProductName] wordt geïnstalleerd in een map per gebruiker en is alleen voor dit gebruikersaccount beschikbaar. U hebt geen lokale Administrator-bevoegdheden nodig.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_pl-pl.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_pl-pl.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Utwórz nowy folder</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">Nazwa &amp;folderu:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Przejdź do folderu docelowego</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Przejdź do folderu docelowego.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Zmień folder docelowy</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">Instalator produktu [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_pl-pl.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_pl-pl.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">Instalator produktu [ProductName]</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">Wybierz zakres i folder instalacji</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">Wybierz zakres i folder instalacji.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Zakres instalacji</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}Zainstaluj tylko dla &amp;siebie ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">Produkt [ProductName] zostanie zainstalowany w folderze przypisanym do użytkownika i będzie dostępny tylko na Twoim koncie użytkownika. Nie potrzebujesz uprawnień administratora lokalnego.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_pl-pl.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_pl-pl.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">Instalator produktu [ProductName]</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">&amp;Akceptuję warunki Umowy licencyjnej</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Przeczytaj uważnie poniższą umowę licencyjną</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Przeczytaj uważnie poniższą umowę licencyjną.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Umowa licencyjna użytkownika oprogramowania</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">Instalator produktu [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_pl-pl.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_pl-pl.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Instalacja pełna</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Wybierz typ instalacji</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Wybierz typ instalacji, który najlepiej odpowiada Twoim potrzebom</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Wybierz typ instalacji, który najlepiej odpowiada Twoim potrzebom.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Instaluje najczęściej używane funkcje programu. Zalecana w przypadku większości użytkowników.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Umożliwia użytkownikom wybranie funkcji programu do zainstalowania i lokalizacji, w której zostaną zainstalowane. Zalecana w przypadku użytkowników zaawansowanych.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Zostaną zainstalowane wszystkie funkcje programu. Wymaga najwięcej miejsca na dysku.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_pt-BR.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_pt-BR.wxl
@@ -41,7 +41,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Criar uma nova pasta</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;Nome da pasta:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Procurar a pasta de destino</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Procurar a pasta de destino.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Alterar pasta de destino</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">Instalação do [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_pt-BR.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_pt-BR.wxl
@@ -112,7 +112,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">Instalação do [ProductName]</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">Escolha o escopo e a pasta de instalação</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">Escolha o escopo e a pasta de instalação.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Escopo de Instalação</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}Instalar ape&amp;nas para você ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">O [ProductName] será instalado em uma pasta por usuário e estará disponível apenas para a sua conta de usuário. Não é necessário ter privilégios de Administrador local.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_pt-BR.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_pt-BR.wxl
@@ -213,7 +213,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Instalação Completa</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Escolher o Tipo de Instalação</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Escolha o tipo de instalação mais adequado às suas necessidades</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Escolha o tipo de instalação mais adequado às suas necessidades.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Instala os recursos mais comuns do programa. Recomendável para a maioria dos usuários.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Permite que os usuários escolham os recursos a serem instalados e onde devem ser instalados. Recomendável para usuários avançados.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Todos os recursos do programa serão instalados. É necessário mais espaço em disco.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_pt-BR.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_pt-BR.wxl
@@ -130,7 +130,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">Instalação do [ProductName]</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">&amp;Aceito os termos do Contrato de Licença</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Leia atenciosamente o contrato de licença a seguir</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Leia atenciosamente o contrato de licença a seguir.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Contrato de Licença de Usuário Final</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">Instalação do [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_pt-PT.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_pt-PT.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Criar uma nova pasta</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;Nome da pasta:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Navegar para a pasta de destino</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Navegar para a pasta de destino.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Alterar a pasta de destino</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">Programa de Configuração do [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_pt-PT.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_pt-PT.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Instalação Completa</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Escolher o Tipo de Configuração</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Escolha o tipo de configuração mais adequado às suas necessidades</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Escolha o tipo de configuração mais adequado às suas necessidades.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Instala as funcionalidades mais comuns do programa. Recomendado para a maioria dos utilizadores.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Permite aos utilizadores escolher as funcionalidades do programa que serão instaladas e onde serão instaladas. Recomendado para utilizadores avançados.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Todas as funcionalidades do programa serão instaladas. Requer a maior quantidade de espaço em disco.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_pt-PT.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_pt-PT.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">Programa de Configuração do [ProductName]</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">&amp;Aceito os termos do Contrato de Licença</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Leia atentamente o seguinte contrato de licença</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Leia atentamente o seguinte contrato de licença.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Contrato de Licença do Utilizador Final</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">Programa de Configuração do [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_pt-PT.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_pt-PT.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">Programa de Configuração do [ProductName]</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">Escolha o âmbito e a pasta de instalação</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">Escolha o âmbito e a pasta de instalação.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Âmbito de Instalação</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}In&amp;stalar apenas para mim ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">O [ProductName] será instalado numa pasta por utilizador e estará disponível apenas para a sua conta de utilizador. Não é necessário ter privilégios de Administrador locais.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_ro-RO.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_ro-RO.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Creare folder nou</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;Nume folder:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Răsfoire la folderul destinaţie</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Răsfoire la folderul destinaţie.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Modificarea folderului de destinaţie</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">Programul de instalare [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_ro-RO.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_ro-RO.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Instalare completă</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Alegeţi tipul instalării</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Alegeţi tipul de instalare care corespunde cel mai bine necesităţilor dvs.</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Alegeţi tipul de instalare care corespunde cel mai bine necesităţilor dvs..</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Instalează cele mai utilizate caracteristici ale programului. Recomandat pentru majoritatea utilizatorilor.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Permite utilizatorilor să aleagă ce caracteristici de program să se instaleze şi unde să se instaleze. Recomandat utilizatorilor avansaţi.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Se vor instala toate caracteristicile programului. Necesită cel mai mult spaţiu pe disc.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_ro-RO.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_ro-RO.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">Programul de instalare [ProductName]</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">Alegeţi aria de instalare şi folderul</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">Alegeţi aria de instalare şi folderul.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Aria de instalare</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}Se instalează &amp;numai pentru dvs. ([USERNAME])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">[ProductName] va fi instalat într-un folder la nivel de utilizator şi va fi disponibil numai pentru contul dvs. de utilizator. Nu sunt necesare privilegii de administrator local.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_ro-RO.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_ro-RO.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Instalare completă</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Alegeţi tipul instalării</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Alegeţi tipul de instalare care corespunde cel mai bine necesităţilor dvs..</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Alegeţi tipul de instalare care corespunde cel mai bine necesităţilor dvs.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Instalează cele mai utilizate caracteristici ale programului. Recomandat pentru majoritatea utilizatorilor.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Permite utilizatorilor să aleagă ce caracteristici de program să se instaleze şi unde să se instaleze. Recomandat utilizatorilor avansaţi.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Se vor instala toate caracteristicile programului. Necesită cel mai mult spaţiu pe disc.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_ro-RO.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_ro-RO.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">Programul de instalare [ProductName]</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">&amp;Accept termenii din Acordul de licenţă</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Citiţi cu atenţie următorul acord de licenţă</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Citiţi cu atenţie următorul acord de licenţă.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Termenii licenţei pentru software Microsoft</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">Programul de instalare [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_ru-ru.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_ru-ru.wxl
@@ -40,7 +40,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Создание новой папки</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;Имя папки:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Перейдите в конечную папку</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Перейдите в конечную папку.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Изменить конечную папку</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">Установка [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_ru-ru.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_ru-ru.wxl
@@ -129,7 +129,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">Установка [ProductName]</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">&amp;Я принимаю условия лицензионного соглашения</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Внимательно прочитайте следующее лицензионное соглашение</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Внимательно прочитайте следующее лицензионное соглашение.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Лицензионное соглашение</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">Установка [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_ru-ru.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_ru-ru.wxl
@@ -212,7 +212,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Полная установка</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Выберите тип установки</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Укажите наиболее подходящий тип установки</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Укажите наиболее подходящий тип установки.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Устанавливает самые распространенные компоненты программ. Рекомендуется для большинства пользователей.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Позволяет выбирать для установки отдельные компоненты и задавать их местонахождение. Рекомендуется для опытных пользователей.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Устанавливает все компоненты программы. Этот вариант требует больше всего места на диске.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_ru-ru.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_ru-ru.wxl
@@ -111,7 +111,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">Установка [ProductName]</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">Выберите область и папку для установки</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">Выберите область и папку для установки.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Область установки</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}Установка для &amp;текущего пользователя ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">Продукт [ProductName] будет установлен в папке пользователя и доступен только для текущего пользователя. Привилегии локального администратора не требуются.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_sk-SK.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_sk-SK.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">[ProductName] – inštalácia</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">&amp;Súhlasím s podmienkami licenčnej zmluvy</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Pozorne si prečítajte nasledujúcu licenčnú zmluvu</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Pozorne si prečítajte nasledujúcu licenčnú zmluvu.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Licenčná zmluva koncového používateľa</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">[ProductName] – inštalácia</String>

--- a/src/ext/UIExtension/wixlib/WixUI_sk-SK.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_sk-SK.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">[ProductName] – inštalácia</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">Vyberte rozsah a priečinok inštalácie</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">Vyberte rozsah a priečinok inštalácie.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Rozsah inštalácie</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}Inštalovať len pre &amp;seba ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">Program [ProductName] sa nainštaluje do priečinka pre konkrétneho používateľa a bude k dispozícii len pre vaše používateľské konto. Nepotrebujete lokálne oprávnenia správcu.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_sk-SK.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_sk-SK.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Vytvoriť nový priečinok</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;Názov priečinka:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Vyhľadať cieľový priečinok</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Vyhľadať cieľový priečinok.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Zmena cieľového priečinka</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">[ProductName] – inštalácia</String>

--- a/src/ext/UIExtension/wixlib/WixUI_sk-SK.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_sk-SK.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Úplná inštalácia</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Výber typu inštalácie</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Vyberte typ inštalácie zodpovedajúci vašim potrebám</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Vyberte typ inštalácie zodpovedajúci vašim potrebám.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Nainštaluje najčastejšie používané funkcie programu. Odporúča sa pre väčšinu používateľov.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Umožňuje používateľom vybrať súčasti programu, ktoré sa majú nainštalovať, a miesto, kam sa majú nainštalovať. Odporúča sa pre skúsených používateľov.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Nainštalujú sa všetky súčasti programu. Vyžaduje najviac miesta na disku.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_sl-SI.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_sl-SI.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">Namestitev programa [ProductName]</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">Sprejmem &amp;pogoje licenčne pogodbe</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Pozorno preberite to licenčno pogodbo</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Pozorno preberite to licenčno pogodbo.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Licenčna pogodba za končnega uporabnika</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">Namestitev programa [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_sl-SI.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_sl-SI.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Ustvari novo mapo</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;Ime mape:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Prebrskajte do ciljne mape</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Prebrskajte do ciljne mape.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Spremeni ciljno mapo</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">Namestitev programa [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_sl-SI.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_sl-SI.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">Namestitev programa [ProductName]</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">Izberite obseg namestitve in mapo</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">Izberite obseg namestitve in mapo.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Obseg namestitve</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}Namestitev &amp;le za osebo ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">[ProductName] bo nameščen v mapo za posameznega uporabnika in bo na voljo le za vaš uporabniški račun. Ne potrebujete lokalnih skrbniških pravic.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_sl-SI.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_sl-SI.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Popolna namestitev</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Izbira vrste namestitve</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Izberite vrsto namestitve, ki najbolj ustrezna vašim potrebam</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Izberite vrsto namestitve, ki najbolj ustrezna vašim potrebam.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Namesti najbolj običajne funkcije programa. Priporočeno za večino uporabnikov.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Uporabniku omogoča, da izbere, katere funkcije programa bodo nameščene in kam bodo nameščene. Priporočeno za izkušene uporabnike.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Nameščene bodo vse funkcije programa. Potrebujete največ prostora na disku.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_sq-AL.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_sq-AL.wxl
@@ -110,7 +110,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes"><!-- _locID_text="InstallScopeDlg_Title" _locComment="InstallScopeDlg_Title" -->Rregullim i [ProductName]</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes"><!-- _locID_text="InstallScopeDlgBannerBitmap" _locComment="InstallScopeDlgBannerBitmap" -->WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes"><!-- _locID_text="InstallScopeDlgDescription" _locComment="InstallScopeDlgDescription" -->Zgjidhni shtrirjen dhe dosjen e instalimit</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes"><!-- _locID_text="InstallScopeDlgDescription" _locComment="InstallScopeDlgDescription" -->Zgjidhni shtrirjen dhe dosjen e instalimit.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes"><!-- _locID_text="InstallScopeDlgTitle" _locComment="InstallScopeDlgTitle" -->{\WixUI_Font_Title}Shtrirje Instalimi</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes"><!-- _locID_text="InstallScopeDlgPerUser" _locComment="InstallScopeDlgPerUser" -->{\WixUI_Font_Emphasized}Instalojeni &amp;vetëm për ju ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes"><!-- _locID_text="InstallScopeDlgPerUserDescription" _locComment="InstallScopeDlgPerUserDescription" -->[ProductName] do të instalohet në një dosje përdoruesi dhe do të mund ta përdorni thjesht nga llogaria juaj e përdoruesit. S’keni nevojë për privilegje Administratori lokal.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_sq-AL.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_sq-AL.wxl
@@ -128,7 +128,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes"><!-- _locID_text="LicenseAgreementDlg_Title" _locComment="LicenseAgreementDlg_Title" -->Rregullim i [ProductName]</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes"><!-- _locID_text="LicenseAgreementDlgLicenseAcceptedCheckBox" _locComment="LicenseAgreementDlgLicenseAcceptedCheckBox" -->I &amp;pranoj kushtet e Marrëveshjesh së Licencës</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes"><!-- _locID_text="LicenseAgreementDlgBannerBitmap" _locComment="LicenseAgreementDlgBannerBitmap" -->WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes"><!-- _locID_text="LicenseAgreementDlgDescription" _locComment="LicenseAgreementDlgDescription" -->Ju lutemi, lexojeni me kujdes marrëveshjen vijuese për licencën</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes"><!-- _locID_text="LicenseAgreementDlgDescription" _locComment="LicenseAgreementDlgDescription" -->Ju lutemi, lexojeni me kujdes marrëveshjen vijuese për licencën.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes"><!-- _locID_text="LicenseAgreementDlgTitle" _locComment="LicenseAgreementDlgTitle" -->{\WixUI_Font_Title}Marrëveshje Licence Përdoruesi të Fundmë</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes"><!-- _locID_text="MaintenanceTypeDlg_Title" _locComment="MaintenanceTypeDlg_Title" -->Rregullim i [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_sq-AL.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_sq-AL.wxl
@@ -211,7 +211,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes"><!-- _locID_text="SetupTypeDlgCompleteButtonTooltip" _locComment="SetupTypeDlgCompleteButtonTooltip" -->Instalim i Plotë</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes"><!-- _locID_text="SetupTypeDlgBannerBitmap" _locComment="SetupTypeDlgBannerBitmap" -->WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes"><!-- _locID_text="SetupTypeDlgTitle" _locComment="SetupTypeDlgTitle" -->{\WixUI_Font_Title}Zgjidhni Lloj Rregulllimi</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes"><!-- _locID_text="SetupTypeDlgDescription" _locComment="SetupTypeDlgDescription" -->Zgjidhni llojin e rregullimit që i përshtatet më mirë nevojave tuaja</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes"><!-- _locID_text="SetupTypeDlgDescription" _locComment="SetupTypeDlgDescription" -->Zgjidhni llojin e rregullimit që i përshtatet më mirë nevojave tuaja.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes"><!-- _locID_text="SetupTypeDlgTypicalText" _locComment="SetupTypeDlgTypicalText" -->Instalon veçoritë më të zakonshme të programit. I këshillueshëm për shumicën e përdoruesve.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes"><!-- _locID_text="SetupTypeDlgCustomText" _locComment="SetupTypeDlgCustomText" -->U lejon përdoruesve të zgjedhin cilat veçori të programit të instalohen dhe ku të instalohen. I këshillueshëm për përdorues të përparuar.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes"><!-- _locID_text="SetupTypeDlgCompleteText" _locComment="SetupTypeDlgCompleteText" -->Do të instalohen krejt veçoritë e programit. Lyp më shumë hapësirë disku se të tjerët.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_sq-AL.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_sq-AL.wxl
@@ -39,7 +39,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes"><!-- _locID_text="BrowseDlgNewFolderTooltip" _locComment="BrowseDlgNewFolderTooltip" -->Krijo një dosje të re</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes"><!-- _locID_text="BrowseDlgPathLabel" _locComment="BrowseDlgPathLabel" -->Emër &amp;dosjeje:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes"><!-- _locID_text="BrowseDlgBannerBitmap" _locComment="BrowseDlgBannerBitmap" -->WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes"><!-- _locID_text="BrowseDlgDescription" _locComment="BrowseDlgDescription" -->Kaloni te dosja destinacion</String>
+    <String Id="BrowseDlgDescription" Overridable="yes"><!-- _locID_text="BrowseDlgDescription" _locComment="BrowseDlgDescription" -->Kaloni te dosja destinacion.</String>
     <String Id="BrowseDlgTitle" Overridable="yes"><!-- _locID_text="BrowseDlgTitle" _locComment="BrowseDlgTitle" -->{\WixUI_Font_Title}Ndryshoni dosjen destinacion</String>
 
     <String Id="CancelDlg_Title" Overridable="yes"><!-- _locID_text="CancelDlg_Title" _locComment="CancelDlg_Title" -->Rregullim i [ProductName] </String>

--- a/src/ext/UIExtension/wixlib/WixUI_sr-Latn-CS.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_sr-Latn-CS.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">Instalacija programa [ProductName]</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">Odaberite opseg instalacije i instalacionu fasciklu</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">Odaberite opseg instalacije i instalacionu fasciklu.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Opseg instalacije</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}Instalirajte &amp;samo za sebe ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">[ProductName] će biti instaliran u fascikli po korisniku i biće dostupan samo za vaš korisnički nalog. Nisu vam potrebne lokalne administratorske privilegije.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_sr-Latn-CS.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_sr-Latn-CS.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Kreirajte novu fasciklu</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">Ime &amp;fascikle:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Potražite odredišnu fasciklu</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Potražite odredišnu fasciklu.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Promena odredišne fascikle</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">Instalacija programa [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_sr-Latn-CS.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_sr-Latn-CS.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">Instalacija programa [ProductName]</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">Prihv&amp;atam uslove navedene u ugovoru o licenciranju</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Pažljivo pročitajte sledeći ugovor o licenciranju</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Pažljivo pročitajte sledeći ugovor o licenciranju.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Ugovor o licenciranju sa krajnjim korisnikom</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">Instalacija programa [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_sr-Latn-CS.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_sr-Latn-CS.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Potpuna instalacija</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Izbor tipa instalacije</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Odaberite tip instalacije koji najviše odgovara vašim potrebama</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Odaberite tip instalacije koji najviše odgovara vašim potrebama.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Instalirajte funkcije programa koje se najčešće koriste. Preporučuje se za većinu korisnika.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Omogućava korisnicima da odaberu koje će funkcije programa biti instalirane i gde će biti instalirane. Preporučuje se za napredne korisnike.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Biće instalirane sve funkcije programa. Zahteva najviše prostora na disku.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_sv-SE.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_sv-SE.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">Installationsguiden för [ProductName]</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">Välj installationsomfattning och mapp</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">Välj installationsomfattning och mapp.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Installationsomfattning</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}Installera &amp;bara för mig: ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">[ProductName] installeras i en mapp per användare och blir bara tillgängligt för ditt användarkonto. Du behöver inte lokala administratörsprivilegier.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_sv-SE.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_sv-SE.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Fullständig installation</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Välj installationstyp</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Välj den installationstyp som passar dig bäst</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Välj den installationstyp som passar dig bäst.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Installerar de vanligaste programfunktionerna. Rekommenderas för de flesta användare.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Användaren kan välja vilka programfunktioner som ska installeras och var de ska installeras. Rekommenderas för avancerade användare.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Alla program installeras. Kräver mest diskutrymme.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_sv-SE.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_sv-SE.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Skapa en ny mapp</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;Mappnamn:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Bläddra till målmappen</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Bläddra till målmappen.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Byt målmapp</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">Installationsguiden för [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_sv-SE.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_sv-SE.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">Installationsguiden för [ProductName]</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">Jag &amp;accepterar villkoren i licensavtalet</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Läs följande licensavtal noggrant</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Läs följande licensavtal noggrant.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Licensavtal</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">Installationsguiden för [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_th-TH.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_th-TH.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">การติดตั้ง [ProductName]</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">เลือกขอบเขตการติดตั้งและโฟลเดอร์</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">เลือกขอบเขตการติดตั้งและโฟลเดอร์.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}ขอบเขตการติดตั้ง</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}ติดตั้งสำหรับ&amp;คุณเท่านั้น ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">[ProductName] จะได้รับการติดตั้งในโฟลเดอร์ต่อผู้ใช้และจะพร้อมใช้งานสำหรับบัญชีผู้ใช้ของคุณเท่านั้น คุณไม่จำเป็นต้องมีสิทธิ์ผู้ดูแลระบบของเครื่อง</String>

--- a/src/ext/UIExtension/wixlib/WixUI_th-TH.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_th-TH.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">การติดตั้งแบบสมบูรณ์</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}เลือกชนิดการติดตั้ง</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">เลือกชนิดการติดตั้งที่ตรงกับความต้องการของคุณมากที่สุด</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">เลือกชนิดการติดตั้งที่ตรงกับความต้องการของคุณมากที่สุด.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">ติดตั้งคุณลักษณะของโปรแกรมโดยทั่วไป แนะนำสำหรับผู้ใช้ส่วนใหญ่</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">อนุญาตให้ผู้ใช้เลือกคุณลักษณะของโปรแกรมที่จะติดตั้ง รวมไปถึงตำแหน่งที่จะติดตั้ง แนะนำสำหรับผู้ใช้ขั้นสูง</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">คุณลักษณะทั้งหมดของโปแกรมจะได้รับการติดตั้ง จำเป็นต้องใช้เนื้อที่ว่างดิสก์มากที่สุด</String>

--- a/src/ext/UIExtension/wixlib/WixUI_th-TH.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_th-TH.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">สร้างโฟลเดอร์ใหม่</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;ชื่อโฟลเดอร์:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">เรียกดูโฟลเดอร์ปลายทาง</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">เรียกดูโฟลเดอร์ปลายทาง.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}เปลี่ยนโฟลเดอร์ปลายทาง</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">การติดตั้ง [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_th-TH.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_th-TH.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">การติดตั้ง [ProductName]</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">ฉัน&amp;ยอมรับเงื่อนไขในข้อตกลงสิทธิ์การใช้งาน</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">โปรดอ่านข้อตกลงสิทธิ์การใช้งานต่อไปนี้อย่างถี่ถ้วน</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">โปรดอ่านข้อตกลงสิทธิ์การใช้งานต่อไปนี้อย่างถี่ถ้วน.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}ข้อตกลงสิทธิ์การใช้งานสำหรับผู้ใช้</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">การติดตั้ง [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_tr-TR.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_tr-TR.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">[ProductName] Kurulumu</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">Yükleme kapsamını ve klasörünü seçin</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">Yükleme kapsamını ve klasörünü seçin.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Yükleme Kapsamı</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}Yalnızca benim için ([LogonUser]) yükle</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">[ProductName] kullanıcıya özel bir klasöre yüklenecek yalnızca sizin kullanıcı hesabınız tarafından kullanılabilecek. Yerel Yönetici ayrıcalıklarınız olması gerekmez.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_tr-TR.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_tr-TR.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Tam Yükleme</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Kurulum Türünü Seç</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Gereksinimlerinize en uygun kurulum türünü seçin</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Gereksinimlerinize en uygun kurulum türünü seçin.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">En sık kullanılan program özelliklerini yükler. Çoğu kullanıcı için önerilir.</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Kullanıcıların yüklenecek program özelliklerini ve bu özelliklerin yükleneceği yeri seçmesine olanak verir. İleri düzey kullanıcılar için önerilir.</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Tüm program özellikleri yüklenecek. En fazla disk alanını gerektirir.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_tr-TR.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_tr-TR.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">[ProductName] Kurulumu</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">Lisans Sözleşmesi'nin koşullarını kabul &amp;ediyorum</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Lütfen aşağıdaki lisans sözleşmesini dikkatle okuyun</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Lütfen aşağıdaki lisans sözleşmesini dikkatle okuyun.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Son Kullanıcı Lisans Sözleşmesi</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">[ProductName] Kurulumu</String>

--- a/src/ext/UIExtension/wixlib/WixUI_tr-TR.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_tr-TR.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Yeni bir klasör oluştur</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">K&amp;lasör adı:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Hedef klasöre gözat</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Hedef klasöre gözat.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Hedef klasörü değiştir</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">[ProductName] Kurulumu</String>

--- a/src/ext/UIExtension/wixlib/WixUI_uk-UA.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_uk-UA.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">Створення нової папки</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">&amp;Ім’я папки:</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">Перехід до папки призначення</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">Перехід до папки призначення.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}Змінення папки призначення</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">Інсталяція програми [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_uk-UA.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_uk-UA.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">Інсталяція програми [ProductName]</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">Вибір типу й папки для інсталяції</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">Вибір типу й папки для інсталяції.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Тип інсталяції</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}Інсталювати &amp;лише для себе ([LogonUser])</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">[ProductName] буде інстальовано в папку на рівні користувача; доступ буде можливий лише з вашого облікового запису користувача. Права локального адміністратора не потрібні.</String>

--- a/src/ext/UIExtension/wixlib/WixUI_uk-UA.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_uk-UA.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">Інсталяція програми [ProductName]</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">Я &amp;приймаю умови ліцензійної угоди</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Уважно прочитайте наведену нижче ліцензійну угоду</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">Уважно прочитайте наведену нижче ліцензійну угоду.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}Ліцензійна угода</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">Інсталяція програми [ProductName]</String>

--- a/src/ext/UIExtension/wixlib/WixUI_uk-UA.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_uk-UA.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">Повна інсталяція</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}Вибір типу інсталяції</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">Виберіть потрібний тип інсталяції</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">Виберіть потрібний тип інсталяції.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">Інсталяція найпоширеніших компонентів програми (рекомендовано для більшості користувачів).</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">Можливість вибрати компоненти програми та місце їх інсталяції (рекомендовано для досвідчених користувачів).</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">Інсталяція усіх програмних компонентів (найбільші вимоги до дискового простору).</String>

--- a/src/ext/UIExtension/wixlib/WixUI_zh-CN.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_zh-CN.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">[ProductName] 安装程序</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">我接受许可协议中的条款(&amp;A)</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">请认真阅读以下许可协议</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">请认真阅读以下许可协议.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}最终用户许可协议</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">[ProductName] 安装程序</String>

--- a/src/ext/UIExtension/wixlib/WixUI_zh-CN.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_zh-CN.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">完整安装</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}选择安装类型</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">选择最符合您需求的安装类型</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">选择最符合您需求的安装类型.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">安装最常用的程序功能。建议大多数用户使用。</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">允许用户选择要安装的程序功能及其安装位置。建议高级用户使用。</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">将安装所有程序功能。需要最多磁盘空间。</String>

--- a/src/ext/UIExtension/wixlib/WixUI_zh-CN.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_zh-CN.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">[ProductName] 安装程序</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">选择安装范围和文件夹</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">选择安装范围和文件夹.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}安装范围</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}只为您([LogonUser])安装(&amp;J)</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">[ProductName] 将安装在每用户文件夹中并且仅供您的用户帐户使用。您不需要本地管理员特权。</String>

--- a/src/ext/UIExtension/wixlib/WixUI_zh-CN.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_zh-CN.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">新建文件夹</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">文件夹名称(&amp;F):</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">浏览到目标文件夹</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">浏览到目标文件夹.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}更改目标文件夹</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">[ProductName] 安装程序</String>

--- a/src/ext/UIExtension/wixlib/WixUI_zh-HK.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_zh-HK.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">[ProductName] 安裝程式</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">我接受授權合約中的條款(&amp;A)</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">請仔細閱讀下面的授權合約</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">請仔細閱讀下面的授權合約.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}使用者授權合約</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">[ProductName] 安裝程式</String>

--- a/src/ext/UIExtension/wixlib/WixUI_zh-HK.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_zh-HK.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">建立新資料夾</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">資料夾名稱(&amp;F):</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">瀏覽到目的地資料夾</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">瀏覽到目的地資料夾.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}變更目的地資料夾</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">[ProductName] 安裝程式</String>

--- a/src/ext/UIExtension/wixlib/WixUI_zh-HK.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_zh-HK.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">[ProductName] 安裝程式</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">選擇安裝範圍和資料夾</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">選擇安裝範圍和資料夾.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}安裝範圍</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}僅為您安裝 ([LogonUser])(&amp;J)</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">[ProductName] 將安裝在個別使用者資料夾中，並且僅供您的使用者帳戶使用。您不需要本機系統管理員權限。</String>

--- a/src/ext/UIExtension/wixlib/WixUI_zh-HK.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_zh-HK.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">完整安裝</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}選擇安裝類型</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">選擇最符合您需求的安裝類型</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">選擇最符合您需求的安裝類型.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">安裝最常用的程式功能。建議一般使用者使用。</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">讓使用者選擇要安裝的程式功能以及安裝位置。建議進階使用者使用。</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">將安裝所有程式功能。需要最大磁碟空間。</String>

--- a/src/ext/UIExtension/wixlib/WixUI_zh-TW.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_zh-TW.wxl
@@ -125,7 +125,7 @@
     <String Id="LicenseAgreementDlg_Title" Overridable="yes">[ProductName] 安裝程式</String>
     <String Id="LicenseAgreementDlgLicenseAcceptedCheckBox" Overridable="yes">我接受授權合約中的條款(&amp;A)</String>
     <String Id="LicenseAgreementDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="LicenseAgreementDlgDescription" Overridable="yes">請仔細閱讀下面的授權合約</String>
+    <String Id="LicenseAgreementDlgDescription" Overridable="yes">請仔細閱讀下面的授權合約.</String>
     <String Id="LicenseAgreementDlgTitle" Overridable="yes">{\WixUI_Font_Title}使用者授權合約</String>
 
     <String Id="MaintenanceTypeDlg_Title" Overridable="yes">[ProductName] 安裝程式</String>

--- a/src/ext/UIExtension/wixlib/WixUI_zh-TW.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_zh-TW.wxl
@@ -36,7 +36,7 @@
     <String Id="BrowseDlgNewFolderTooltip" Overridable="yes">建立新資料夾</String>
     <String Id="BrowseDlgPathLabel" Overridable="yes">資料夾名稱(&amp;F):</String>
     <String Id="BrowseDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="BrowseDlgDescription" Overridable="yes">瀏覽到目的地資料夾</String>
+    <String Id="BrowseDlgDescription" Overridable="yes">瀏覽到目的地資料夾.</String>
     <String Id="BrowseDlgTitle" Overridable="yes">{\WixUI_Font_Title}變更目的地資料夾</String>
 
     <String Id="CancelDlg_Title" Overridable="yes">[ProductName] 安裝程式</String>

--- a/src/ext/UIExtension/wixlib/WixUI_zh-TW.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_zh-TW.wxl
@@ -107,7 +107,7 @@
 
     <String Id="InstallScopeDlg_Title" Overridable="yes">[ProductName] 安裝程式</String>
     <String Id="InstallScopeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
-    <String Id="InstallScopeDlgDescription" Overridable="yes">選擇安裝範圍和資料夾</String>
+    <String Id="InstallScopeDlgDescription" Overridable="yes">選擇安裝範圍和資料夾.</String>
     <String Id="InstallScopeDlgTitle" Overridable="yes">{\WixUI_Font_Title}安裝範圍</String>
     <String Id="InstallScopeDlgPerUser" Overridable="yes">{\WixUI_Font_Emphasized}僅為您安裝 ([LogonUser])(&amp;J)</String>
     <String Id="InstallScopeDlgPerUserDescription" Overridable="yes">[ProductName] 將安裝在個別使用者資料夾中，並且僅供您的使用者帳戶使用。您不需要本機系統管理員權限。</String>

--- a/src/ext/UIExtension/wixlib/WixUI_zh-TW.wxl
+++ b/src/ext/UIExtension/wixlib/WixUI_zh-TW.wxl
@@ -208,7 +208,7 @@
     <String Id="SetupTypeDlgCompleteButtonTooltip" Overridable="yes">完整安裝</String>
     <String Id="SetupTypeDlgBannerBitmap" Overridable="yes">WixUI_Bmp_Banner</String>
     <String Id="SetupTypeDlgTitle" Overridable="yes">{\WixUI_Font_Title}選擇安裝類型</String>
-    <String Id="SetupTypeDlgDescription" Overridable="yes">選擇最符合您需求的安裝類型</String>
+    <String Id="SetupTypeDlgDescription" Overridable="yes">選擇最符合您需求的安裝類型.</String>
     <String Id="SetupTypeDlgTypicalText" Overridable="yes">安裝最常用的程式功能。建議一般使用者使用。</String>
     <String Id="SetupTypeDlgCustomText" Overridable="yes">讓使用者選擇要安裝的程式功能以及安裝位置。建議進階使用者使用。</String>
     <String Id="SetupTypeDlgCompleteText" Overridable="yes">將安裝所有程式功能。需要最大磁碟空間。</String>


### PR DESCRIPTION
To resolve issue [5317](https://github.com/wixtoolset/issues/issues/5317), which is about some dialog description strings not ending in a period (the majority do).
A period was appended to the following variable localisations to make them consistent (note that a some of those localisations already had a period)

- BrowseDlgDescription
- InstallScopeDlgDescription
- LicenseAgreementDlgDescription
- SetupTypeDlgDescription