### PR TITLE
Sign binaries redistrubted with customers' bundles

### DIFF
--- a/src/DTF/Libraries/Compression.Cab/Compression.Cab.csproj
+++ b/src/DTF/Libraries/Compression.Cab/Compression.Cab.csproj
@@ -12,6 +12,7 @@
     <CreateDocumentationFile>true</CreateDocumentationFile>
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <FxCopEnabled>false</FxCopEnabled>
+    <ShouldSignOutput>true</ShouldSignOutput>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DTF/Libraries/Compression.Zip/Compression.Zip.csproj
+++ b/src/DTF/Libraries/Compression.Zip/Compression.Zip.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>Microsoft.Deployment.Compression.Zip</AssemblyName>
     <CreateDocumentationFile>true</CreateDocumentationFile>
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <ShouldSignOutput>true</ShouldSignOutput>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DTF/Libraries/Compression/Compression.csproj
+++ b/src/DTF/Libraries/Compression/Compression.csproj
@@ -12,6 +12,7 @@
     <CreateDocumentationFile>true</CreateDocumentationFile>
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <FxCopEnabled>false</FxCopEnabled>
+    <ShouldSignOutput>true</ShouldSignOutput>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DTF/Libraries/Resources/Resources.csproj
+++ b/src/DTF/Libraries/Resources/Resources.csproj
@@ -10,6 +10,7 @@
     <AssemblyName>Microsoft.Deployment.Resources</AssemblyName>
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <CreateDocumentationFile>true</CreateDocumentationFile>
+    <ShouldSignOutput>true</ShouldSignOutput>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DTF/Libraries/WindowsInstaller.Linq/WindowsInstaller.Linq.csproj
+++ b/src/DTF/Libraries/WindowsInstaller.Linq/WindowsInstaller.Linq.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>Microsoft.Deployment.WindowsInstaller.Linq</AssemblyName>
     <CreateDocumentationFile>true</CreateDocumentationFile>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <ShouldSignOutput>true</ShouldSignOutput>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DTF/Libraries/WindowsInstaller.Package/WindowsInstaller.Package.csproj
+++ b/src/DTF/Libraries/WindowsInstaller.Package/WindowsInstaller.Package.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>Microsoft.Deployment.WindowsInstaller.Package</AssemblyName>
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <CreateDocumentationFile>true</CreateDocumentationFile>
+    <ShouldSignOutput>true</ShouldSignOutput>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DTF/Libraries/WindowsInstaller/WindowsInstaller.csproj
+++ b/src/DTF/Libraries/WindowsInstaller/WindowsInstaller.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>Microsoft.Deployment.WindowsInstaller</AssemblyName>
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <CreateDocumentationFile>true</CreateDocumentationFile>
+    <ShouldSignOutput>true</ShouldSignOutput>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DTF/Tools/SfxCA/SfxCA.vcxproj
+++ b/src/DTF/Tools/SfxCA/SfxCA.vcxproj
@@ -30,6 +30,7 @@
     <TargetName>SfxCA</TargetName>
     <CharacterSet>Unicode</CharacterSet>
     <ProjectModuleDefinitionFile>EntryPoints.def</ProjectModuleDefinitionFile>
+    <ShouldSignOutput>true</ShouldSignOutput>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), wix.proj))\tools\WixBuild.props" />

--- a/src/ext/BalExtension/mba/core/core.csproj
+++ b/src/ext/BalExtension/mba/core/core.csproj
@@ -14,7 +14,7 @@
     <CreateDocumentationFile>true</CreateDocumentationFile>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <FxCopEnabled>true</FxCopEnabled>
-    <SignOutput Condition="'$(PleaseSignOutput)'!=''">true</SignOutput>
+    <ShouldSignOutput>true</ShouldSignOutput>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ext/BalExtension/mba/core/core.csproj
+++ b/src/ext/BalExtension/mba/core/core.csproj
@@ -14,6 +14,7 @@
     <CreateDocumentationFile>true</CreateDocumentationFile>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <FxCopEnabled>true</FxCopEnabled>
+    <SignOutput Condition="'$(PleaseSignOutput)'!=''">true</SignOutput>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/Dotnet.targets
+++ b/tools/Dotnet.targets
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+
+
+<Project InitialTargets="DotnetToolRestore" 
+  xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <WixRoot Condition=" '$(WixRoot)'=='' ">$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)..\))</WixRoot>
+    <DotnetToolsFolder>$(WixRoot)packages\tools\</DotnetToolsFolder>
+    <DotnetExe>$(ProgramW6432)\dotnet\dotnet.exe</DotnetExe>
+    <DotnetExe Condition="!Exists('$(DotnetExe)')">$(MSBuildProgramFiles32)\dotnet\dotnet.exe</DotnetExe>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SignClientPath>$(DotnetToolsFolder)SignClient.exe</SignClientPath>
+  </PropertyGroup>
+
+  <!--
+  ================================================================================================
+  DotnetToolRestore
+
+    Restores the required packages to build using nuget.exe.
+  ================================================================================================
+  -->
+  <ItemGroup>
+    <RestoreDotnetToolsPackage Include="SignClient" Condition="'$(PleaseSignOutput)'!=''">
+      <Version>1.1.7</Version>
+    </RestoreDotnetToolsPackage>
+  </ItemGroup>
+  <Target Name="DotnetToolRestore" DependsOnTargets="_FindDotnetExe;_FindMissingDotnetToolPackages">
+    <Exec Command="&quot;$(DotnetExe)&quot; tool install %(Identity) --version %(Version) --tool-path &quot;$(DotnetToolsFolder)\&quot;" Condition="Exists('$(DotnetExe)') and '@(_MissingDotnetToolPackage)'!=''" WorkingDirectory="$(MSBuildThisFileDirectory)" />
+  </Target>
+
+  <Target Name="_FindMissingDotnetToolPackages">
+    <CreateItem Include="@(RestoreDotnetToolsPackage)" Condition="!Exists('$(DotnetToolsFolder).store\%(Identity)\%(Version)\%(Identity)\%(Version)\%(Identity).%(Version).nupkg')" PreserveExistingMetadata="true">
+      <Output TaskParameter="Include" ItemName="_MissingDotnetToolPackage"/>
+    </CreateItem>
+  </Target>
+
+  <!-- Find dotnet.exe in the PATH if it is not in the default location. -->
+  <Target Name="_FindDotnetExe" Condition="!Exists('$(DotnetExe)')">
+    <CreateItem Include="$(PATH)">
+      <Output TaskParameter="Include" ItemName="_FindDotnetExePaths" />
+    </CreateItem>
+    <CombinePath BasePath="%(_FindDotnetExePaths.Identity)" Paths="dotnet.exe">
+      <Output TaskParameter="CombinedPaths" ItemName="_FindDotnetExeCombinedPaths" />
+    </CombinePath>
+    <CreateItem Include="@(_FindDotnetExeCombinedPaths->Reverse())">
+      <Output TaskParameter="Include" ItemName="_FindDotnetExeCombinedPathsReversed" />
+    </CreateItem>
+    <CreateItem Include="@(_FindDotnetExeCombinedPathsReversed)">
+      <Output TaskParameter="Include" PropertyName="DotnetExe" Condition="Exists('%(_FindDotnetExeCombinedPathsReversed.Identity)')" />
+    </CreateItem>
+  </Target>
+
+  <!-- Sentinel value that indicates Dotnet.targets has been initialized. -->
+  <PropertyGroup>
+    <WixBuildDotnetToolPropertiesDefined>true</WixBuildDotnetToolPropertiesDefined>
+  </PropertyGroup>
+</Project>

--- a/tools/WixBuild.Signing.targets
+++ b/tools/WixBuild.Signing.targets
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+
+
+<Project InitialTargets="DotnetToolRestore" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <!-- Ensure that the SignClient is initialized. -->
+  <Import Project="Dotnet.targets" Condition="'$(WixBuildDotnetToolPropertiesDefined)'!='true'" />
+
+  <PropertyGroup>
+    <_SigningAppSettingsPath>$(MSBuildThisFileDirectory)appsettings.json</_SigningAppSettingsPath>
+    <_SigningFilterNonePath>$(MSBuildThisFileDirectory)signing-filter.none.txt</_SigningFilterNonePath>
+    <_SigningName>WiX Toolset</_SigningName>
+    <_SigningUrl>http://wixtoolset.org</_SigningUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- By default, $(TargetPath) will be signed. You can add files to @(FilesToSign) to sign them as well. -->
+    <FilesToSign Include="$(TargetPath)" />
+  </ItemGroup>
+
+  <Target Name="SignFiles" AfterTargets="AfterBuild" Condition="'$(SignOutput)'=='true'">
+    <Exec Command="&quot;$(SignClientPath)&quot; sign -c &quot;$(_SigningAppSettingsPath)&quot; -i &quot;%(FilesToSign.FullPath)&quot; -f &quot;$(_SigningFilterNonePath)&quot; -s &quot;$(SignClientSecret)&quot; -r &quot;$(SignClientUser)&quot; -n &quot;$(_SigningName)&quot; -d &quot;$(_SigningName)&quot; -u &quot;$(_SigningUrl)&quot;" />
+  </Target>
+
+  <!--
+  ================================================================================================
+
+    Signing overrides to actually do signing. We don't sign the MSI packages or their CABs because
+    they are always wrapped in a bundle that is signed.
+
+  ================================================================================================
+  -->
+  <Target Name="SignCabs">
+    <!-- <Exec Command="&quot;$(SignClientPath)&quot; sign -c &quot;$(_SigningAppSettingsPath)&quot; -i &quot;%(SignCabs.FullPath)&quot; -f &quot;$(_SigningFilterNonePath)&quot; -s &quot;$(SignClientSecret)&quot; -r &quot;$(SignClientUser)&quot; -n &quot;$(_SigningName)&quot; -d &quot;$(_SigningName)&quot; -u &quot;$(_SigningUrl)&quot;" /> -->
+  </Target>
+
+  <Target Name="SignMsi">
+    <!-- <Exec Command="&quot;$(SignClientPath)&quot; sign -c &quot;$(_SigningAppSettingsPath)&quot; -i &quot;%(SignMsi.FullPath)&quot; -f &quot;$(_SigningFilterNonePath)&quot; -s &quot;$(SignClientSecret)&quot; -r &quot;$(SignClientUser)&quot; -n &quot;$(_SigningName)&quot; -d &quot;$(_SigningName)&quot; -u &quot;$(_SigningUrl)&quot;" /> -->
+  </Target>
+
+  <Target Name="SignContainers">
+    <Exec Command="&quot;$(SignClientPath)&quot; sign -c &quot;$(_SigningAppSettingsPath)&quot; -i &quot;%(SignContainers.FullPath)&quot; -f &quot;$(_SigningFilterNonePath)&quot; -s &quot;$(SignClientSecret)&quot; -r &quot;$(SignClientUser)&quot; -n &quot;$(_SigningName)&quot; -d &quot;$(_SigningName)&quot; -u &quot;$(_SigningUrl)&quot;" />
+  </Target>
+
+  <Target Name="SignBundleEngine">
+    <Exec Command="&quot;$(SignClientPath)&quot; sign -c &quot;$(_SigningAppSettingsPath)&quot; -i &quot;%(SignBundleEngine.FullPath)&quot; -f &quot;$(_SigningFilterNonePath)&quot; -s &quot;$(SignClientSecret)&quot; -r &quot;$(SignClientUser)&quot; -n &quot;$(_SigningName)&quot; -d &quot;$(_SigningName)&quot; -u &quot;$(_SigningUrl)&quot;" />
+  </Target>
+
+  <Target Name="SignBundle">
+    <Exec Command="&quot;$(SignClientPath)&quot; sign -c &quot;$(_SigningAppSettingsPath)&quot; -i &quot;%(SignBundle.FullPath)&quot; -f &quot;$(_SigningFilterNonePath)&quot; -s &quot;$(SignClientSecret)&quot; -r &quot;$(SignClientUser)&quot; -n &quot;$(_SigningName)&quot; -d &quot;$(_SigningName)&quot; -u &quot;$(_SigningUrl)&quot;" />
+  </Target>
+
+  <!-- Sentinel value that indicates WixBuid.Signing.targets has been initialized. -->
+  <PropertyGroup>
+    <WixBuildSigningTargetsDefined>true</WixBuildSigningTargetsDefined>
+  </PropertyGroup>
+</Project>

--- a/tools/WixBuild.Tools.targets
+++ b/tools/WixBuild.Tools.targets
@@ -15,6 +15,9 @@
   <!-- Steal some tasks from the MSBuild tasks assembly -->
   <UsingTask TaskName="AssignTargetPath" AssemblyName="Microsoft.Build.Tasks, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 
+  <!-- Ensure Signing targets are imported. -->
+  <Import Project="WixBuild.Signing.targets" Condition="'$(WixBuildSigningTargetsDefined)'!='true'" />
+
   <!--
   ================================================================================================
   Diagnostics
@@ -119,6 +122,16 @@
       Code="WIXBUILD013"
       Condition=" $(BuildArm) and !(Exists('$(PlatformSdkArmLibraryRoot)')) "
       Text="No suitable Windows SDK found to build ARM" />
+
+    <Error
+      Code="WIXBUILD014"
+      Condition=" '$(PleaseSignOutput)'!='' and !Exists('$(SignClientPath)') "
+      Text="Cannot locate SignClient. Ensure SignClient is present at &quot;$(SignClientPath)&quot;. If not, run the following command from the root of the project: msbuild -t:DotnetToolRestore" />
+
+    <Error
+      Code="WIXBUILD015"
+      Condition=" '$(PleaseSignOutput)'!='' and ('$(SignClientUser)'=='' or '$(SignClientSecret)'=='') "
+      Text="Signing is requested but one or both required properites SignClientUser and SignClientSecret were not specified on the command line or as environment variables." />
 
   </Target>
 

--- a/tools/WixBuild.csproj.targets
+++ b/tools/WixBuild.csproj.targets
@@ -11,5 +11,6 @@
       $(PrepareForBuildDependsOn);
       WriteCSharpVersionFile
     </PrepareForBuildDependsOn>
+    <SignOutput Condition="'$(SignOutput)'=='' and '$(ShouldSignOutput)'=='true' and '$(PleaseSignOutput)'!=''">true</SignOutput>
   </PropertyGroup>
 </Project>

--- a/tools/WixBuild.props
+++ b/tools/WixBuild.props
@@ -30,6 +30,7 @@
   </PropertyGroup>
 
   <Import Project="Nuget.targets" />
+  <Import Project="Dotnet.targets" />
 
   <!-- Converts the VS-standard Debug and Release to the wix-standard debug and ship -->
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' or '$(Configuration)' == '' or '$(WixFlavor)' == 'debug' ">

--- a/tools/WixBuild.targets
+++ b/tools/WixBuild.targets
@@ -6,6 +6,7 @@
 
   <Import Project="WixBuild.props" Condition=" '$(WixBuildPropertiesDefined)'!='true' " />
   <Import Project="WixBuild$(MSBuildProjectExtension).targets" Condition=" Exists('WixBuild$(MSBuildProjectExtension).targets') " />
+  <Import Project="WixBuild.Signing.targets" />
   <Import Project="WixBuild.Tools.targets" />
   <Import Project="WixBuild.VisualStudioSdk.targets" Condition=" '$(TargetVisualStudio)'!='' " />
 

--- a/tools/WixBuild.vcxproj.props
+++ b/tools/WixBuild.vcxproj.props
@@ -48,6 +48,7 @@
     <OutDir Condition=" '$(MultiTargetLibrary)'=='true' ">$(OutDir)$(MultiTargetDirSuffix)\</OutDir>
 
     <AdditionalMultiTargetLibraryPath Condition=" '$(MultiTargetLibrary)'!='true' ">$(OutputPath)$(MultiTargetDirSuffix)\</AdditionalMultiTargetLibraryPath>
+    <SignOutput Condition="'$(PleaseSignOutput)'!='' and $(MSBuildProjectDirectory.Contains('\src\ext\')) and '$(ConfigurationType)'=='DynamicLibrary'">true</SignOutput>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tools/WixBuild.vcxproj.props
+++ b/tools/WixBuild.vcxproj.props
@@ -48,7 +48,7 @@
     <OutDir Condition=" '$(MultiTargetLibrary)'=='true' ">$(OutDir)$(MultiTargetDirSuffix)\</OutDir>
 
     <AdditionalMultiTargetLibraryPath Condition=" '$(MultiTargetLibrary)'!='true' ">$(OutputPath)$(MultiTargetDirSuffix)\</AdditionalMultiTargetLibraryPath>
-    <SignOutput Condition="'$(PleaseSignOutput)'!='' and $(MSBuildProjectDirectory.Contains('\src\ext\')) and '$(ConfigurationType)'=='DynamicLibrary'">true</SignOutput>
+    <ShouldSignOutput Condition="$(MSBuildProjectDirectory.Contains('\src\ext\')) and '$(ConfigurationType)'=='DynamicLibrary'">true</ShouldSignOutput>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tools/WixBuild.vcxproj.targets
+++ b/tools/WixBuild.vcxproj.targets
@@ -11,5 +11,6 @@
       WriteCppVersionFile;
       GenerateWixInclude
     </PrepareForBuildDependsOn>
+    <SignOutput Condition="'$(SignOutput)'=='' and '$(ShouldSignOutput)'=='true' and '$(PleaseSignOutput)'!=''">true</SignOutput>
   </PropertyGroup>
 </Project>

--- a/tools/WixBuild.wixproj.targets
+++ b/tools/WixBuild.wixproj.targets
@@ -3,40 +3,7 @@
 
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
-  <PropertyGroup>
-    <SignToolExe>&quot;$(PlatformSdkBinPath)signtool.exe&quot;</SignToolExe>
-  </PropertyGroup>
-
   <Import Project="$(WixTargetsPath)" />
-
-  <!-- Signing overrides to actually do signing -->
-  <!--
-    We don't sign the Msi Packages or their cabinets because they are
-    always wrapped in a bundle that is signed.
-  -->
-  <Target Name="SignCabs">
-  <!--
-    <Exec Command="$(SignToolExe) sign /n &quot;.NET Foundation&quot; /t http://timestamp.digicert.com &quot;%(SignCabs.FullPath)&quot;" />
-  -->
-  </Target>
-
-  <Target Name="SignMsi">
-  <!--
-    <Exec Command="$(SignToolExe) sign /n &quot;.NET Foundation&quot; /t http://timestamp.digicert.com &quot;%(SignMsi.FullPath)&quot;" />
-  -->
-  </Target>
-
-  <Target Name="SignContainers">
-    <Exec Command="$(SignToolExe) sign /n &quot;.NET Foundation&quot; /t http://timestamp.digicert.com &quot;%(SignContainers.FullPath)&quot;" />
-  </Target>
-
-  <Target Name="SignBundleEngine">
-    <Exec Command="$(SignToolExe) sign /n &quot;.NET Foundation&quot; /t http://timestamp.digicert.com &quot;%(SignBundleEngine.FullPath)&quot;" />
-  </Target>
-
-  <Target Name="SignBundle">
-    <Exec Command="$(SignToolExe) sign /n &quot;.NET Foundation&quot; /t http://timestamp.digicert.com &quot;%(SignBundle.FullPath)&quot;" />
-  </Target>
 
   <PropertyGroup>
     <PrepareForBuildDependsOn>

--- a/tools/appsettings.json
+++ b/tools/appsettings.json
@@ -1,0 +1,13 @@
+{
+  "SignClient": {
+    "AzureAd": {
+      "AADInstance": "https://login.microsoftonline.com/",
+      "ClientId": "c248d68a-ba6f-4aa9-8a68-71fe872063f8",
+      "TenantId": "16076fdc-fcc1-4a15-b1ca-32c9a255900e"
+    },
+    "Service": {
+      "Url": "https://codesign.dotnetfoundation.org/",
+      "ResourceId": "https://SignService/3c30251f-36f3-490b-a955-520addb85001"
+    }
+  }
+}

--- a/tools/signing-filter.none.txt
+++ b/tools/signing-filter.none.txt
@@ -1,0 +1,1 @@
+sign-no-files


### PR DESCRIPTION
Fixes wixtoolset/issues#5329. Only managed and native binaries that would ship within bundles are signed when requested.