### PR TITLE
Feature/display internal ui

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,9 @@
+## WixBuild: Version 3.11.2.4516
+
+* HeathS: Add support for .NET Foundation signing service
+
+* RobMen: WIXBUG:6075 - Fix "Zip Slip" vulnerability in DTF.
+
 ## WixBuild: Version 3.11.1.2318
 
 * RobMen - WIXBUG:5724 - fix DLL hijack of clean room when bundle launched elevated.

--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+## WixBuild: Version 3.11.1.2318
+
+* RobMen - WIXBUG:5724 - fix DLL hijack of clean room when bundle launched elevated.
+
 ## WixBuild: Version 3.11.0.1701
 
 * RobMen: WIXBUG:5536 - introduce wix.nativeca.targets to simplify CPP CA projects.

--- a/history/5724.md
+++ b/history/5724.md
@@ -1,0 +1,1 @@
+* RobMen - WIXBUG:5724 - fix DLL hijack of clean room when bundle launched elevated.

--- a/history/5724.md
+++ b/history/5724.md
@@ -1,1 +1,0 @@
-* RobMen - WIXBUG:5724 - fix DLL hijack of clean room when bundle launched elevated.

--- a/history/sign.md
+++ b/history/sign.md
@@ -1,0 +1,1 @@
+* HeathS: Add support for .NET Foundation signing service

--- a/history/sign.md
+++ b/history/sign.md
@@ -1,1 +1,0 @@
-* HeathS: Add support for .NET Foundation signing service

--- a/history/zipslip.md
+++ b/history/zipslip.md
@@ -1,1 +1,0 @@
-* RobMen: WIXBUG:6075 - Fix "Zip Slip" vulnerability in DTF.

--- a/history/zipslip.md
+++ b/history/zipslip.md
@@ -1,0 +1,1 @@
+* RobMen: WIXBUG:6075 - Fix "Zip Slip" vulnerability in DTF.

--- a/src/DTF/Libraries/Compression.Cab/Compression.Cab.csproj
+++ b/src/DTF/Libraries/Compression.Cab/Compression.Cab.csproj
@@ -12,6 +12,7 @@
     <CreateDocumentationFile>true</CreateDocumentationFile>
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <FxCopEnabled>false</FxCopEnabled>
+    <ShouldSignOutput>true</ShouldSignOutput>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DTF/Libraries/Compression.Zip/Compression.Zip.csproj
+++ b/src/DTF/Libraries/Compression.Zip/Compression.Zip.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>Microsoft.Deployment.Compression.Zip</AssemblyName>
     <CreateDocumentationFile>true</CreateDocumentationFile>
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <ShouldSignOutput>true</ShouldSignOutput>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DTF/Libraries/Compression/ArchiveFileStreamContext.cs
+++ b/src/DTF/Libraries/Compression/ArchiveFileStreamContext.cs
@@ -638,6 +638,8 @@ namespace Microsoft.Deployment.Compression
 
             if (filePath != null)
             {
+                this.ValidateArchivePath(filePath);
+
                 if (this.directory != null)
                 {
                     filePath = Path.Combine(this.directory, filePath);
@@ -645,6 +647,16 @@ namespace Microsoft.Deployment.Compression
             }
 
             return filePath;
+        }
+
+        private void ValidateArchivePath(string filePath)
+        {
+            string basePath = Path.GetFullPath(String.IsNullOrEmpty(this.directory) ? Environment.CurrentDirectory : this.directory);
+            string path = Path.GetFullPath(Path.Combine(basePath, filePath));
+            if (!path.StartsWith(basePath, StringComparison.InvariantCultureIgnoreCase))
+            {
+                throw new InvalidDataException("Archive cannot contain files with absolute or traversal paths.");
+            }
         }
 
         #endregion

--- a/src/DTF/Libraries/Compression/ArchiveFileStreamContext.cs
+++ b/src/DTF/Libraries/Compression/ArchiveFileStreamContext.cs
@@ -633,13 +633,13 @@ namespace Microsoft.Deployment.Compression
             }
             else
             {
+                this.ValidateArchivePath(path);
+
                 filePath = path;
             }
 
             if (filePath != null)
             {
-                this.ValidateArchivePath(filePath);
-
                 if (this.directory != null)
                 {
                     filePath = Path.Combine(this.directory, filePath);

--- a/src/DTF/Libraries/Compression/Compression.csproj
+++ b/src/DTF/Libraries/Compression/Compression.csproj
@@ -12,6 +12,7 @@
     <CreateDocumentationFile>true</CreateDocumentationFile>
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <FxCopEnabled>false</FxCopEnabled>
+    <ShouldSignOutput>true</ShouldSignOutput>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DTF/Libraries/Resources/Resources.csproj
+++ b/src/DTF/Libraries/Resources/Resources.csproj
@@ -10,6 +10,7 @@
     <AssemblyName>Microsoft.Deployment.Resources</AssemblyName>
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <CreateDocumentationFile>true</CreateDocumentationFile>
+    <ShouldSignOutput>true</ShouldSignOutput>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DTF/Libraries/WindowsInstaller.Linq/WindowsInstaller.Linq.csproj
+++ b/src/DTF/Libraries/WindowsInstaller.Linq/WindowsInstaller.Linq.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>Microsoft.Deployment.WindowsInstaller.Linq</AssemblyName>
     <CreateDocumentationFile>true</CreateDocumentationFile>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <ShouldSignOutput>true</ShouldSignOutput>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DTF/Libraries/WindowsInstaller.Package/WindowsInstaller.Package.csproj
+++ b/src/DTF/Libraries/WindowsInstaller.Package/WindowsInstaller.Package.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>Microsoft.Deployment.WindowsInstaller.Package</AssemblyName>
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <CreateDocumentationFile>true</CreateDocumentationFile>
+    <ShouldSignOutput>true</ShouldSignOutput>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DTF/Libraries/WindowsInstaller/WindowsInstaller.csproj
+++ b/src/DTF/Libraries/WindowsInstaller/WindowsInstaller.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>Microsoft.Deployment.WindowsInstaller</AssemblyName>
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <CreateDocumentationFile>true</CreateDocumentationFile>
+    <ShouldSignOutput>true</ShouldSignOutput>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DTF/Tools/SfxCA/SfxCA.vcxproj
+++ b/src/DTF/Tools/SfxCA/SfxCA.vcxproj
@@ -30,6 +30,7 @@
     <TargetName>SfxCA</TargetName>
     <CharacterSet>Unicode</CharacterSet>
     <ProjectModuleDefinitionFile>EntryPoints.def</ProjectModuleDefinitionFile>
+    <ShouldSignOutput>true</ShouldSignOutput>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), wix.proj))\tools\WixBuild.props" />

--- a/src/burn/engine/apply.cpp
+++ b/src/burn/engine/apply.cpp
@@ -1824,6 +1824,7 @@ static HRESULT ExecuteExePackage(
     HRESULT hrExecute = S_OK;
     GENERIC_EXECUTE_MESSAGE message = { };
     int nResult = 0;
+    BOOL fDisplayInternalUi = false;
 
     if (FAILED(pExecuteAction->exePackage.pPackage->hrCacheResult))
     {
@@ -1835,7 +1836,7 @@ static HRESULT ExecuteExePackage(
     pContext->pExecutingPackage = pExecuteAction->exePackage.pPackage;
 
     // send package execute begin to UX
-    nResult = pEngineState->userExperience.pUserExperience->OnExecutePackageBegin(pExecuteAction->exePackage.pPackage->sczId, !fRollback);
+    nResult = pEngineState->userExperience.pUserExperience->OnExecutePackageBegin(pExecuteAction->exePackage.pPackage->sczId, !fRollback, &fDisplayInternalUi);
     hr = UserExperienceInterpretExecuteResult(&pEngineState->userExperience, fRollback, MB_OKCANCEL, nResult);
     ExitOnRootFailure(hr, "UX aborted execute EXE package begin.");
 
@@ -1900,7 +1901,8 @@ static HRESULT ExecuteMsiPackage(
     pContext->pExecutingPackage = pExecuteAction->msiPackage.pPackage;
 
     // send package execute begin to UX
-    nResult = pEngineState->userExperience.pUserExperience->OnExecutePackageBegin(pExecuteAction->msiPackage.pPackage->sczId, !fRollback);
+    nResult = pEngineState->userExperience.pUserExperience->OnExecutePackageBegin(pExecuteAction->msiPackage.pPackage->sczId, !fRollback, &(pExecuteAction->msiPackage.pPackage->Msi.fDisplayInternalUI));
+    pExecuteAction->msiPackage.uiLevel = MsiEngineCalculateInstallUiLevel(pExecuteAction->msiPackage.pPackage->Msi.fDisplayInternalUI, pEngineState->command.display, pExecuteAction->msiPackage.action);
     hr = UserExperienceInterpretExecuteResult(&pEngineState->userExperience, fRollback, MB_OKCANCEL, nResult);
     ExitOnRootFailure(hr, "UX aborted execute MSI package begin.");
 
@@ -1951,7 +1953,8 @@ static HRESULT ExecuteMspPackage(
     pContext->pExecutingPackage = pExecuteAction->mspTarget.pPackage;
 
     // send package execute begin to UX
-    nResult = pEngineState->userExperience.pUserExperience->OnExecutePackageBegin(pExecuteAction->mspTarget.pPackage->sczId, !fRollback);
+    nResult = pEngineState->userExperience.pUserExperience->OnExecutePackageBegin(pExecuteAction->mspTarget.pPackage->sczId, !fRollback, &(pExecuteAction->mspTarget.pPackage->Msp.fDisplayInternalUI));
+    pExecuteAction->mspTarget.uiLevel = MsiEngineCalculateInstallUiLevel(pExecuteAction->mspTarget.pPackage->Msp.fDisplayInternalUI, pEngineState->command.display, pExecuteAction->mspTarget.action);
     hr = UserExperienceInterpretExecuteResult(&pEngineState->userExperience, fRollback, MB_OKCANCEL, nResult);
     ExitOnRootFailure(hr, "UX aborted execute MSP package begin.");
 
@@ -2003,6 +2006,7 @@ static HRESULT ExecuteMsuPackage(
     HRESULT hrExecute = S_OK;
     GENERIC_EXECUTE_MESSAGE message = { };
     int nResult = 0;
+    BOOL fDisplayInternalUi = false;
 
     if (FAILED(pExecuteAction->msuPackage.pPackage->hrCacheResult))
     {
@@ -2014,7 +2018,7 @@ static HRESULT ExecuteMsuPackage(
     pContext->pExecutingPackage = pExecuteAction->msuPackage.pPackage;
 
     // send package execute begin to UX
-    nResult = pEngineState->userExperience.pUserExperience->OnExecutePackageBegin(pExecuteAction->msuPackage.pPackage->sczId, !fRollback);
+    nResult = pEngineState->userExperience.pUserExperience->OnExecutePackageBegin(pExecuteAction->msuPackage.pPackage->sczId, !fRollback, &fDisplayInternalUi);
     hr = UserExperienceInterpretExecuteResult(&pEngineState->userExperience, fRollback, MB_OKCANCEL, nResult);
     ExitOnRootFailure(hr, "UX aborted execute MSU package begin.");
 

--- a/src/burn/inc/IBootstrapperApplication.h
+++ b/src/burn/inc/IBootstrapperApplication.h
@@ -606,7 +606,8 @@ DECLARE_INTERFACE_IID_(IBootstrapperApplication, IUnknown, "53C31D56-49C0-426B-A
     //  IDNOACTION instructs the engine to continue.
     STDMETHOD_(int, OnExecutePackageBegin)(
         __in_z LPCWSTR wzPackageId,
-        __in BOOL fExecute
+        __in BOOL fExecute,
+        __inout BOOL* pDisplayInternalUi
         ) = 0;
 
     // OnExecutePatchTarget - called when the engine executes one or more patches targeting

--- a/src/ext/BalExtension/mba/core/BootstrapperApplication.cs
+++ b/src/ext/BalExtension/mba/core/BootstrapperApplication.cs
@@ -1425,11 +1425,12 @@ namespace Microsoft.Tools.WindowsInstallerXml.Bootstrapper
             return args.Result;
         }
 
-        Result IBootstrapperApplication.OnExecutePackageBegin(string wzPackageId, bool fExecute)
+        Result IBootstrapperApplication.OnExecutePackageBegin(string wzPackageId, bool fExecute, ref bool displayInternalUi)
         {
-            ExecutePackageBeginEventArgs args = new ExecutePackageBeginEventArgs(wzPackageId, fExecute);
+            ExecutePackageBeginEventArgs args = new ExecutePackageBeginEventArgs(wzPackageId, fExecute, displayInternalUi);
             this.OnExecutePackageBegin(args);
 
+            displayInternalUi = args.DisplayinternalUi;
             return args.Result;
         }
 

--- a/src/ext/BalExtension/mba/core/EventArgs.cs
+++ b/src/ext/BalExtension/mba/core/EventArgs.cs
@@ -1514,16 +1514,19 @@ namespace Microsoft.Tools.WindowsInstallerXml.Bootstrapper
     {
         private string packageId;
         private bool shouldExecute;
+        private bool displayInternalUi;
 
         /// <summary>
         /// Creates a new instance of the <see cref="ExecutePackageBeginEventArgs"/> class.
         /// </summary>
         /// <param name="packageId">The identity of the package to act on.</param>
         /// <param name="shouldExecute">Whether the package should really be acted on.</param>
-        public ExecutePackageBeginEventArgs(string packageId, bool shouldExecute)
+        /// <param name="displayInternalUi">Whether the package should display it's internal UI</param>
+        public ExecutePackageBeginEventArgs(string packageId, bool shouldExecute, bool displayInternalUi)
         {
             this.packageId = packageId;
             this.shouldExecute = shouldExecute;
+            this.displayInternalUi = displayInternalUi;
         }
 
         /// <summary>
@@ -1540,6 +1543,18 @@ namespace Microsoft.Tools.WindowsInstallerXml.Bootstrapper
         public bool ShouldExecute
         {
             get { return this.shouldExecute; }
+        }
+
+        public bool DisplayinternalUi 
+        { 
+            get
+            {
+                return this.displayInternalUi;
+            }
+            set
+            {
+                this.displayInternalUi = value;
+            }
         }
     }
 

--- a/src/ext/BalExtension/mba/core/IBootstrapperApplication.cs
+++ b/src/ext/BalExtension/mba/core/IBootstrapperApplication.cs
@@ -314,7 +314,8 @@ namespace Microsoft.Tools.WindowsInstallerXml.Bootstrapper
         [return: MarshalAs(UnmanagedType.I4)]
         Result OnExecutePackageBegin(
             [MarshalAs(UnmanagedType.LPWStr)] string wzPackageId,
-            [MarshalAs(UnmanagedType.Bool)] bool fExecute
+            [MarshalAs(UnmanagedType.Bool)] bool fExecute,
+            [MarshalAs(UnmanagedType.Bool)] ref bool fDisplayInternalUi
             );
 
         [PreserveSig]

--- a/src/ext/BalExtension/mba/core/core.csproj
+++ b/src/ext/BalExtension/mba/core/core.csproj
@@ -14,7 +14,7 @@
     <CreateDocumentationFile>true</CreateDocumentationFile>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <FxCopEnabled>true</FxCopEnabled>
-    <SignOutput Condition="'$(PleaseSignOutput)'!=''">true</SignOutput>
+    <ShouldSignOutput>true</ShouldSignOutput>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ext/BalExtension/mba/core/core.csproj
+++ b/src/ext/BalExtension/mba/core/core.csproj
@@ -14,6 +14,7 @@
     <CreateDocumentationFile>true</CreateDocumentationFile>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <FxCopEnabled>true</FxCopEnabled>
+    <SignOutput Condition="'$(PleaseSignOutput)'!=''">true</SignOutput>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
+++ b/src/ext/BalExtension/wixstdba/WixStandardBootstrapperApplication.cpp
@@ -738,7 +738,8 @@ public: // IBootstrapperApplication
 
     virtual STDMETHODIMP_(int) OnExecutePackageBegin(
         __in_z LPCWSTR wzPackageId,
-        __in BOOL fExecute
+        __in BOOL fExecute,
+        __inout BOOL* pDisplayInternalUi
         )
     {
         LPWSTR sczFormattedString = NULL;
@@ -792,7 +793,7 @@ public: // IBootstrapperApplication
         }
 
         ReleaseStr(sczFormattedString);
-        return __super::OnExecutePackageBegin(wzPackageId, fExecute);
+        return __super::OnExecutePackageBegin(wzPackageId, fExecute, pDisplayInternalUi);
     }
 
 

--- a/src/ext/DifxAppExtension/difxapp.proj
+++ b/src/ext/DifxAppExtension/difxapp.proj
@@ -4,6 +4,12 @@
 
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <ItemGroup>
+    <ProjectReference Include="wixlib\DIFxAppExtension.wixproj">
+      <Properties>Platform=x86</Properties>
+    </ProjectReference>
+    <ProjectReference Include="wixlib\DIFxAppExtension.wixproj">
+      <Properties>Platform=x64</Properties>
+    </ProjectReference>
     <ProjectReference Include="wixext\WixDifxAppExtension.csproj" />
   </ItemGroup>
 

--- a/src/ext/UtilExtension/util.proj
+++ b/src/ext/UtilExtension/util.proj
@@ -4,8 +4,8 @@
 
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <ItemGroup>
-    <ProjectReference Include="wixext\WixUtilExtension.csproj" />
     <ProjectReference Include="wixlib\UtilExtension.wixproj" />
+    <ProjectReference Include="wixext\WixUtilExtension.csproj" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), wix.proj))\tools\Traversal.targets" />

--- a/src/ext/VSExtension/vs.proj
+++ b/src/ext/VSExtension/vs.proj
@@ -5,8 +5,8 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <ItemGroup>
     <ProjectReference Include="ca\vsca.vcxproj" />
-    <ProjectReference Include="wixext\WixVSExtension.csproj" />
     <ProjectReference Include="wixlib\VSExtension.wixproj" />
+    <ProjectReference Include="wixext\WixVSExtension.csproj" />
 
     <ProjectReference Include="wixext\WixVSExtension.MSBuild12\WixVSExtension.MSBuild12.csproj" Condition=" '$(VS2013Available)'=='true' " />
     <ProjectReference Include="wixext\WixVSExtension.MSBuild14\WixVSExtension.MSBuild14.csproj" Condition=" '$(VS2015Available)'=='true' " />

--- a/src/ext/ext.proj
+++ b/src/ext/ext.proj
@@ -11,6 +11,8 @@
       <BuildInParallel>false</BuildInParallel>
     </ProjectReference>
 
+    <ProjectReference Include="UtilExtension\util.proj" />
+
     <ProjectReference Include="BalExtension\bal.proj" />
     <ProjectReference Include="ComPlusExtension\complus.proj" />
     <ProjectReference Include="DependencyExtension\dependency.proj" />
@@ -27,7 +29,6 @@
     <ProjectReference Include="SqlExtension\sql.proj" />
     <ProjectReference Include="TagExtension\tag.proj" />
     <ProjectReference Include="UIExtension\ui.proj" />
-    <ProjectReference Include="UtilExtension\util.proj" />
     <ProjectReference Include="VSExtension\vs.proj" />
   </ItemGroup>
 

--- a/src/libs/balutil/inc/BalBaseBootstrapperApplication.h
+++ b/src/libs/balutil/inc/BalBaseBootstrapperApplication.h
@@ -431,7 +431,8 @@ public: // IBootstrapperApplication
 
     virtual STDMETHODIMP_(int) OnExecutePackageBegin(
         __in_z LPCWSTR wzPackageId,
-        __in BOOL fExecute
+        __in BOOL fExecute,
+        __inout BOOL* pDisplayInternalUi
         )
     {
         // Only track retry on execution (not rollback).
@@ -439,6 +440,8 @@ public: // IBootstrapperApplication
         {
             BalRetryStartPackage(BALRETRY_TYPE_EXECUTE, wzPackageId, NULL);
         }
+
+        if(*pDisplayInternalUi){/*NOPE*/}
 
         m_fRollingBack = !fExecute;
         return CheckCanceled() ? IDCANCEL : IDNOACTION;

--- a/tools/Dotnet.targets
+++ b/tools/Dotnet.targets
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+
+
+<Project InitialTargets="DotnetToolRestore" 
+  xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <WixRoot Condition=" '$(WixRoot)'=='' ">$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)..\))</WixRoot>
+    <DotnetToolsFolder>$(WixRoot)packages\tools\</DotnetToolsFolder>
+    <DotnetExe>$(ProgramW6432)\dotnet\dotnet.exe</DotnetExe>
+    <DotnetExe Condition="!Exists('$(DotnetExe)')">$(MSBuildProgramFiles32)\dotnet\dotnet.exe</DotnetExe>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SignClientPath>$(DotnetToolsFolder)SignClient.exe</SignClientPath>
+  </PropertyGroup>
+
+  <!--
+  ================================================================================================
+  DotnetToolRestore
+
+    Restores the required packages to build using nuget.exe.
+  ================================================================================================
+  -->
+  <ItemGroup>
+    <RestoreDotnetToolsPackage Include="SignClient" Condition="'$(PleaseSignOutput)'!=''">
+      <Version>1.1.7</Version>
+    </RestoreDotnetToolsPackage>
+  </ItemGroup>
+  <Target Name="DotnetToolRestore" DependsOnTargets="_FindDotnetExe;_FindMissingDotnetToolPackages">
+    <Exec Command="&quot;$(DotnetExe)&quot; tool install %(Identity) --version %(Version) --tool-path &quot;$(DotnetToolsFolder)\&quot;" Condition="Exists('$(DotnetExe)') and '@(_MissingDotnetToolPackage)'!=''" WorkingDirectory="$(MSBuildThisFileDirectory)" />
+  </Target>
+
+  <Target Name="_FindMissingDotnetToolPackages">
+    <CreateItem Include="@(RestoreDotnetToolsPackage)" Condition="!Exists('$(DotnetToolsFolder).store\%(Identity)\%(Version)\%(Identity)\%(Version)\%(Identity).%(Version).nupkg')" PreserveExistingMetadata="true">
+      <Output TaskParameter="Include" ItemName="_MissingDotnetToolPackage"/>
+    </CreateItem>
+  </Target>
+
+  <!-- Find dotnet.exe in the PATH if it is not in the default location. -->
+  <Target Name="_FindDotnetExe" Condition="!Exists('$(DotnetExe)')">
+    <CreateItem Include="$(PATH)">
+      <Output TaskParameter="Include" ItemName="_FindDotnetExePaths" />
+    </CreateItem>
+    <CombinePath BasePath="%(_FindDotnetExePaths.Identity)" Paths="dotnet.exe">
+      <Output TaskParameter="CombinedPaths" ItemName="_FindDotnetExeCombinedPaths" />
+    </CombinePath>
+    <CreateItem Include="@(_FindDotnetExeCombinedPaths->Reverse())">
+      <Output TaskParameter="Include" ItemName="_FindDotnetExeCombinedPathsReversed" />
+    </CreateItem>
+    <CreateItem Include="@(_FindDotnetExeCombinedPathsReversed)">
+      <Output TaskParameter="Include" PropertyName="DotnetExe" Condition="Exists('%(_FindDotnetExeCombinedPathsReversed.Identity)')" />
+    </CreateItem>
+  </Target>
+
+  <!-- Sentinel value that indicates Dotnet.targets has been initialized. -->
+  <PropertyGroup>
+    <WixBuildDotnetToolPropertiesDefined>true</WixBuildDotnetToolPropertiesDefined>
+  </PropertyGroup>
+</Project>

--- a/tools/WixBuild.Signing.targets
+++ b/tools/WixBuild.Signing.targets
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+
+
+<Project InitialTargets="DotnetToolRestore" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <!-- Ensure that the SignClient is initialized. -->
+  <Import Project="Dotnet.targets" Condition="'$(WixBuildDotnetToolPropertiesDefined)'!='true'" />
+
+  <PropertyGroup>
+    <_SigningAppSettingsPath>$(MSBuildThisFileDirectory)appsettings.json</_SigningAppSettingsPath>
+    <_SigningFilterNonePath>$(MSBuildThisFileDirectory)signing-filter.none.txt</_SigningFilterNonePath>
+    <_SigningName>WiX Toolset</_SigningName>
+    <_SigningUrl>http://wixtoolset.org</_SigningUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- By default, $(TargetPath) will be signed. You can add files to @(FilesToSign) to sign them as well. -->
+    <FilesToSign Include="$(TargetPath)" />
+  </ItemGroup>
+
+  <Target Name="SignFiles" AfterTargets="AfterBuild" Condition="'$(SignOutput)'=='true'">
+    <Exec Command="&quot;$(SignClientPath)&quot; sign -c &quot;$(_SigningAppSettingsPath)&quot; -i &quot;%(FilesToSign.FullPath)&quot; -f &quot;$(_SigningFilterNonePath)&quot; -s &quot;$(SignClientSecret)&quot; -r &quot;$(SignClientUser)&quot; -n &quot;$(_SigningName)&quot; -d &quot;$(_SigningName)&quot; -u &quot;$(_SigningUrl)&quot;" />
+  </Target>
+
+  <!--
+  ================================================================================================
+
+    Signing overrides to actually do signing. We don't sign the MSI packages or their CABs because
+    they are always wrapped in a bundle that is signed.
+
+  ================================================================================================
+  -->
+  <Target Name="SignCabs">
+    <!-- <Exec Command="&quot;$(SignClientPath)&quot; sign -c &quot;$(_SigningAppSettingsPath)&quot; -i &quot;%(SignCabs.FullPath)&quot; -f &quot;$(_SigningFilterNonePath)&quot; -s &quot;$(SignClientSecret)&quot; -r &quot;$(SignClientUser)&quot; -n &quot;$(_SigningName)&quot; -d &quot;$(_SigningName)&quot; -u &quot;$(_SigningUrl)&quot;" /> -->
+  </Target>
+
+  <Target Name="SignMsi">
+    <!-- <Exec Command="&quot;$(SignClientPath)&quot; sign -c &quot;$(_SigningAppSettingsPath)&quot; -i &quot;%(SignMsi.FullPath)&quot; -f &quot;$(_SigningFilterNonePath)&quot; -s &quot;$(SignClientSecret)&quot; -r &quot;$(SignClientUser)&quot; -n &quot;$(_SigningName)&quot; -d &quot;$(_SigningName)&quot; -u &quot;$(_SigningUrl)&quot;" /> -->
+  </Target>
+
+  <Target Name="SignContainers">
+    <Exec Command="&quot;$(SignClientPath)&quot; sign -c &quot;$(_SigningAppSettingsPath)&quot; -i &quot;%(SignContainers.FullPath)&quot; -f &quot;$(_SigningFilterNonePath)&quot; -s &quot;$(SignClientSecret)&quot; -r &quot;$(SignClientUser)&quot; -n &quot;$(_SigningName)&quot; -d &quot;$(_SigningName)&quot; -u &quot;$(_SigningUrl)&quot;" />
+  </Target>
+
+  <Target Name="SignBundleEngine">
+    <Exec Command="&quot;$(SignClientPath)&quot; sign -c &quot;$(_SigningAppSettingsPath)&quot; -i &quot;%(SignBundleEngine.FullPath)&quot; -f &quot;$(_SigningFilterNonePath)&quot; -s &quot;$(SignClientSecret)&quot; -r &quot;$(SignClientUser)&quot; -n &quot;$(_SigningName)&quot; -d &quot;$(_SigningName)&quot; -u &quot;$(_SigningUrl)&quot;" />
+  </Target>
+
+  <Target Name="SignBundle">
+    <Exec Command="&quot;$(SignClientPath)&quot; sign -c &quot;$(_SigningAppSettingsPath)&quot; -i &quot;%(SignBundle.FullPath)&quot; -f &quot;$(_SigningFilterNonePath)&quot; -s &quot;$(SignClientSecret)&quot; -r &quot;$(SignClientUser)&quot; -n &quot;$(_SigningName)&quot; -d &quot;$(_SigningName)&quot; -u &quot;$(_SigningUrl)&quot;" />
+  </Target>
+
+  <!-- Sentinel value that indicates WixBuid.Signing.targets has been initialized. -->
+  <PropertyGroup>
+    <WixBuildSigningTargetsDefined>true</WixBuildSigningTargetsDefined>
+  </PropertyGroup>
+</Project>

--- a/tools/WixBuild.Tools.targets
+++ b/tools/WixBuild.Tools.targets
@@ -15,6 +15,9 @@
   <!-- Steal some tasks from the MSBuild tasks assembly -->
   <UsingTask TaskName="AssignTargetPath" AssemblyName="Microsoft.Build.Tasks, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 
+  <!-- Ensure Signing targets are imported. -->
+  <Import Project="WixBuild.Signing.targets" Condition="'$(WixBuildSigningTargetsDefined)'!='true'" />
+
   <!--
   ================================================================================================
   Diagnostics
@@ -119,6 +122,16 @@
       Code="WIXBUILD013"
       Condition=" $(BuildArm) and !(Exists('$(PlatformSdkArmLibraryRoot)')) "
       Text="No suitable Windows SDK found to build ARM" />
+
+    <Error
+      Code="WIXBUILD014"
+      Condition=" '$(PleaseSignOutput)'!='' and !Exists('$(SignClientPath)') "
+      Text="Cannot locate SignClient. Ensure SignClient is present at &quot;$(SignClientPath)&quot;. If not, run the following command from the root of the project: msbuild -t:DotnetToolRestore" />
+
+    <Error
+      Code="WIXBUILD015"
+      Condition=" '$(PleaseSignOutput)'!='' and ('$(SignClientUser)'=='' or '$(SignClientSecret)'=='') "
+      Text="Signing is requested but one or both required properites SignClientUser and SignClientSecret were not specified on the command line or as environment variables." />
 
   </Target>
 

--- a/tools/WixBuild.Version.targets
+++ b/tools/WixBuild.Version.targets
@@ -7,7 +7,7 @@
         <MajorBuildNumber>3</MajorBuildNumber>
         <MinorBuildNumber>11</MinorBuildNumber>
         <StartBuildYear>2016</StartBuildYear>
-        <BuildRevision>1</BuildRevision>
+        <BuildRevision>2</BuildRevision>
 
         <MajorMinorVersionString>$(MajorBuildNumber)$(MinorBuildNumber)</MajorMinorVersionString>
         <MajorMinorVersionDottedString>$(MajorBuildNumber).$(MinorBuildNumber)</MajorMinorVersionDottedString>

--- a/tools/WixBuild.Version.targets
+++ b/tools/WixBuild.Version.targets
@@ -7,7 +7,7 @@
         <MajorBuildNumber>3</MajorBuildNumber>
         <MinorBuildNumber>11</MinorBuildNumber>
         <StartBuildYear>2016</StartBuildYear>
-        <BuildRevision>0</BuildRevision>
+        <BuildRevision>1</BuildRevision>
 
         <MajorMinorVersionString>$(MajorBuildNumber)$(MinorBuildNumber)</MajorMinorVersionString>
         <MajorMinorVersionDottedString>$(MajorBuildNumber).$(MinorBuildNumber)</MajorMinorVersionDottedString>

--- a/tools/WixBuild.csproj.targets
+++ b/tools/WixBuild.csproj.targets
@@ -11,5 +11,6 @@
       $(PrepareForBuildDependsOn);
       WriteCSharpVersionFile
     </PrepareForBuildDependsOn>
+    <SignOutput Condition="'$(SignOutput)'=='' and '$(ShouldSignOutput)'=='true' and '$(PleaseSignOutput)'!=''">true</SignOutput>
   </PropertyGroup>
 </Project>

--- a/tools/WixBuild.props
+++ b/tools/WixBuild.props
@@ -30,6 +30,7 @@
   </PropertyGroup>
 
   <Import Project="Nuget.targets" />
+  <Import Project="Dotnet.targets" />
 
   <!-- Converts the VS-standard Debug and Release to the wix-standard debug and ship -->
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' or '$(Configuration)' == '' or '$(WixFlavor)' == 'debug' ">

--- a/tools/WixBuild.targets
+++ b/tools/WixBuild.targets
@@ -6,6 +6,7 @@
 
   <Import Project="WixBuild.props" Condition=" '$(WixBuildPropertiesDefined)'!='true' " />
   <Import Project="WixBuild$(MSBuildProjectExtension).targets" Condition=" Exists('WixBuild$(MSBuildProjectExtension).targets') " />
+  <Import Project="WixBuild.Signing.targets" />
   <Import Project="WixBuild.Tools.targets" />
   <Import Project="WixBuild.VisualStudioSdk.targets" Condition=" '$(TargetVisualStudio)'!='' " />
 

--- a/tools/WixBuild.vcxproj.props
+++ b/tools/WixBuild.vcxproj.props
@@ -48,6 +48,7 @@
     <OutDir Condition=" '$(MultiTargetLibrary)'=='true' ">$(OutDir)$(MultiTargetDirSuffix)\</OutDir>
 
     <AdditionalMultiTargetLibraryPath Condition=" '$(MultiTargetLibrary)'!='true' ">$(OutputPath)$(MultiTargetDirSuffix)\</AdditionalMultiTargetLibraryPath>
+    <SignOutput Condition="'$(PleaseSignOutput)'!='' and $(MSBuildProjectDirectory.Contains('\src\ext\')) and '$(ConfigurationType)'=='DynamicLibrary'">true</SignOutput>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tools/WixBuild.vcxproj.props
+++ b/tools/WixBuild.vcxproj.props
@@ -48,7 +48,7 @@
     <OutDir Condition=" '$(MultiTargetLibrary)'=='true' ">$(OutDir)$(MultiTargetDirSuffix)\</OutDir>
 
     <AdditionalMultiTargetLibraryPath Condition=" '$(MultiTargetLibrary)'!='true' ">$(OutputPath)$(MultiTargetDirSuffix)\</AdditionalMultiTargetLibraryPath>
-    <SignOutput Condition="'$(PleaseSignOutput)'!='' and $(MSBuildProjectDirectory.Contains('\src\ext\')) and '$(ConfigurationType)'=='DynamicLibrary'">true</SignOutput>
+    <ShouldSignOutput Condition="$(MSBuildProjectDirectory.Contains('\src\ext\')) and '$(ConfigurationType)'=='DynamicLibrary'">true</ShouldSignOutput>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tools/WixBuild.vcxproj.targets
+++ b/tools/WixBuild.vcxproj.targets
@@ -11,5 +11,6 @@
       WriteCppVersionFile;
       GenerateWixInclude
     </PrepareForBuildDependsOn>
+    <SignOutput Condition="'$(SignOutput)'=='' and '$(ShouldSignOutput)'=='true' and '$(PleaseSignOutput)'!=''">true</SignOutput>
   </PropertyGroup>
 </Project>

--- a/tools/WixBuild.wixproj.targets
+++ b/tools/WixBuild.wixproj.targets
@@ -3,40 +3,7 @@
 
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
-  <PropertyGroup>
-    <SignToolExe>&quot;$(PlatformSdkBinPath)signtool.exe&quot;</SignToolExe>
-  </PropertyGroup>
-
   <Import Project="$(WixTargetsPath)" />
-
-  <!-- Signing overrides to actually do signing -->
-  <!--
-    We don't sign the Msi Packages or their cabinets because they are
-    always wrapped in a bundle that is signed.
-  -->
-  <Target Name="SignCabs">
-  <!--
-    <Exec Command="$(SignToolExe) sign /n &quot;.NET Foundation&quot; /t http://timestamp.digicert.com &quot;%(SignCabs.FullPath)&quot;" />
-  -->
-  </Target>
-
-  <Target Name="SignMsi">
-  <!--
-    <Exec Command="$(SignToolExe) sign /n &quot;.NET Foundation&quot; /t http://timestamp.digicert.com &quot;%(SignMsi.FullPath)&quot;" />
-  -->
-  </Target>
-
-  <Target Name="SignContainers">
-    <Exec Command="$(SignToolExe) sign /n &quot;.NET Foundation&quot; /t http://timestamp.digicert.com &quot;%(SignContainers.FullPath)&quot;" />
-  </Target>
-
-  <Target Name="SignBundleEngine">
-    <Exec Command="$(SignToolExe) sign /n &quot;.NET Foundation&quot; /t http://timestamp.digicert.com &quot;%(SignBundleEngine.FullPath)&quot;" />
-  </Target>
-
-  <Target Name="SignBundle">
-    <Exec Command="$(SignToolExe) sign /n &quot;.NET Foundation&quot; /t http://timestamp.digicert.com &quot;%(SignBundle.FullPath)&quot;" />
-  </Target>
 
   <PropertyGroup>
     <PrepareForBuildDependsOn>

--- a/tools/appsettings.json
+++ b/tools/appsettings.json
@@ -1,0 +1,13 @@
+{
+  "SignClient": {
+    "AzureAd": {
+      "AADInstance": "https://login.microsoftonline.com/",
+      "ClientId": "c248d68a-ba6f-4aa9-8a68-71fe872063f8",
+      "TenantId": "16076fdc-fcc1-4a15-b1ca-32c9a255900e"
+    },
+    "Service": {
+      "Url": "https://codesign.dotnetfoundation.org/",
+      "ResourceId": "https://SignService/3c30251f-36f3-490b-a955-520addb85001"
+    }
+  }
+}

--- a/tools/signing-filter.none.txt
+++ b/tools/signing-filter.none.txt
@@ -1,0 +1,1 @@
+sign-no-files


### PR DESCRIPTION

Fixes [#3703](https://github.com/wixtoolset/issues/issues/3703)

## WiX v3.x pull requests

Active development has now moved to [WiX v4][wix4].

Since there is no stable release version of Wix 4.x, I changed the sources in the 3.x repository, because hopefully there will be another stable version of Wix 3.x

Pull requests for WiX v3.x must be approved before they can be reviewed or accepted.

There are only a few lines of code which needs to be changed to fix this issue / implement this feature. It is now possible to change the "DisplayInternalUi" flag of each (MSI) package of a bootstrapper burn setup during the execution-process. So the end-user can decide to show the internal UI of a package durring installation and the developer must not provide two different bootstrapper setups (one with and one without GUI).



[issue]: https://github.com/wixtoolset/issues/issues/3703
[wix4]: https://github.com/wixtoolset/wix4
[wixdevs]: http://wixtoolset.org/documentation/mailinglist/