### PR TITLE
Use IsWow64Process2 if available to determine Wow64 process

### DIFF
--- a/src/libs/dutil/procutil.cpp
+++ b/src/libs/dutil/procutil.cpp
@@ -68,14 +68,36 @@ extern "C" HRESULT DAPI ProcWow64(
     HRESULT hr = S_OK;
     BOOL fIsWow64 = FALSE;
 
-    typedef BOOL (WINAPI *LPFN_ISWOW64PROCESS)(HANDLE, PBOOL);
-    LPFN_ISWOW64PROCESS pfnIsWow64Process = (LPFN_ISWOW64PROCESS)::GetProcAddress(::GetModuleHandleW(L"kernel32"), "IsWow64Process");
+    // Try newer API first: IsWow64Process2
+    // It provides more reliable Wow64 process detection on arm64 systems.
 
-    if (pfnIsWow64Process)
+    typedef BOOL(WINAPI* LPFN_ISWOW64PROCESS2)(HANDLE, USHORT *, USHORT *);
+    LPFN_ISWOW64PROCESS2 pfnIsWow64Process2 = (LPFN_ISWOW64PROCESS2)::GetProcAddress(::GetModuleHandleW(L"kernel32"), "IsWow64Process2");
+
+    if (pfnIsWow64Process2)
     {
-        if (!pfnIsWow64Process(hProcess, &fIsWow64))
+        USHORT pProcessMachine = IMAGE_FILE_MACHINE_UNKNOWN;
+        if (!pfnIsWow64Process2(hProcess, &pProcessMachine, nullptr))
         {
-            ExitWithLastError(hr, "Failed to check WOW64 process.");
+            ExitWithLastError(hr, "Failed to check WOW64 process - IsWow64Process2.");
+        }
+
+        if (pProcessMachine != IMAGE_FILE_MACHINE_UNKNOWN)
+        {
+            fIsWow64 = TRUE;
+        }
+    }
+    else
+    {
+        typedef BOOL(WINAPI* LPFN_ISWOW64PROCESS)(HANDLE, PBOOL);
+        LPFN_ISWOW64PROCESS pfnIsWow64Process = (LPFN_ISWOW64PROCESS)::GetProcAddress(::GetModuleHandleW(L"kernel32"), "IsWow64Process");
+
+        if (pfnIsWow64Process)
+        {
+            if (!pfnIsWow64Process(hProcess, &fIsWow64))
+            {
+                ExitWithLastError(hr, "Failed to check WOW64 process - IsWow64Process.");
+            }
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/wixtoolset/issues/issues/6162

Burn needs to use IsWow64Process2, if available, to determine if it's running as a wow64 process. This API is needed to properly determine wow64 process on arm64 systems.

Old API (IsWow64Process) is used if new one is not available - this would be on all systems with OS earlier than Win10 1511.

Tested x86/x64/arm64 burn bundles on Win7, Win2k12 and Win10.