### PR TITLE
WIXFEAT:5658 - Retry ElevationElevate once if we think it failed due to antivirus interference.

### DIFF
--- a/history/5658.md
+++ b/history/5658.md
@@ -1,0 +1,1 @@
+* ipetrovic11,stukselbax,SeanHall: WIXFEAT:5658 - Retry launching the elevated bundle once if we think it failed due to antivirus interference.

--- a/src/burn/engine/elevation.cpp
+++ b/src/burn/engine/elevation.cpp
@@ -275,6 +275,10 @@ extern "C" HRESULT ElevationElevate(
             LogId(REPORT_STANDARD, MSG_LAUNCH_ELEVATED_ENGINE_SUCCESS);
 
             hr = PipeWaitForChildConnect(&pEngineState->companionConnection);
+            if (HRESULT_FROM_WIN32(ERROR_NO_DATA) == hr)
+            {
+                hr = E_SUSPECTED_AV_INTERFERENCE;
+            }
             ExitOnFailure(hr, "Failed to connect to elevated child process.");
 
             LogId(REPORT_STANDARD, MSG_CONNECT_TO_ELEVATED_ENGINE_SUCCESS);

--- a/src/burn/inc/IBootstrapperEngine.h
+++ b/src/burn/inc/IBootstrapperEngine.h
@@ -5,6 +5,12 @@
 #define IDERROR -1
 #define IDNOACTION 0
 
+#ifndef FACILITY_WIX
+#define FACILITY_WIX 500
+#endif
+
+static const HRESULT E_SUSPECTED_AV_INTERFERENCE = MAKE_HRESULT(SEVERITY_ERROR, FACILITY_WIX, 2000);
+
 #define IDDOWNLOAD 101 // Only valid as a return code from OnResolveSource() to instruct the engine to use the download source.
 #define IDRESTART  102
 #define IDSUSPEND  103

--- a/src/libs/balutil/inc/balutil.h
+++ b/src/libs/balutil/inc/balutil.h
@@ -22,7 +22,9 @@ extern "C" {
 #define BalExitOnNullWithLastError(p, x, f) if (NULL == p) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (!FAILED(x)) { x = E_FAIL; } BalLogError(x, f); ExitTrace(x, f); goto LExit; }
 #define BalExitOnNullWithLastError1(p, x, f, s) if (NULL == p) { DWORD Dutil_er = ::GetLastError(); x = HRESULT_FROM_WIN32(Dutil_er); if (!FAILED(x)) { x = E_FAIL; } BalLogError(x, f, s); ExitTrace1(x, f, s); goto LExit; }
 
+#ifndef FACILITY_WIX
 #define FACILITY_WIX 500
+#endif
 
 static const HRESULT E_WIXSTDBA_CONDITION_FAILED = MAKE_HRESULT(SEVERITY_ERROR, FACILITY_WIX, 1);
 


### PR DESCRIPTION
Fixes wixtoolset/issues#5658 for wix3