### PR TITLE
Fix DependencyDetectProviderKeyPackageId to return on first GetProvid…

### DIFF
--- a/src/burn/engine/dependency.cpp
+++ b/src/burn/engine/dependency.cpp
@@ -188,6 +188,8 @@ extern "C" HRESULT DependencyDetectProviderKeyPackageId(
             continue;
         }
         ExitOnFailure(hr, "Failed to get the package provider information.");
+
+        ExitFunction();
     }
 
     // Older bundles may not have written the id so try the default.

--- a/src/burn/engine/dependency.cpp
+++ b/src/burn/engine/dependency.cpp
@@ -188,11 +188,6 @@ extern "C" HRESULT DependencyDetectProviderKeyPackageId(
             continue;
         }
         ExitOnFailure(hr, "Failed to get the package provider information.");
-
-        if (psczId && *psczId)
-        {
-            ExitFunction();
-        }
     }
 
     // Older bundles may not have written the id so try the default.

--- a/src/burn/engine/dependency.cpp
+++ b/src/burn/engine/dependency.cpp
@@ -188,6 +188,11 @@ extern "C" HRESULT DependencyDetectProviderKeyPackageId(
             continue;
         }
         ExitOnFailure(hr, "Failed to get the package provider information.");
+
+        if (psczId && *psczId)
+        {
+            ExitFunction();
+        }
     }
 
     // Older bundles may not have written the id so try the default.


### PR DESCRIPTION
DependencyDetectProviderKeyPackageId was incorrectly refactored in a448a60ec8fe428058cc3ac01aeae1175b1d6402 to no longer return success after finding the first provider key. This results in incorrect provider behavior if there are multiple provider keys and the target one is not last.

This PR fixes the issue.