### PR TITLE
Add support for two new controls to standard bootstrapper

### DIFF
--- a/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
+++ b/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
@@ -141,6 +141,8 @@ enum WIXSTDBA_CONTROL
 
     WIXSTDBA_CONTROL_SUCCESS_HEADER,
     WIXSTDBA_CONTROL_SUCCESS_INSTALL_HEADER,
+    WIXSTDBA_CONTROL_SUCCESS_INSTALL_DESCRIPTION,
+    WIXSTDBA_CONTROL_SUCCESS_INSTALL_ILLUSTRATION,
     WIXSTDBA_CONTROL_SUCCESS_UNINSTALL_HEADER,
     WIXSTDBA_CONTROL_SUCCESS_REPAIR_HEADER,
 
@@ -212,6 +214,8 @@ static THEME_ASSIGN_CONTROL_ID vrgInitControls[] = {
 
     { WIXSTDBA_CONTROL_SUCCESS_HEADER, L"SuccessHeader" },
     { WIXSTDBA_CONTROL_SUCCESS_INSTALL_HEADER, L"SuccessInstallHeader" },
+    { WIXSTDBA_CONTROL_SUCCESS_INSTALL_DESCRIPTION, L"SuccessInstallDescription" },
+    { WIXSTDBA_CONTROL_SUCCESS_INSTALL_ILLUSTRATION, L"SuccessInstallIllustration" },
     { WIXSTDBA_CONTROL_SUCCESS_UNINSTALL_HEADER, L"SuccessUninstallHeader" },
     { WIXSTDBA_CONTROL_SUCCESS_REPAIR_HEADER, L"SuccessRepairHeader" },
 
@@ -2517,6 +2521,16 @@ private: // privates
                     if (ThemeControlExists(m_pTheme, WIXSTDBA_CONTROL_SUCCESS_INSTALL_HEADER))
                     {
                         ThemeControlEnable(m_pTheme, WIXSTDBA_CONTROL_SUCCESS_INSTALL_HEADER, BOOTSTRAPPER_ACTION_INSTALL == m_plannedAction);
+                    }
+
+                    if (ThemeControlExists(m_pTheme, WIXSTDBA_CONTROL_SUCCESS_INSTALL_DESCRIPTION))
+                    {
+                        ThemeControlEnable(m_pTheme, WIXSTDBA_CONTROL_SUCCESS_INSTALL_DESCRIPTION, BOOTSTRAPPER_ACTION_INSTALL == m_plannedAction);
+                    }
+
+                    if (ThemeControlExists(m_pTheme, WIXSTDBA_CONTROL_SUCCESS_INSTALL_ILLUSTRATION))
+                    {
+                        ThemeControlEnable(m_pTheme, WIXSTDBA_CONTROL_SUCCESS_INSTALL_ILLUSTRATION, BOOTSTRAPPER_ACTION_INSTALL == m_plannedAction);
                     }
 
                     if (ThemeControlExists(m_pTheme, WIXSTDBA_CONTROL_SUCCESS_UNINSTALL_HEADER))


### PR DESCRIPTION
Implementes https://github.com/wixtoolset/issues/issues/6084 by adding two new controls **SuccessInstallDescription** and **SuccessInstallIllustration** to Success page when installation has finished.