### PR TITLE
jchoover: WIXBUG:6071 - Enable HTTP to HTTPS redirects for burn downl…

### DIFF
--- a/history/wixbug6071.md
+++ b/history/wixbug6071.md
@@ -1,0 +1,1 @@
+* jchoover: WIXBUG:6071 - Enable HTTP to HTTPS redirects for burn downloads.

--- a/src/libs/dutil/dlutil.cpp
+++ b/src/libs/dutil/dlutil.cpp
@@ -558,6 +558,10 @@ static HRESULT OpenRequest(
     {
         dwRequestFlags |= INTERNET_FLAG_SECURE;
     }
+    else if (INTERNET_SCHEME_HTTP == scheme)
+    {
+        dwRequestFlags |= INTERNET_FLAG_IGNORE_REDIRECT_TO_HTTPS;
+    }
 
     // Allocate the resource name.
     hr = StrAllocString(&sczResource, wzResource, 0);


### PR DESCRIPTION
https://github.com/wixtoolset/issues/issues/6071
