### PR TITLE
WIXBUG:6024 - Fix accessibility issue by hiding burn's hidden window.

### DIFF
--- a/history/6024.md
+++ b/history/6024.md
@@ -1,0 +1,1 @@
+* BMurri: WIXBUG:6024 - Fix accessibility issue by hiding burn's hidden window.

--- a/src/burn/engine/uithread.cpp
+++ b/src/burn/engine/uithread.cpp
@@ -134,7 +134,7 @@ static DWORD WINAPI ThreadProc(
     info.pUserExperience = &pEngineState->userExperience;
 
     // Create the window to handle reboots without activating it.
-    hWnd = ::CreateWindowExW(WS_EX_TOOLWINDOW, wc.lpszClassName, NULL, WS_POPUP | WS_VISIBLE, CW_USEDEFAULT, SW_SHOWNA, 0, 0, HWND_DESKTOP, NULL, pContext->hInstance, &info);
+    hWnd = ::CreateWindowExW(WS_EX_NOACTIVATE, wc.lpszClassName, NULL, WS_POPUP, CW_USEDEFAULT, SW_HIDE, 0, 0, HWND_DESKTOP, NULL, pContext->hInstance, &info);
     ExitOnNullWithLastError(hWnd, hr, "Failed to create window.");
 
     // Persist the window handle and let the caller know we've initialized.


### PR DESCRIPTION
Fixes wixtoolset/issues#6024
