### PR TITLE
Handle architecture mismatch to avoid crashing host

### DIFF
--- a/src/tools/WixTasks/WixToolTask.cs
+++ b/src/tools/WixTasks/WixToolTask.cs
@@ -240,6 +240,11 @@ namespace Microsoft.Tools.WindowsInstallerXml.Build.Tasks
                 Assembly toolAssembly = Assembly.LoadFrom((string)pathAndArguments[0]);
                 this.exitCode = (int)toolAssembly.EntryPoint.Invoke(null, new object[] { pathAndArguments[1] });
             }
+            catch (BadImageFormatException bife)
+            {
+                Log.LogError("Unable to load tool from path {0} due to architecture mismatch.  Consider setting the RunAsSeparateProcess parameter to $(RunWixToolsOutOfProc).", bife.FileName);
+                this.exitCode = -1;
+            }
             catch (FileNotFoundException fnfe)
             {
                 Log.LogError("Unable to load tool from path {0}.  Consider setting the ToolPath parameter to $(WixToolPath).", fnfe.FileName);


### PR DESCRIPTION
Fixes: https://github.com/wixtoolset/issues/issues/6636

MSBuild typically handles exceptions thrown directly by tasks and reports them as errors. WixToolTask.ExecuteTool, however, is forking its execution onto another thread and this thread is throwing when invoking Heat directly in-proc. This is crashing its host. 

This is no. 15 of all crashes in Visual Studio 17.3.

Handle the error and give a helpful message instead of crashing.