### PR TITLE
Fix crashing bug in finalizer

### DIFF
--- a/src/DTF/Libraries/Compression.Cab/CabPacker.cs
+++ b/src/DTF/Libraries/Compression.Cab/CabPacker.cs
@@ -424,13 +424,11 @@ namespace Microsoft.Deployment.Compression.Cab
         {
             try
             {
-                if (disposing)
+                // See comment in CabUnpacker.Dispose for more info.
+                if (this.fciHandle != null)
                 {
-                    if (this.fciHandle != null)
-                    {
-                        this.fciHandle.Dispose();
-                        this.fciHandle = null;
-                    }
+                    this.fciHandle.Dispose();
+                    this.fciHandle = null;
                 }
             }
             finally

--- a/src/DTF/Libraries/Compression.Cab/CabUnpacker.cs
+++ b/src/DTF/Libraries/Compression.Cab/CabUnpacker.cs
@@ -324,13 +324,15 @@ namespace Microsoft.Deployment.Compression.Cab
         {
             try
             {
-                if (disposing)
+                // While fdiHandle is a SafeHandle, it will callback to C# method from this instance
+                // when releasing handle, and since finalizers execute in nondeterministic order, if
+                // the handle's finalizer runs after this instance, it will get exception and crash
+                // the process. Therefore we must release this handle regardless of the 'disposing'
+                // flag.
+                if (this.fdiHandle != null)
                 {
-                    if (this.fdiHandle != null)
-                    {
-                        this.fdiHandle.Dispose();
-                        this.fdiHandle = null;
-                    }
+                    this.fdiHandle.Dispose();
+                    this.fdiHandle = null;
                 }
             }
             finally


### PR DESCRIPTION
CabUnpacker and CabPacker uses a SafeHandle that will callback to C# method when releasing handle. If we don't release the handle in their finalizers, since finalizers from different classes run in nondeterministic orders, this will cause intermittent crash.

Reproducing code:

      private async void button1_Click(object sender, EventArgs e)
      {
         button1.Enabled = false;
         var file = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "small.cab");
         var tasks = Enumerable.Range(0, 1000).Select(_ =>
         {
            return Task.Run(() => TestCab(file));
         });
         await Task.WhenAll(tasks);
         button1.Enabled = true;
      }

      static void TestCab(string file)
      {
         var cab = new CabInfo(file);
         foreach (var fi in cab.GetFiles())
         {
            var sr = new BinaryReader(fi.OpenRead());
            sr.ReadByte();
         }
      }

# WiX v3.x pull requests

Active development has now moved to [WiX v4][wix4].

* **Pull requests for new features are extremely unlikely to be accepted for WiX v3.x.**
* Pull requests for important bug fixes might be accepted.

Pull requests for WiX v3.x must be approved before they can be reviewed or accepted.

* If an [issue][issue] doesn't exist for the problem, create one.
* Provide lots of detail so someone just reading the issue can get a good understanding of the problem.
* If possible, attend the biweekly (fortnightly) online meeting for discussion. Meetings are announced on the [wix-devs mailing list][wixdevs].


[issue]: https://github.com/wixtoolset/issues/issues
[wix4]: https://github.com/wixtoolset/wix4
[wixdevs]: http://wixtoolset.org/documentation/mailinglist/