### PR TITLE
Fix RemoveRegistryValue docs

### DIFF
--- a/src/tools/wix/Xsd/wix.xsd
+++ b/src/tools/wix/Xsd/wix.xsd
@@ -5404,8 +5404,6 @@
         <xs:annotation>
           <xs:documentation>
                         The localizable key for the registry value.
-                        If the parent element is a RegistryKey, this value may be omitted to use the
-                        path of the parent, or if its specified it will be appended to the path of the parent.
                     </xs:documentation>
         </xs:annotation>
       </xs:attribute>


### PR DESCRIPTION
The documentation for the Key attribute incorrectly claimed that the element
could appear inside a RegistryKey element.

wixtoolset/issues#5777