### PR TITLE
WIXBUG:5711 - Remove last reference to .NET 2.0 assembly

### DIFF
--- a/history/5711.md
+++ b/history/5711.md
@@ -1,0 +1,1 @@
+* SeanHall: WIXBUG:5711 - Remove last remaining reference to .NET 2.0 assembly

--- a/src/ext/VSExtension/wixext/WixVSExtension.csproj
+++ b/src/ext/VSExtension/wixext/WixVSExtension.csproj
@@ -38,7 +38,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.Build.Framework" />
-    <Reference Include="Microsoft.Build.Utilities" />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <ProjectReference Include="..\..\..\tools\Wix\Wix.csproj" />

--- a/src/ext/lux/tasks/LuxTasks.csproj
+++ b/src/ext/lux/tasks/LuxTasks.csproj
@@ -31,7 +31,7 @@
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.Build.Framework" />
-    <Reference Include="Microsoft.Build.Utilities" />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <ProjectReference Include="..\..\..\tools\wix\Wix.csproj" />
     <ProjectReference Include="..\..\..\tools\WixTasks\WixTasks.csproj" />
     <ProjectReference Include="..\wixext\WixLuxExtension.csproj" />

--- a/src/tools/WixTasks/WixTasks.csproj
+++ b/src/tools/WixTasks/WixTasks.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
 
@@ -67,7 +67,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="Microsoft.Build.Framework" />
-    <Reference Include="Microsoft.Build.Utilities" />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <ProjectReference Include="..\..\dtf\Libraries\WindowsInstaller\WindowsInstaller.csproj" />

--- a/tools/src/WixBuild/WixBuild.csproj
+++ b/tools/src/WixBuild/WixBuild.csproj
@@ -19,7 +19,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="Microsoft.Build.Framework" />
-    <Reference Include="Microsoft.Build.Utilities" />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), wix.proj))\tools\WixBuild.targets" />
   <Import Project="$(LibGit2SharpPropsFilePath)" />


### PR DESCRIPTION
Reference Microsoft.Build.Utilities.v4.0 instead of Microsoft.Build.Utilities.

Fixes https://github.com/wixtoolset/issues/issues/5711