### PR TITLE
Wix binder needs to use x86 burn.exe for arm64 projects

### DIFF
--- a/src/tools/wix/Binder.cs
+++ b/src/tools/wix/Binder.cs
@@ -3813,7 +3813,8 @@ namespace Microsoft.Tools.WindowsInstallerXml
             // Copy the burn.exe to a writable location then mark it to be moved to its
             // final build location.
             string stubPlatform;
-            if (Platform.X64 == bundleInfo.Platform) // today, the x64 Burn uses the x86 stub.
+            if (Platform.X64 == bundleInfo.Platform ||
+                Platform.ARM64 == bundleInfo.Platform) // today, the x64 and arm64 Burn use the x86 stub.
             {
                 stubPlatform = "x86";
             }


### PR DESCRIPTION
Fixes https://github.com/wixtoolset/issues/issues/6161

There is only one burn.exe today - the x86 version. It is used for x86 and x64, but it should also be used for arm64 products.

A simple change. I've tested the build process and arm64 burn bundle that was produced.