### PR TITLE
Prevent Zip Slip when using ArchiveFileStreamContext to decompress

### DIFF
--- a/history/zipslip.md
+++ b/history/zipslip.md
@@ -1,0 +1,1 @@
+* RobMen: WIXBUG:6075 - Fix "Zip Slip" vulnerability in DTF.

--- a/src/DTF/Libraries/Compression/ArchiveFileStreamContext.cs
+++ b/src/DTF/Libraries/Compression/ArchiveFileStreamContext.cs
@@ -638,6 +638,8 @@ namespace Microsoft.Deployment.Compression
 
             if (filePath != null)
             {
+                this.ValidateArchivePath(filePath);
+
                 if (this.directory != null)
                 {
                     filePath = Path.Combine(this.directory, filePath);
@@ -645,6 +647,16 @@ namespace Microsoft.Deployment.Compression
             }
 
             return filePath;
+        }
+
+        private void ValidateArchivePath(string filePath)
+        {
+            string basePath = Path.GetFullPath(String.IsNullOrEmpty(this.directory) ? Environment.CurrentDirectory : this.directory);
+            string path = Path.GetFullPath(Path.Combine(basePath, filePath));
+            if (!path.StartsWith(basePath, StringComparison.InvariantCultureIgnoreCase))
+            {
+                throw new InvalidDataException("Archive cannot contain files with absolute or traversal paths.");
+            }
         }
 
         #endregion


### PR DESCRIPTION
Fixes wixtoolset/issues#6075