### PR TITLE
Add support for outbound firewall rules

### DIFF
--- a/history/4009.md
+++ b/history/4009.md
@@ -1,0 +1,1 @@
+* JanMoeller - WIXFEAT:4009 - Add support for outbound firewall rules

--- a/src/ext/FirewallExtension/wixext/FirewallCompiler.cs
+++ b/src/ext/FirewallExtension/wixext/FirewallCompiler.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Tools.WindowsInstallerXml.Extensions
     using System.Xml.Schema;
     using Microsoft.Tools.WindowsInstallerXml;
 
+
     /// <summary>
     /// The compiler for the Windows Installer XML Toolset Firewall Extension.
     /// </summary>
@@ -129,6 +130,12 @@ namespace Microsoft.Tools.WindowsInstallerXml.Extensions
                             if (YesNoType.Yes == this.Core.GetAttributeYesNoValue(sourceLineNumbers, attrib))
                             {
                                 attributes |= 0x1; // feaIgnoreFailures
+                            }
+                            break;
+                        case "Outbound":
+                            if (YesNoType.Yes == this.Core.GetAttributeYesNoValue(sourceLineNumbers, attrib))
+                            {
+                                attributes |= 0x2; // feaOutbound
                             }
                             break;
                         case "Program":

--- a/src/ext/FirewallExtension/wixext/FirewallDecompiler.cs
+++ b/src/ext/FirewallExtension/wixext/FirewallDecompiler.cs
@@ -99,6 +99,11 @@ namespace Microsoft.Tools.WindowsInstallerXml.Extensions
                     {
                         fire.IgnoreFailure = Firewall.YesNoType.yes;
                     }
+
+                    if (0x2 == (attr & 0x2)) // feaOutbound
+                    {
+                        fire.Outbound = Firewall.YesNoType.yes;
+                    }
                 }
 
                 if (!row.IsColumnEmpty(7))

--- a/src/ext/FirewallExtension/wixext/Xsd/firewall.xsd
+++ b/src/ext/FirewallExtension/wixext/Xsd/firewall.xsd
@@ -147,6 +147,14 @@
                 </xs:annotation>
             </xs:attribute>
 
+            <xs:attribute name="Outbound" type="YesNoType">
+                <xs:annotation>
+                    <xs:documentation>
+                        If "yes," registers an outbound firewall rule.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+
             <xs:attribute name="Profile">
               <xs:annotation>
                 <xs:documentation>


### PR DESCRIPTION
This implements issue [4009](https://github.com/wixtoolset/issues/issues/4009) without requiring any adjustments to existing component definitions that use the Firewall extension.
