### PR TITLE
Update documentation to include  CNDL1150 warning

### DIFF
--- a/src/tools/wix/Xsd/wix.xsd
+++ b/src/tools/wix/Xsd/wix.xsd
@@ -6977,6 +6977,10 @@
             </xs:documentation>
       <xs:appinfo>
         <xse:msiRef table="MsiServiceConfig" href="http://msdn.microsoft.com/library/aa371637.aspx" />
+	<xse:remarks>
+	  <html:p>MsiServiceConfig functionality is documented in the Windows Installer SDK to "not [work] as expected." Consider using
+	  the WixUtilExtension ServiceConfig instead.</html:p>
+        </xse:remarks>
       </xs:appinfo>
     </xs:annotation>
     <xs:complexType>


### PR DESCRIPTION
This imports the [1150 error](https://github.com/wixtoolset/wix3/commit/e8504c54e4cd186f676931e1d39a6e8400e575b8) error message into the documentation. I tried to follow local style for where in the xml this lives. 

Fixes https://github.com/wixtoolset/issues/issues/5964