### PR TITLE
WIP: Fix wix3 CA building for sdk-style .csproj format

### DIFF
--- a/src/tools/WixTasks/wix.ca.targets
+++ b/src/tools/WixTasks/wix.ca.targets
@@ -15,11 +15,28 @@
     <WixTasksPath Condition=" '$(WixTasksPath)' == '' ">$(MSBuildExtensionsPath)\..\WiX Toolset v3.14\bin\WixTasks.dll</WixTasksPath>
     <!-- This is a fallback in case using the relative paths above did not work. -->
     <WixTasksPath Condition=" !Exists('$(WixTasksPath)') ">$(MSBuildProgramFiles32)\WiX Toolset v3.14\bin\WixTasks.dll</WixTasksPath>
-
-    <TargetCAFileName Condition=" '$(TargetCAFileName)' == '' ">$(TargetName).CA$(TargetExt)</TargetCAFileName>
   </PropertyGroup>
 
   <UsingTask TaskName="ReadRegistry" AssemblyFile="$(WixTasksPath)"/>
+
+
+  <!--
+  ==================================================================================================
+  CalculateTargetCAFileName
+
+    Creates property TargetCAFileName from TargetName and TargetExt properties.
+    This is necessary because of new sdk-style .csproj format, because there
+    TargetName and TargetExt properties can be only used inside targets otherwise they are blank.
+
+    [OUT]
+    $(TargetCAFileName) - Path for MakeSfxCA to create unmanaged custom action library
+  ==================================================================================================
+  -->
+  <Target Name="CalculateTargetCAFileName">
+    <PropertyGroup>
+      <TargetCAFileName Condition=" '$(TargetCAFileName)' == '' ">$(TargetName).CA$(TargetExt)</TargetCAFileName>
+    </PropertyGroup>
+  </Target>
 
   <!--
   ==================================================================================================
@@ -99,6 +116,7 @@
   ==================================================================================================
   -->
   <Target Name="PackCustomAction"
+   DependsOnTargets="CalculateTargetCAFileName"
    Inputs="@(IntermediateAssembly);@(Content);$(CustomActionContents)"
    Outputs="$(IntermediateOutputPath)$(TargetCAFileName)">
 
@@ -196,7 +214,7 @@
 
   ==================================================================================================
   -->
-  <Target Name="AfterCompile"
+  <Target Name="AfterCompileHack" AfterTargets="AfterCompile"
    DependsOnTargets="PackCustomAction" />
 
   <!--
@@ -208,7 +226,7 @@
 
   ==================================================================================================
   -->
-  <Target Name="BeforeClean"
+  <Target Name="BeforeCleanHack" AfterTargets="BeforeClean"
    DependsOnTargets="CleanCustomAction" />
 
   <Import Project="$(CustomAfterWixCATargets)" Condition=" '$(CustomAfterWixCATargets)' != '' and Exists('$(CustomAfterWixCATargets)')" />

--- a/src/tools/WixTasks/wix.ca.targets
+++ b/src/tools/WixTasks/wix.ca.targets
@@ -170,19 +170,8 @@
       <Output TaskParameter="Include" ItemName="IntermediateCAPackage" />
     </CreateItem>
 
-    <CreateProperty Value="@(IntermediateCAPackage->'%(RootDir)%(Directory)%(Filename).rsp')">
-      <Output TaskParameter="Value" PropertyName="IntermediateCAResponseFile" />
-    </CreateProperty>
-
-    <!-- Use a response file to pass the potentially very long contents to MakeSfxCA.exe -->
-    <WriteLinesToFile File="$(IntermediateCAResponseFile)" Lines="@(CustomActionContents->'&quot;%(Identity)&quot;')" Overwrite="true" />
-
-    <CreateItem Include="$(IntermediateCAResponseFile)">
-      <Output TaskParameter="Include" ItemName="FileWrites" />
-    </CreateItem>
-
     <!-- Run the MakeSfxCA.exe CA packaging tool. -->
-    <Exec Command='"$(MakeSfxCA)" "@(IntermediateCAPackage)" "$(SfxCADll)" "@(IntermediateCAAssembly)" "@$(IntermediateCAResponseFile)"'
+    <Exec Command='"$(MakeSfxCA)" "@(IntermediateCAPackage)" "$(SfxCADll)" "@(IntermediateCAAssembly)" "@(CustomActionContents)"'
      WorkingDirectory="$(ProjectDir)" />
 
     <!-- Add modules to be copied to output dir. -->


### PR DESCRIPTION
- Fix injection of wix AfterCompile and BeforeClean targets so that they are not overwritten by Microsoft targets
- Fix creation of TargetCAFileName property in SDK-style msbuild format

TL;DR
This fixes using WiX nuget for building Custom Actions in new sdk-style .csproj format.

More in the issue here: https://github.com/wixtoolset/issues/issues/6139