### PR TITLE
SfxCA fixes

### DIFF
--- a/history/4688.md
+++ b/history/4688.md
@@ -1,0 +1,1 @@
+* RobMen: WIXBUG:4688 - Support really long paths in MakeSfxCA.exe by using a response file

--- a/history/6089.md
+++ b/history/6089.md
@@ -1,0 +1,1 @@
+* RobMen: WIXBUG:6089 - Do not sign SfxCA stub as it prevents signing actual CA dll

--- a/src/DTF/Tools/MakeSfxCA/MakeSfxCA.cs
+++ b/src/DTF/Tools/MakeSfxCA/MakeSfxCA.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Deployment.Tools.MakeSfxCA
     using Microsoft.Deployment.Compression.Cab;
     using Microsoft.Deployment.Resources;
     using ResourceCollection = Microsoft.Deployment.Resources.ResourceCollection;
+    using Microsoft.Tools.WindowsInstallerXml;
 
     /// <summary>
     /// Command-line tool for building self-extracting custom action packages.
@@ -48,6 +49,8 @@ namespace Microsoft.Deployment.Tools.MakeSfxCA
         /// <returns>0 on success, nonzero on failure.</returns>
         public static int Main(string[] args)
         {
+            args = ExpandArguments(args);
+
             if (args.Length < 3)
             {
                 Usage(Console.Out);
@@ -172,6 +175,35 @@ namespace Microsoft.Deployment.Tools.MakeSfxCA
             log.WriteLine("MakeSfxCA finished: " + new FileInfo(output).FullName);
         }
 
+        /// <summary>
+        /// Read the arguments include parsing response files.
+        /// </summary>
+        /// <param name="args">Arguments to expand</param>
+        /// <returns>Expanded list of arguments</returns>
+        private static string[] ExpandArguments(string[] args)
+        {
+            string[] result = new string[args.Length];
+            int j = 0;
+
+            for (int i = 0; i < args.Length; ++i)
+            {
+                if (args[i].StartsWith("@"))
+                {
+                    string[] parsed = CommandLineResponseFile.Parse(args[i].Substring(1));
+
+                    Array.Resize(ref result, result.Length + parsed.Length - 1);
+                    Array.Copy(parsed, 0, result, j, parsed.Length);
+                    j += parsed.Length;
+                }
+                else
+                {
+                    result[j] = args[i];
+                    ++j;
+                }
+            }
+
+            return result;
+        }
         /// <summary>
         /// Splits any list items delimited by semicolons into separate items.
         /// </summary>

--- a/src/DTF/Tools/MakeSfxCA/MakeSfxCA.csproj
+++ b/src/DTF/Tools/MakeSfxCA/MakeSfxCA.csproj
@@ -14,6 +14,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\..\tools\wconsole\CommandLineResponseFile.cs">
+      <Link>CommandLineResponseFile.cs</Link>
+    </Compile>
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="MakeSfxCA.cs" />
     <None Include="app.config" />

--- a/src/DTF/Tools/SfxCA/SfxCA.vcxproj
+++ b/src/DTF/Tools/SfxCA/SfxCA.vcxproj
@@ -30,7 +30,7 @@
     <TargetName>SfxCA</TargetName>
     <CharacterSet>Unicode</CharacterSet>
     <ProjectModuleDefinitionFile>EntryPoints.def</ProjectModuleDefinitionFile>
-    <ShouldSignOutput>true</ShouldSignOutput>
+    <ShouldSignOutput>false</ShouldSignOutput>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), wix.proj))\tools\WixBuild.props" />

--- a/src/tools/WixTasks/wix.ca.targets
+++ b/src/tools/WixTasks/wix.ca.targets
@@ -81,7 +81,7 @@
     </CreateProperty>
 
   </Target>
-  
+
   <!--
   ==================================================================================================
   PackCustomAction
@@ -93,7 +93,7 @@
     @(IntermediateAssembly) - Managed custom action assembly.
     @(Content) - Project items of type Content will be included in the package.
     $(CustomActionContents) - Optional space-delimited list of additional files to include.
-    
+
     [OUT]
     $(IntermediateOutputPath)$(TargetCAFileName) - Managed custom action package with unmanaged stub.
   ==================================================================================================
@@ -114,35 +114,35 @@
      Condition=" '%(ReferenceComWrappersToCopyLocal.extension)' == '.dll' or '%(ReferenceComWrappersToCopyLocal.extension)' == '.exe' ">
       <Output TaskParameter="Include" ItemName="CustomActionReferenceContents"/>
     </CreateItem>
-	
-	<!-- include PDBs for Debug only -->
-	<CreateItem
-	 Include="@(IntermediateAssembly->'%(RootDir)%(Directory)%(Filename).pdb')"
-	 Condition=" Exists('%(RootDir)%(Directory)%(Filename).pdb') and '$(Configuration)' == 'Debug' ">
-	  <Output TaskParameter="Include" ItemName="CustomActionReferenceContents"/>
-	</CreateItem>
-	
-	<CreateItem
-	 Include="@(ReferenceCopyLocalPaths)"
-	 Condition=" '%(ReferenceCopyLocalPaths.extension)' == '.pdb' and '$(Configuration)' == 'Debug' ">
-	  <Output TaskParameter="Include" ItemName="CustomActionReferenceContents"/>
-	</CreateItem>
-	
-	<CreateItem
+
+    <!-- include PDBs for Debug only -->
+    <CreateItem
+     Include="@(IntermediateAssembly->'%(RootDir)%(Directory)%(Filename).pdb')"
+     Condition=" Exists('%(RootDir)%(Directory)%(Filename).pdb') and '$(Configuration)' == 'Debug' ">
+      <Output TaskParameter="Include" ItemName="CustomActionReferenceContents"/>
+    </CreateItem>
+
+    <CreateItem
+     Include="@(ReferenceCopyLocalPaths)"
+     Condition=" '%(ReferenceCopyLocalPaths.extension)' == '.pdb' and '$(Configuration)' == 'Debug' ">
+      <Output TaskParameter="Include" ItemName="CustomActionReferenceContents"/>
+    </CreateItem>
+
+    <CreateItem
      Include="@(ReferenceComWrappersToCopyLocal)"
      Condition=" '%(ReferenceComWrappersToCopyLocal.extension)' == '.pdb' and '$(Configuration)' == 'Debug' ">
       <Output TaskParameter="Include" ItemName="CustomActionReferenceContents"/>
     </CreateItem>
-	
+
     <!--
-  Items to include in the CA package:
+    Items to include in the CA package:
      - Reference assemblies marked CopyLocal
      - Project items of type Content
      - Additional items in the CustomActionContents property
-  -->
-    <CreateProperty Value="@(CustomActionReferenceContents);@(Content->'%(FullPath)');$(CustomActionContents)">
-      <Output TaskParameter="Value" PropertyName="CustomActionContents" />
-    </CreateProperty>
+    -->
+    <CreateItem Include="@(CustomActionReferenceContents);@(Content->'%(FullPath)');$(CustomActionContents)">
+      <Output TaskParameter="Include" ItemName="CustomActionContents" />
+    </CreateItem>
 
     <CreateItem Include="@(IntermediateAssembly->'%(FullPath)')">
       <Output TaskParameter="Include" ItemName="IntermediateCAAssembly" />
@@ -152,13 +152,24 @@
       <Output TaskParameter="Include" ItemName="IntermediateCAPackage" />
     </CreateItem>
 
+    <CreateProperty Value="@(IntermediateCAPackage->'%(RootDir)%(Directory)%(Filename).rsp')">
+      <Output TaskParameter="Value" PropertyName="IntermediateCAResponseFile" />
+    </CreateProperty>
+
+    <!-- Use a response file to pass the potentially very long contents to MakeSfxCA.exe -->
+    <WriteLinesToFile File="$(IntermediateCAResponseFile)" Lines="@(CustomActionContents->'&quot;%(Identity)&quot;')" Overwrite="true" />
+
+    <CreateItem Include="$(IntermediateCAResponseFile)">
+      <Output TaskParameter="Include" ItemName="FileWrites" />
+    </CreateItem>
+
     <!-- Run the MakeSfxCA.exe CA packaging tool. -->
-    <Exec Command='"$(MakeSfxCA)" "@(IntermediateCAPackage)" "$(SfxCADll)" "@(IntermediateCAAssembly)" "$(CustomActionContents)"'
+    <Exec Command='"$(MakeSfxCA)" "@(IntermediateCAPackage)" "$(SfxCADll)" "@(IntermediateCAAssembly)" "@$(IntermediateCAResponseFile)"'
      WorkingDirectory="$(ProjectDir)" />
-  
+
     <!-- Add modules to be copied to output dir. -->
     <CreateItem Include="@(AddModules);@(IntermediateCAPackage)">
-    <Output TaskParameter="Include" ItemName="AddModules" />
+      <Output TaskParameter="Include" ItemName="AddModules" />
     </CreateItem>
 
   </Target>


### PR DESCRIPTION
Support really long paths in MakeSfxCA.exe by using a response file
Do not sign SfxCA stub as it prevents signing actual CA dll
