### PR TITLE
How to install a windows service

### DIFF
--- a/src/chm/documents/howtos/general/index.html.md
+++ b/src/chm/documents/howtos/general/index.html.md
@@ -9,4 +9,7 @@ This section includes guides to general topics such as debugging and logging ins
 * [How To: Get a log of your installation for debugging](get_a_log.html)
 * [How To: Look inside your MSI with Orca](look_inside_msi.html)
 * [How To: Generate a GUID](generate_guids.html)
+* [How To: Use WiX Extensions](extension_usage_introduction.html)
+* [How To: Optimize build speed](optimizing_builds.html)
+* [How To: Specify source files](specifying_source_files.html)
 

--- a/src/chm/documents/howtos/general/index.html.md
+++ b/src/chm/documents/howtos/general/index.html.md
@@ -12,4 +12,4 @@ This section includes guides to general topics such as debugging and logging ins
 * [How To: Use WiX Extensions](extension_usage_introduction.html)
 * [How To: Optimize build speed](optimizing_builds.html)
 * [How To: Specify source files](specifying_source_files.html)
-
+* [How To: Install a windows service](install_windows_service.html)

--- a/src/chm/documents/howtos/general/install_windows_service.html.md
+++ b/src/chm/documents/howtos/general/install_windows_service.html.md
@@ -1,0 +1,43 @@
+---
+title: How To: Install a windows service
+layout: documentation
+---
+# How To: Install a windows service
+To install a Windows service, you use the [&lt;ServiceInstall&gt;](./../../xsd/wix/serviceinstall.html) element from the Wix schema.
+Fine-tuned configuration can be made using the [&lt;ServiceControl&gt;](./../../xsd/wix/servicecontrol.html) element, and the &lt;ServiceConfig&gt;
+elements from the Wix and Util schema.
+
+## Step 1: Add the &lt;ServiceInstall&gt; element to Product.wxs
+Your main XML file, normally named Product.wxs, should include a &lt;ServiceInstall&gt; element with the basic information about the service to install.
+This element should be the child of a [&lt;Component&gt;](./../../xsd/wix/component.html). It is most useful to use the &lt;Component&gt; representing
+the service executable file as the parent.
+
+In the &lt;ServiceInstall&gt; you define various attributes of the service, as explained in the element's documentation.
+
+**Tip:** to specify a system account, such as LocalService or NetworkService, use the prefix "NT AUTHORITY", e.g. use the value `NT AUTHORITY\LocalService`
+as the `Account` attribute value, to make the service run under this account.
+
+## Step 2: Configure service failure actions (Optional)
+Using the [&lt;ServiceConfig&gt;](./../../xsd/util/serviceconfig.html) element in the `util` schema, you can configure how the service behaves if it
+fails. To use it, first, [include](extension_usage_introduction.html#using-wix-extensions-in-visual-studio) the [util](./../../xsd/util/index.html)
+schema in your XML file, and prefix the element name with the `util` prefix:
+
+    <ServiceInstall>
+        <util:ServiceConfig FirstFailureActionType="restart"
+                            SecondFailureActionType="restart"
+                            ThirdFailureActionType="restart" /> 
+    </ServiceInstall>
+
+## Step 3: Configure additional options (Optional)
+Using the [&lt;ServiceConfig&gt;](./../../xsd/wix/serviceconfig.html) element in the `wix` schema, You can configure additional settings, such as
+DelayedAutoStart, or whether to configure the service when installing, reinstalling or uninstalling the installer. Wix is the default schema
+name in Wix Toolkit, and need not be included explicitly to be used. Its parent element is &lt;Component&gt; or &lt;ServiceInstall&gt;, so it can be
+added along side the above &lt;util:ServiceConfig&gt;:
+
+    <ServiceInstall>
+        <util:ServiceConfig FirstFailureActionType="restart"
+                            SecondFailureActionType="restart"
+                            ThirdFailureActionType="restart" />
+        <ServiceConfig DelayedAutoStart="yes"
+                       OnInstall="yes" /> 
+    </ServiceInstall>

--- a/src/chm/documents/howtos/index.html.md
+++ b/src/chm/documents/howtos/index.html.md
@@ -47,3 +47,4 @@ This section includes How To documentation for performing common WiX tasks.
 * [Use WiX Extensions](general/extension_usage_introduction.html)
 * [Optimize building cabinet files](general/optimizing_builds.html)
 * [Specify source file locations](general/specifying_source_files.html)
+* [Install a windows service](general/install_windows_service.html)


### PR DESCRIPTION
This pull requests adds a tutorial on how to install a Windows service, which is a common task for an installer, yet there is no guide on how to achieve it in the documentation.

It also adds some missing links in the  src/chm/documents/howtos/general/index.html.md file.

see wixtoolset/issues#5840 for more details.