### PR TITLE
Add option to suppress hard links

### DIFF
--- a/src/tools/wix/Binder.cs
+++ b/src/tools/wix/Binder.cs
@@ -106,6 +106,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
         private bool suppressAssemblies;
         private bool suppressAclReset;
         private bool suppressFileHashAndInfo;
+        private bool suppressHardLinks;
         private StringCollection suppressICEs;
         private bool suppressLayout;
         private bool suppressPatchSequenceData;
@@ -252,6 +253,16 @@ namespace Microsoft.Tools.WindowsInstallerXml
         {
             get { return this.suppressFileHashAndInfo; }
             set { this.suppressFileHashAndInfo = value; }
+        }
+
+        /// <summary>
+        /// Gets and sets the option to suppress creating hardlinks for files at build time.
+        /// </summary>
+        /// <value>The option to suppress creating hardlinks for files at build time.</value>
+        public bool SuppressHardLinks
+        {
+            get { return this.suppressHardLinks; }
+            set { this.suppressHardLinks = value; }
         }
 
         /// <summary>
@@ -483,6 +494,10 @@ namespace Microsoft.Tools.WindowsInstallerXml
                     {
                         consoleMessageHandler.Display(this, WixWarnings.DeprecatedCommandLineSwitch(parameter));
                         this.suppressFileHashAndInfo = true;
+                    }
+                    else if (parameter.Equals("shardlinks", StringComparison.Ordinal))
+                    {
+                        this.suppressHardLinks = true;
                     }
                     else if (parameter.StartsWith("sice:", StringComparison.Ordinal))
                     {
@@ -741,6 +756,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
 
             this.FileManager.CabCachePath = this.cabCachePath;
             this.FileManager.ReuseCabinets = this.reuseCabinets;
+            this.FileManager.SuppressHardLinks = this.suppressHardLinks;
         }
 
         /// <summary>

--- a/src/tools/wix/BinderFileManager.cs
+++ b/src/tools/wix/BinderFileManager.cs
@@ -68,6 +68,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
         private SubStorage activeSubstorage;
         private bool deltaBinaryPatch;
         private string tempFilesLocation;
+        private bool suppressHardLinks;
         private Dictionary<BindStage, StringCollection> sourcePaths;
         private Dictionary<BindStage, StringCollection> bindPaths;
         private Dictionary<BindStage, NameValueCollection> namedBindPaths;
@@ -186,6 +187,16 @@ namespace Microsoft.Tools.WindowsInstallerXml
         {
             get { return this.tempFilesLocation; }
             set { this.tempFilesLocation = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the option to suppress hard links during build.
+        /// </summary>
+        /// <value>The option to suppress hard links during build.</value>
+        public bool SuppressHardLinks
+        {
+            get { return this.suppressHardLinks; }
+            set { this.suppressHardLinks = value; }
         }
 
         /// <summary>
@@ -622,10 +633,13 @@ namespace Microsoft.Tools.WindowsInstallerXml
                 File.Delete(destination);
             }
 
-            if (!CreateHardLink(destination, source, IntPtr.Zero))
+            if (this.suppressHardLinks || !CreateHardLink(destination, source, IntPtr.Zero))
             {
 #if DEBUG
-                int er = Marshal.GetLastWin32Error();
+                if (!this.suppressHardLinks)
+                {
+                    int er = Marshal.GetLastWin32Error();
+                }
 #endif
 
                 File.Copy(source, destination, overwrite);

--- a/src/tools/wix/WixStrings.resx
+++ b/src/tools/wix/WixStrings.resx
@@ -277,36 +277,38 @@
     <value>warning</value>
   </data>
   <data name="BinderArguments" xml:space="preserve">
-    <value>   -bcgg      use backwards compatible guid generation algorithm
-              (almost never needed)
-   -cc &lt;path&gt; path to cache built cabinets (will not be deleted after linking)
-   -ct &lt;N&gt;    number of threads to use when creating cabinets
-              (default: %NUMBER_OF_PROCESSORS%)
-   -cub &lt;file.cub&gt; additional .cub file containing ICEs to run
-   -dcl:level set default cabinet compression level
-              (low, medium, high, none, mszip; mszip default)
-   -eav       exact assembly versions (breaks .NET 1.1 RTM compatibility)
-   -fv        add a 'fileVersion' entry to the MsiAssemblyName table
-              (rarely needed)
+    <value>   -bcgg        use backwards compatible guid generation algorithm
+                (almost never needed)
+   -cc &lt;path&gt;   path to cache built cabinets (will not be deleted after linking)
+   -ct &lt;N&gt;      number of threads to use when creating cabinets
+                (default: %NUMBER_OF_PROCESSORS%)
+   -cub &lt;file.cub&gt;  additional .cub file containing ICEs to run
+   -dcl:level   set default cabinet compression level
+                (low, medium, high, none, mszip; mszip default)
+   -eav         exact assembly versions (breaks .NET 1.1 RTM compatibility)
+   -fv          add a 'fileVersion' entry to the MsiAssemblyName table
+                (rarely needed)
    -ice:&lt;ICE&gt;   run a specific internal consistency evaluator (ICE)
-   -O1        optimize smart cabbing for smallest cabinets (deprecated)
-   -O2        optimize smart cabbing for faster install time (deprecated)
+   -O1          optimize smart cabbing for smallest cabinets (deprecated)
+   -O2          optimize smart cabbing for faster install time (deprecated)
    -pdbout &lt;output.wixpdb&gt;  save the WixPdb to a specific file
-              (default: same name as output with wixpdb extension)
-   -reusecab  reuse cabinets from cabinet cache
-   -sa        suppress assemblies: do not get assembly name information
-              for assemblies
-   -sacl      suppress resetting ACLs
-              (useful when laying out image to a network share)
-   -sf        suppress files: do not get any file information
-              (equivalent to -sa and -sh)
-   -sh        suppress file info: do not get hash, version, language, etc
+                (default: same name as output with wixpdb extension)
+   -reusecab    reuse cabinets from cabinet cache
+   -sa          suppress assemblies: do not get assembly name information
+                for assemblies
+   -sacl        suppress resetting ACLs
+                (useful when laying out image to a network share)
+   -sf          suppress files: do not get any file information
+                (equivalent to -sa and -sh)
+   -sh          suppress file info: do not get hash, version, language, etc
+   -shardlinks  suppress creating hardlinks for files during build,
+                always copy.
    -sice:&lt;ICE&gt;  suppress an internal consistency evaluator (ICE)
-   -sl        suppress layout
-   -spdb      suppress outputting the WixPdb
-   -spsd      suppress patch sequence data in patch XML to decrease bundle
-              size and increase patch applicability performance
-              (patch packages themselves are not modified)
-   -sval      suppress MSI/MSM validation</value>
+   -sl          suppress layout
+   -spdb        suppress outputting the WixPdb
+   -spsd        suppress patch sequence data in patch XML to decrease bundle
+                size and increase patch applicability performance
+                (patch packages themselves are not modified)
+   -sval        suppress MSI/MSM validation</value>
   </data>
 </root>


### PR DESCRIPTION
This option would force WiX toolset to copy the output instead of just creating hard links to the built components.

A use-case where this is useful is in a build system where there's a file cache in place, so the output (without the suppression, the hard link) is saved on it. This means that when a component is rebuilt, the file projected by those hard links seem to be edited as well, poisoning the cache.