### PR TITLE
Add support for Visual Studio 2019

### DIFF
--- a/src/chm/documents/customactions/wixvsextension.html.md
+++ b/src/chm/documents/customactions/wixvsextension.html.md
@@ -16,6 +16,7 @@ The [WixVSExtension](~/xsd/vs/index.html) includes a set of custom actions to ma
   * [Visual Studio 2013](#vs2013properties)
   * [Visual Studio 2015](#vs2015properties)
   * [Visual Studio 2017](#vs2017properties)
+  * [Visual Studio 2019](#vs2019properties)
 * [Custom Actions](#allcustomactions)
 
 ## <a name="allproperties"></a> Properties
@@ -1236,6 +1237,139 @@ Here is a complete list of properties for the <a name="vs2017properties">**Visua
   </tr>
 </table>
 
+Here is a complete list of properties for the <a name="VS2019properties">**Visual Studio 2019**</a> product family:
+
+<table cellspacing="0" cellpadding="4" class="style1" border="1">
+    <tr>
+    <td valign="top">
+      <p><b>Property name</b></p>
+    </td>
+    <td valign="top">
+      <p><b>Meaning</b></p>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">
+      <p>VS2019DEVENV</p>
+    </td>
+    <td>
+      <p>Full path to devenv.exe for Visual Studio 2019 if it is installed on the system. This property is available starting with WiX v3.14.</p>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">
+      <p>VS2019_EXTENSIONS_DIR</p>
+    </td>
+    <td>
+      <p>Full path to the Visual Studio 2019 extensions directory. This property is available starting with WiX v3.14.</p>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">
+      <p>VS2019_ITEMTEMPLATES_DIR</p>
+    </td>
+    <td>
+      <p>Full path to the Visual Studio 2019 item templates directory. This property is available starting with WiX v3.14.</p>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">
+      <p>VS2019_PROJECTTEMPLATES_DIR</p>
+    </td>
+    <td>
+      <p>Full path to the Visual Studio 2019 project templates directory. This property is available starting with WiX v3.14.</p>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">
+      <p>VS2019_SCHEMAS_DIR</p>
+    </td>
+    <td>
+      <p>Full path to the Visual Studio 2019 XML schemas directory. This property is available starting with WiX v3.14.</p>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">
+      <p>VS2019_ROOT_FOLDER</p>
+    </td>
+    <td>
+      <p>Full path to the Visual Studio 2019 root installation directory. This property is available starting with WiX v3.14.</p>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">
+      <p>VS2019_IDE_DIR</p>
+    </td>
+    <td>
+      <p>Full path to the Visual Studio 2019 directory containing devenv.exe. This property is available starting with WiX v3.14.</p>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">
+      <p>VS2019_IDE_VB_PROJECTSYSTEM_INSTALLED</p>
+    </td>
+    <td>
+      <p>Indicates whether Visual Studio 2019 Professional Edition or higher is installed and the Visual Basic project system is installed for it. This property is available starting with WiX v3.14.</p>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">
+      <p>VS2019_IDE_VC_PROJECTSYSTEM_INSTALLED</p>
+    </td>
+    <td>
+      <p>Indicates whether Visual Studio 2019 Professional Edition or higher is installed and the Visual C++ project system is installed for it. This property is available starting with WiX v3.14.</p>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">
+      <p>VS2019_IDE_VCSHARP_PROJECTSYSTEM_INSTALLED</p>
+    </td>
+    <td>
+      <p>Indicates whether Visual Studio 2019 Professional Edition or higher is installed and the Visual C# project system is installed for it. This property is available starting with WiX v3.14.</p>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">
+      <p>VS2019_IDE_VWD_PROJECTSYSTEM_INSTALLED</p>
+    </td>
+    <td>
+      <p>Indicates whether Visual Studio 2019 Professional Edition or higher is installed and the Visual Web Developer project system is installed for it. This property is available starting with WiX v3.14.</p>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">
+      <p>VS2019_IDE_VSTS_TESTSYSTEM_INSTALLED</p>
+    </td>
+    <td>
+      <p>Indicates whether or not the Visual Studio 2019 Team Test project system is installed on the system. This property is available starting with WiX v3.14.</p>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">
+      <p>VS2019_IDE_MODELING_PROJECTSYSTEM_INSTALLED</p>
+    </td>
+    <td>
+      <p>Indicates whether or not the Visual Studio 2019 Modeling project system is installed on the system. This property is available starting with WiX v3.14.</p>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">
+      <p>VS2019_IDE_FSHARP_PROJECTSYSTEM_INSTALLED</p>
+    </td>
+    <td>
+      <p>Indicates whether or not the Visual Studio 2019 F# project system is installed on the system. This property is available starting with WiX v3.14.</p>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">
+      <p>VS2019_BOOTSTRAPPER_PACKAGE_FOLDER</p>
+    </td>
+    <td>
+      <p>The location of the Visual Studio 2019 bootstrapper package folder. This property is available starting with WiX v3.14.</p>
+    </td>
+  </tr>
+</table>
+
 ## <a name="allcustomactions"></a> Custom Actions
 
 Here is a complete list of custom actions:
@@ -1703,6 +1837,22 @@ Here is a complete list of custom actions:
     </td>
     <td>
       <p>Runs devenv.exe /InstallVSTemplates if Visual Studio 2017 Community Edition or higher is found on the system. Including this custom action automatically adds the VS2017DEVENV property. This custom action is available starting with WiX v3.11.</p>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">
+      <p>VS2019Setup</p>
+    </td>
+    <td>
+      <p>Runs devenv.exe /setup if Visual Studio 2019 Community Edition or higher is found on the system. Including this custom action automatically adds the VS2019DEVENV property. This custom action is available starting with WiX v3.14.</p>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">
+      <p>VS2019InstallVSTemplates</p>
+    </td>
+    <td>
+      <p>Runs devenv.exe /InstallVSTemplates if Visual Studio 2019 Community Edition or higher is found on the system. Including this custom action automatically adds the VS2019DEVENV property. This custom action is available starting with WiX v3.14.</p>
     </td>
   </tr>
 </table>

--- a/src/ext/VSExtension/ca/vsca.cpp
+++ b/src/ext/VSExtension/ca/vsca.cpp
@@ -47,6 +47,12 @@ static HRESULT ProcessVS2017(
     __in BOOL fComplete
     );
 
+static HRESULT ProcessVS2019(
+    __in_opt ISetupInstance* pInstance,
+    __in DWORD64 qwVersion,
+    __in BOOL fComplete
+    );
+
 static HRESULT SetPropertyForComponent(
     __in DWORD cComponents,
     __in VS_COMPONENT_PROPERTY* rgComponents,
@@ -56,6 +62,7 @@ static HRESULT SetPropertyForComponent(
 static VS_INSTANCE vrgInstances[] =
 {
     { FILEMAKEVERSION(15, 0, 0, 0), FILEMAKEVERSION(15, 0xffff, 0xffff, 0xffff), ProcessVS2017 },
+    { FILEMAKEVERSION(16, 0, 0, 0), FILEMAKEVERSION(16, 0xffff, 0xffff, 0xffff), ProcessVS2019 },
 };
 
 /******************************************************************
@@ -150,11 +157,8 @@ extern "C" UINT __stdcall FindInstances(
     {
         const VS_INSTANCE* pElem = &vrgInstances[i];
 
-        if (pElem->qwMinVersion <= qwVersion && qwVersion <= pElem->qwMaxVersion)
-        {
-            hr = pElem->pfnProcessInstance(NULL, 0, TRUE);
-            ExitOnFailure(hr, "Failed to process latest instance.");
-        }
+        hr = pElem->pfnProcessInstance(NULL, 0, TRUE);
+        ExitOnFailure(hr, "Failed to process latest instance.");
     }
 
 LExit:
@@ -369,6 +373,80 @@ static HRESULT ProcessVS2017(
         {
             hr = ProcessInstance(pLatest, L"VS2017_ROOT_FOLDER", countof(rgComponents), rgComponents);
             ExitOnFailure(hr, "Failed to process VS2017 instance.");
+        }
+    }
+    else if (pInstance)
+    {
+        hr = InstanceInProducts(pInstance, countof(rgwzProducts), rgwzProducts);
+        ExitOnFailure(hr, "Failed to compare product IDs.");
+
+        if (S_FALSE == hr)
+        {
+            ExitFunction();
+        }
+
+        hr = InstanceIsGreater(pLatest, qwLatest, pInstance, qwVersion);
+        ExitOnFailure(hr, "Failed to compare instances.");
+
+        if (S_FALSE == hr)
+        {
+            ExitFunction();
+        }
+
+        ReleaseNullObject(pLatest);
+
+        pLatest = pInstance;
+        qwLatest = qwVersion;
+
+        // Caller will do a final Release() otherwise.
+        pLatest->AddRef();
+    }
+
+LExit:
+    if (fComplete)
+    {
+        ReleaseObject(pLatest);
+    }
+
+    return hr;
+}
+
+static HRESULT ProcessVS2019(
+    __in_opt ISetupInstance* pInstance,
+    __in DWORD64 qwVersion,
+    __in BOOL fComplete
+    )
+{
+    static ISetupInstance* pLatest = NULL;
+    static DWORD64 qwLatest = 0;
+
+    static LPCWSTR rgwzProducts[] =
+    {
+        L"Microsoft.VisualStudio.Product.Community",
+        L"Microsoft.VisualStudio.Product.Professional",
+        L"Microsoft.VisualStudio.Product.Enterprise",
+    };
+
+    // TODO: Consider making table-driven with these defaults per-version for easy customization.
+    static VS_COMPONENT_PROPERTY rgComponents[] =
+    {
+        { L"Microsoft.VisualStudio.Component.FSharp", L"VS2019_IDE_FSHARP_PROJECTSYSTEM_INSTALLED" },
+        { L"Microsoft.VisualStudio.Component.Roslyn.LanguageServices", L"VS2019_IDE_VB_PROJECTSYSTEM_INSTALLED" },
+        { L"Microsoft.VisualStudio.Component.Roslyn.LanguageServices", L"VS2019_IDE_VCSHARP_PROJECTSYSTEM_INSTALLED" },
+        { L"Microsoft.VisualStudio.PackageGroup.TestTools.Core", L"VS2019_IDE_VSTS_TESTSYSTEM_INSTALLED" },
+        { L"Microsoft.VisualStudio.Component.VC.CoreIde", L"VS2019_IDE_VC_PROJECTSYSTEM_INSTALLED" },
+        { L"Microsoft.VisualStudio.Component.Web", L"VS2019_IDE_VWD_PROJECTSYSTEM_INSTALLED" },
+        { L"Microsoft.VisualStudio.PackageGroup.DslRuntime", L"VS2019_IDE_MODELING_PROJECTSYSTEM_INSTALLED" },
+    };
+
+    HRESULT hr = S_OK;
+
+    if (fComplete)
+    {
+        if (pLatest)
+        {
+            hr = ProcessInstance(pLatest, L"VS2019_ROOT_FOLDER", countof(rgComponents), rgComponents);
+            ExitOnFailure(hr, "Failed to process VS2019 instance.");
         }
     }
     else if (pInstance)

--- a/src/ext/VSExtension/wixlib/VS2019.wxs
+++ b/src/ext/VSExtension/wixlib/VS2019.wxs
@@ -88,42 +88,42 @@
     </Fragment>
 
     <!-- Indicates whether the Visual C# project system is installed as a part of  -->
-    <!-- Visual Studio 2017 standard or higher. If this property is set, that      -->
-    <!-- means Visual Studio 2017 standard or higher is installed and the Visual   -->
-    <!-- C# language tools were installed as a part of VS 2017 setup.              -->
+    <!-- Visual Studio 2019 standard or higher. If this property is set, that      -->
+    <!-- means Visual Studio 2019 standard or higher is installed and the Visual   -->
+    <!-- C# language tools were installed as a part of VS 2019 setup.              -->
     <Fragment>
         <Property Id="VS2019_IDE_VCSHARP_PROJECTSYSTEM_INSTALLED" Secure="yes" />
         <CustomActionRef Id="VSFindInstances" />
     </Fragment>
 
     <!-- Indicates whether the Visual Basic project system is installed as a part of -->
-    <!-- Visual Studio 2017 standard or higher. If this property is set, that        -->
-    <!-- means Visual Studio 2017 standard or higher is installed and the Visual     -->
-    <!-- Basic language tools were installed as a part of VS 2017 setup.             -->
+    <!-- Visual Studio 2019 standard or higher. If this property is set, that        -->
+    <!-- means Visual Studio 2019 standard or higher is installed and the Visual     -->
+    <!-- Basic language tools were installed as a part of VS 2019 setup.             -->
     <Fragment>
         <Property Id="VS2019_IDE_VB_PROJECTSYSTEM_INSTALLED" Secure="yes" />
         <CustomActionRef Id="VSFindInstances" />
     </Fragment>
 
     <!-- Indicates whether the Visual Web Developer project system is installed as a part of -->
-    <!-- Visual Studio 2017 standard or higher. If this property is set, that                -->
-    <!-- means Visual Studio 2017 standard or higher is installed and the Visual             -->
-    <!-- Web Developer language tools were installed as a part of VS 2017 setup.             -->
+    <!-- Visual Studio 2019 standard or higher. If this property is set, that                -->
+    <!-- means Visual Studio 2019 standard or higher is installed and the Visual             -->
+    <!-- Web Developer language tools were installed as a part of VS 2019 setup.             -->
     <Fragment>
         <Property Id="VS2019_IDE_VWD_PROJECTSYSTEM_INSTALLED" Secure="yes" />
         <CustomActionRef Id="VSFindInstances" />
     </Fragment>
 
     <!-- Indicates whether the Visual C++ project system is installed as a part of -->
-    <!-- Visual Studio 2017 standard or higher. If this property is set, that      -->
-    <!-- means Visual Studio 2017 standard or higher is installed and the Visual   -->
-    <!-- C++ language tools were installed as a part of VS 2017 setup.             -->
+    <!-- Visual Studio 2019 standard or higher. If this property is set, that      -->
+    <!-- means Visual Studio 2019 standard or higher is installed and the Visual   -->
+    <!-- C++ language tools were installed as a part of VS 2019 setup.             -->
     <Fragment>
         <Property Id="VS2019_IDE_VC_PROJECTSYSTEM_INSTALLED" Secure="yes" />
         <CustomActionRef Id="VSFindInstances" />
     </Fragment>
 
-    <!-- Indicates whether the Visual Studio 2017 Team Test project system is installed -->
+    <!-- Indicates whether the Visual Studio 2019 Team Test project system is installed -->
     <Fragment>
         <Property Id="VS2019_IDE_VSTS_TESTSYSTEM_INSTALLED" Secure="yes" />
         <CustomActionRef Id="VSFindInstances" />

--- a/src/ext/VSExtension/wixlib/VS2019.wxs
+++ b/src/ext/VSExtension/wixlib/VS2019.wxs
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+
+
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Fragment>
+        <Property Id="VS2019_ROOT_FOLDER" Secure="yes" />
+
+        <!-- Currently supported only on x86 -->
+        <CustomActionRef Id="VSFindInstances" />
+    </Fragment>
+
+    <Fragment>
+        <PropertyRef Id="VS2019_ROOT_FOLDER" />
+        <Property Id="VS2019_IDE_DIR" Secure="yes">
+            <DirectorySearch Id="VS2019DirectorySearch" Path="[VS2019_ROOT_FOLDER]">
+                <DirectorySearch Id="VS2019EnvironmentDirectorySearch" Path="Common7\IDE" Depth="1" />
+            </DirectorySearch>
+        </Property>
+    </Fragment>
+
+    <Fragment>
+        <Property Id="VS2019_EXTENSIONS_DIR" Secure="yes">
+            <DirectorySearchRef Id="VS2019EnvironmentDirectorySearch" Parent="VS2019DirectorySearch" Path="Common7\IDE">
+                <DirectorySearch Id="VS2019ExtensionsDirectorySearch" Path="Extensions" Depth="1" />
+            </DirectorySearchRef>
+        </Property>
+    </Fragment>
+
+    <Fragment>
+        <Property Id="VS2019_PROJECTTEMPLATES_DIR" Secure="yes">
+            <DirectorySearchRef Id="VS2019EnvironmentDirectorySearch" Parent="VS2019DirectorySearch" Path="Common7\IDE">
+                <DirectorySearch Id="VS2019ProjectTemplatesDirectorySearch" Path="ProjectTemplates" Depth="1" />
+            </DirectorySearchRef>
+        </Property>
+    </Fragment>
+
+    <Fragment>
+        <PropertyRef Id="VS2019_ROOT_FOLDER" />
+        <Property Id="VS2019_SCHEMAS_DIR" Secure="yes">
+            <DirectorySearch Id="VS2019XmlDirectorySearch" Path="[VS2019_ROOT_FOLDER]\Xml" Depth="1">
+                <DirectorySearch Id="VS2019XmlSchemasDirectorySearch" Path="Schemas" Depth="1" />
+            </DirectorySearch>
+        </Property>
+    </Fragment>
+
+    <Fragment>
+        <Property Id="VS2019_ITEMTEMPLATES_DIR" Secure="yes">
+            <DirectorySearchRef Id="VS2019EnvironmentDirectorySearch" Parent="VS2019DirectorySearch" Path="Common7\IDE">
+                <DirectorySearch Id="VS2019ItemTemplatesDirectorySearch" Path="ItemTemplates" Depth="1" />
+            </DirectorySearchRef>
+        </Property>
+    </Fragment>
+
+    <Fragment>
+        <PropertyRef Id="VS2019_ROOT_FOLDER" />
+        <Property Id="VS2019_BOOTSTRAPPER_PACKAGE_FOLDER" Secure="yes">
+            <DirectorySearch Id="VS2019SDKDirectorySearch" Path="[VS2019_ROOT_FOLDER]\SDK" Depth="1">
+                <DirectorySearch Id="SearchForVS2019BootstrapperPackageDirectory" Path="Bootstrapper" Depth="1" />
+            </DirectorySearch>
+        </Property>
+    </Fragment>
+
+    <Fragment>
+        <Property Id="VS2019DEVENV" Secure="yes">
+            <DirectorySearchRef Id="VS2019EnvironmentDirectorySearch" Parent="VS2019DirectorySearch" Path="Common7\IDE">
+                <FileSearch Id="VS2019DevEnvSearch" Name="devenv.exe" />
+            </DirectorySearchRef>
+        </Property>
+    </Fragment>
+
+    <Fragment>
+        <CustomAction Id="VS2019Setup" Property="VS2019DEVENV" ExeCommand="/setup" Execute="deferred" Return="ignore" Impersonate="no" />
+        <PropertyRef Id="VS2019DEVENV" />
+
+        <InstallExecuteSequence>
+            <Custom Action="VS2019Setup" Before="InstallFinalize" Overridable="yes">VS2019DEVENV</Custom>
+        </InstallExecuteSequence>
+    </Fragment>
+
+    <Fragment>
+        <CustomAction Id="VS2019InstallVSTemplates" Property="VS2019DEVENV" ExeCommand="/InstallVSTemplates" Execute="deferred" Return="ignore" Impersonate="no" />
+        <PropertyRef Id="VS2019DEVENV" />
+
+        <InstallExecuteSequence>
+            <Custom Action="VS2019InstallVSTemplates" Before="InstallFinalize" Overridable="yes">VS2019DEVENV</Custom>
+        </InstallExecuteSequence>
+    </Fragment>
+
+    <!-- Indicates whether the Visual C# project system is installed as a part of  -->
+    <!-- Visual Studio 2017 standard or higher. If this property is set, that      -->
+    <!-- means Visual Studio 2017 standard or higher is installed and the Visual   -->
+    <!-- C# language tools were installed as a part of VS 2017 setup.              -->
+    <Fragment>
+        <Property Id="VS2019_IDE_VCSHARP_PROJECTSYSTEM_INSTALLED" Secure="yes" />
+        <CustomActionRef Id="VSFindInstances" />
+    </Fragment>
+
+    <!-- Indicates whether the Visual Basic project system is installed as a part of -->
+    <!-- Visual Studio 2017 standard or higher. If this property is set, that        -->
+    <!-- means Visual Studio 2017 standard or higher is installed and the Visual     -->
+    <!-- Basic language tools were installed as a part of VS 2017 setup.             -->
+    <Fragment>
+        <Property Id="VS2019_IDE_VB_PROJECTSYSTEM_INSTALLED" Secure="yes" />
+        <CustomActionRef Id="VSFindInstances" />
+    </Fragment>
+
+    <!-- Indicates whether the Visual Web Developer project system is installed as a part of -->
+    <!-- Visual Studio 2017 standard or higher. If this property is set, that                -->
+    <!-- means Visual Studio 2017 standard or higher is installed and the Visual             -->
+    <!-- Web Developer language tools were installed as a part of VS 2017 setup.             -->
+    <Fragment>
+        <Property Id="VS2019_IDE_VWD_PROJECTSYSTEM_INSTALLED" Secure="yes" />
+        <CustomActionRef Id="VSFindInstances" />
+    </Fragment>
+
+    <!-- Indicates whether the Visual C++ project system is installed as a part of -->
+    <!-- Visual Studio 2017 standard or higher. If this property is set, that      -->
+    <!-- means Visual Studio 2017 standard or higher is installed and the Visual   -->
+    <!-- C++ language tools were installed as a part of VS 2017 setup.             -->
+    <Fragment>
+        <Property Id="VS2019_IDE_VC_PROJECTSYSTEM_INSTALLED" Secure="yes" />
+        <CustomActionRef Id="VSFindInstances" />
+    </Fragment>
+
+    <!-- Indicates whether the Visual Studio 2017 Team Test project system is installed -->
+    <Fragment>
+        <Property Id="VS2019_IDE_VSTS_TESTSYSTEM_INSTALLED" Secure="yes" />
+        <CustomActionRef Id="VSFindInstances" />
+    </Fragment>
+
+    <!-- Indicates whether the Visual Studio Modeling project system is installed -->
+    <Fragment>
+        <Property Id="VS2019_IDE_MODELING_PROJECTSYSTEM_INSTALLED" Secure="yes" />
+        <CustomActionRef Id="VSFindInstances" />
+    </Fragment>
+
+    <!-- Indicates whether the Visual Studio F# project system is installed -->
+    <Fragment>
+        <Property Id="VS2019_IDE_FSHARP_PROJECTSYSTEM_INSTALLED" Secure="yes" />
+        <CustomActionRef Id="VSFindInstances" />
+    </Fragment>
+</Wix>

--- a/src/ext/VSExtension/wixlib/VSExtension.wixproj
+++ b/src/ext/VSExtension/wixlib/VSExtension.wixproj
@@ -24,6 +24,7 @@
     <Compile Include="VS14.wxs" />
     <Compile Include="VS2015.wxs" />
     <Compile Include="VS2017.wxs" />
+    <Compile Include="VS2019.wxs" />
     <Compile Include="VSExtension_x86.wxs" />
     <Compile Include="VsixPackage.wxs" />
     <Compile Include="vs2005\vs2005_VSIPCC_Collection_Files_RTL.wxs" />

--- a/tools/OneTimeWixBuildInitialization.proj
+++ b/tools/OneTimeWixBuildInitialization.proj
@@ -14,12 +14,14 @@
   -->
   <PropertyGroup>
     <NetfxSdkInstallPath>$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0A', 'InstallationFolder', null, RegistryView.Registry64, RegistryView.Registry32))</NetfxSdkInstallPath>
+    <NetfxSdkInstallPath Condition=" '$(NetfxSdkInstallPath)'=='' ">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Microsoft SDKs\NETFXSDK\4.7.2', 'InstallationFolder', null, RegistryView.Registry64, RegistryView.Registry32))</NetfxSdkInstallPath>
     <NetfxSdkInstallPath Condition=" '$(NetfxSdkInstallPath)'=='' ">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Microsoft SDKs\NETFXSDK\4.6.2', 'InstallationFolder', null, RegistryView.Registry64, RegistryView.Registry32))</NetfxSdkInstallPath>
     <NetfxSdkInstallPath Condition=" '$(NetfxSdkInstallPath)'=='' ">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Microsoft SDKs\NETFXSDK\4.6.1', 'InstallationFolder', null, RegistryView.Registry64, RegistryView.Registry32))</NetfxSdkInstallPath>
     <NetfxSdkInstallPath Condition=" '$(NetfxSdkInstallPath)'=='' ">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.1A', 'InstallationFolder', null, RegistryView.Registry64, RegistryView.Registry32))</NetfxSdkInstallPath>
     <NetfxSdkInstallPath Condition=" '$(NetfxSdkInstallPath)'=='' ">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.0A', 'InstallationFolder', null, RegistryView.Registry64, RegistryView.Registry32))</NetfxSdkInstallPath>
     <NetfxSdkInstallPath Condition=" '$(NetfxSdkInstallPath)'=='' ">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0A', 'InstallationFolder', null, RegistryView.Registry64, RegistryView.Registry32))</NetfxSdkInstallPath>
     <NetfxSdkInstallPath Condition=" !HasTrailingSlash('$(NetfxSdkInstallPath)') ">$(NetfxSdkInstallPath)\</NetfxSdkInstallPath>
+    <StrongNameSignFolder Condition=" Exists('$(NetfxSdkInstallPath)bin\NETFX 4.7.2 Tools\sn.exe') ">$(NetfxSdkInstallPath)bin\NETFX 4.7.2 Tools\</StrongNameSignFolder>
     <StrongNameSignFolder Condition=" Exists('$(NetfxSdkInstallPath)bin\NETFX 4.6.2 Tools\sn.exe') ">$(NetfxSdkInstallPath)bin\NETFX 4.6.2 Tools\</StrongNameSignFolder>
     <StrongNameSignFolder Condition=" Exists('$(NetfxSdkInstallPath)bin\NETFX 4.6.1 Tools\sn.exe') ">$(NetfxSdkInstallPath)bin\NETFX 4.6.1 Tools\</StrongNameSignFolder>
     <StrongNameSignFolder Condition=" Exists('$(NetfxSdkInstallPath)bin\NETFX 4.6 Tools\sn.exe') ">$(NetfxSdkInstallPath)bin\NETFX 4.6 Tools\</StrongNameSignFolder>


### PR DESCRIPTION
Fixes wixtoolset/issues#5979. Ran end-to-end tests on machines with both VS2017 and VS2019, and only VS2019 with test MSI before and after changes. Properties for all versions on both machines were defined correctly after changes.