### PR TITLE
wixstdba: Add auto-launch option via 'AutoLaunch' variable.

### DIFF
--- a/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
+++ b/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
@@ -965,19 +965,24 @@ public: // IBootstrapperApplication
         SetState(WIXSTDBA_STATE_APPLIED, hrStatus);
         SetTaskbarButtonProgress(100); // show full progress bar, green, yellow, or red
 
-        // Auto-launch if configured to do so
-        BOOL fLaunchTargetExists = BalStringVariableExists(WIXSTDBA_VARIABLE_LAUNCH_TARGET_PATH);
-        BOOL fAutoLaunchExists = BalStringVariableExists(WIXSTDBA_VARIABLE_LAUNCH_AUTO);
-        if (fLaunchTargetExists && fAutoLaunchExists && BOOTSTRAPPER_ACTION_UNINSTALL < m_plannedAction)
+        // Only perform auto-launch if apply completed successfully,
+        // and if action is either Install, Modify or Repair
+        if (hrStatus == S_OK && BOOTSTRAPPER_ACTION_UNINSTALL < m_plannedAction)
         {
-            // An auto-launch will NOT be executed if a restart is to be performed
-            if (!(m_fRestartRequired && m_fAllowRestart))
+            // Auto-launch if configured to do so
+            BOOL fLaunchTargetExists = BalStringVariableExists(WIXSTDBA_VARIABLE_LAUNCH_TARGET_PATH);
+            BOOL fAutoLaunchExists = BalStringVariableExists(WIXSTDBA_VARIABLE_LAUNCH_AUTO);
+            if (fLaunchTargetExists && fAutoLaunchExists)
             {
-                LONGLONG llAutoLaunch = 0;
-                HRESULT hr = BalGetNumericVariable(WIXSTDBA_VARIABLE_LAUNCH_AUTO, &llAutoLaunch);
-                if (hr == S_OK && llAutoLaunch)
+                // An auto-launch will NOT be executed if a restart is to be performed
+                if (!(m_fRestartRequired && m_fAllowRestart))
                 {
-                    OnClickLaunchButton();
+                    LONGLONG llAutoLaunch = 0;
+                    HRESULT hr = BalGetNumericVariable(WIXSTDBA_VARIABLE_LAUNCH_AUTO, &llAutoLaunch);
+                    if (hr == S_OK && llAutoLaunch)
+                    {
+                        OnClickLaunchButton();
+                    }
                 }
             }
         }

--- a/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
+++ b/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
@@ -12,6 +12,7 @@ static const LPCWSTR WIXSTDBA_VARIABLE_LAUNCH_TARGET_ELEVATED_ID = L"LaunchTarge
 static const LPCWSTR WIXSTDBA_VARIABLE_LAUNCH_ARGUMENTS = L"LaunchArguments";
 static const LPCWSTR WIXSTDBA_VARIABLE_LAUNCH_HIDDEN = L"LaunchHidden";
 static const LPCWSTR WIXSTDBA_VARIABLE_LAUNCH_WORK_FOLDER = L"LaunchWorkingFolder";
+static const LPCWSTR WIXSTDBA_VARIABLE_LAUNCH_AUTO = L"AutoLaunch";
 
 static const DWORD WIXSTDBA_ACQUIRE_PERCENTAGE = 30;
 
@@ -963,6 +964,23 @@ public: // IBootstrapperApplication
 
         SetState(WIXSTDBA_STATE_APPLIED, hrStatus);
         SetTaskbarButtonProgress(100); // show full progress bar, green, yellow, or red
+
+        // Auto-launch if configured to do so
+        BOOL fLaunchTargetExists = BalStringVariableExists(WIXSTDBA_VARIABLE_LAUNCH_TARGET_PATH);
+        BOOL fAutoLaunchExists = BalStringVariableExists(WIXSTDBA_VARIABLE_LAUNCH_AUTO);
+        if (fLaunchTargetExists && fAutoLaunchExists && BOOTSTRAPPER_ACTION_UNINSTALL < m_plannedAction)
+        {
+            // An auto-launch will NOT be executed if a restart is to be performed
+            if (!(m_fRestartRequired && m_fAllowRestart))
+            {
+                LONGLONG llAutoLaunch = 0;
+                HRESULT hr = BalGetNumericVariable(WIXSTDBA_VARIABLE_LAUNCH_AUTO, &llAutoLaunch);
+                if (hr == S_OK && llAutoLaunch)
+                {
+                    OnClickLaunchButton();
+                }
+            }
+        }
 
         return IDNOACTION;
     }


### PR DESCRIPTION
Any feedback welcome on this PR.

A feature often requested that could be quite useful, e.g:
 * https://stackoverflow.com/questions/39745742/how-to-launch-the-application-after-a-quiet-call-to-wix-burn-bootstrap
* http://windows-installer-xml-wix-toolset.687559.n2.nabble.com/How-to-force-to-launch-application-in-silent-install-mode-td4021727.html
* https://stackoverflow.com/questions/12823722/start-application-after-installation-using-wix-burn
 * https://github.com/vslavik/winsparkle/issues/132

If accepted, perhaps WiX4 would be a better place for it?

## Usage
### Within bootstrapper .wxs Bundle:
```
<Variable Name="AutoLaunch" bal:Overridable="yes" Type="numeric" Value="0" />
```
### When running bootstrapper:
```
BootstrapperInstaller.exe AutoLaunch=1
```

Auto-launching will **not** be performed if a restart is to be performed.